### PR TITLE
Deserialize `DateTime` with `Parse` instead of `ParseExact` (round-trip)

### DIFF
--- a/src/Chr.Avro.Binary/BinaryDeserializerBuilder.cs
+++ b/src/Chr.Avro.Binary/BinaryDeserializerBuilder.cs
@@ -1993,9 +1993,8 @@ namespace Chr.Avro.Serialization
                 if (target == typeof(DateTime) || target == typeof(DateTime?) || target == typeof(DateTimeOffset) || target == typeof(DateTimeOffset?))
                 {
                     var parseDateTime = typeof(DateTime)
-                        .GetMethod(nameof(DateTime.ParseExact), new[]
+                        .GetMethod(nameof(DateTime.Parse), new[]
                         {
-                            typeof(string),
                             typeof(string),
                             typeof(IFormatProvider),
                             typeof(DateTimeStyles)
@@ -2006,7 +2005,6 @@ namespace Chr.Avro.Serialization
                             null,
                             parseDateTime,
                             result,
-                            Expression.Constant("O"),
                             Expression.Constant(CultureInfo.InvariantCulture),
                             Expression.Constant(DateTimeStyles.RoundtripKind)
                         ),


### PR DESCRIPTION
Resolves #10. At some point this might be worth revisiting—`Parse` accepts a bunch of stuff (`"7 PM"`, `"Mon Sep 9"`, etc.) and it’d be nice to specify ISO 8601 exclusively. (There’s no option currently available in .NET.)