### PR TITLE
Improve contract consistency

### DIFF
--- a/docs/src/pages/internals/mapping.js
+++ b/docs/src/pages/internals/mapping.js
@@ -16,7 +16,7 @@ export default () =>
     <h1>{title}</h1>
     <p>Chr.Avro supports mapping .NET’s <ExternalLink to='https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/built-in-types-table'>built-in types</ExternalLink>, as well as commonly used types like <DotnetReference id='T:System.DateTime' /> and <DotnetReference id='T:System.Uri' />, to Avro schemas. This document is a comprehensive explanation of how that mapping works.</p>
 
-    <p>The <DotnetReference id='T:Chr.Avro.Serialization.BinarySerializerBuilder'>serializer builder</DotnetReference> and <DotnetReference id='T:Chr.Avro.Serialization.BinaryDeserializerBuilder'>deserializer builder</DotnetReference> generally throw <DotnetReference id='T:Chr.Avro.UnsupportedTypeException' /> when a type can’t be mapped to a schema. Other exceptions, usually <DotnetReference id='T:System.OverflowException' /> and <DotnetReference id='T:System.FormatException' />, are thrown when errors occur during serialization or deserialization.</p>
+    <p>The <DotnetReference id='T:Chr.Avro.Serialization.BinarySerializerBuilder'>serializer builder</DotnetReference> and <DotnetReference id='T:Chr.Avro.Serialization.BinaryDeserializerBuilder'>deserializer builder</DotnetReference> generally throw <DotnetReference id='T:System.AggregateException' /> when a type can’t be mapped to a schema. Other exceptions, usually <DotnetReference id='T:System.OverflowException' /> and <DotnetReference id='T:System.FormatException' />, are thrown when errors occur during serialization or deserialization.</p>
 
     <h2 id='arrays'>Arrays</h2>
     <p>Avro specifies an <Highlight inline language='avro'>"array"</Highlight> type for variable-length lists of items. Chr.Avro can map a .NET type to <Highlight inline language='avro'>"array"</Highlight> if either of the following is true:</p>
@@ -153,10 +153,10 @@ deserializer.Deserialize(serializer.Serialize(epoch)); // 0L`}</Highlight>
         <p>Enumerator names don’t need to be an exact match—all non-alphanumeric characters are stripped and comparisons are case-insensitive. For example, a <code>PRIMARY_RESIDENCE</code> symbol will match enumerators named <code>PrimaryResidence</code>, <code>primaryResidence</code>, etc.</p>
       </li>
       <li>
-        <p>When the serializer builder and deserializer builder find multiple matching enumerators, <DotnetReference id='T:Chr.Avro.UnsupportedTypeException' /> is thrown.</p>
+        <p>When the serializer builder and deserializer builder find multiple matching enumerators, <DotnetReference id='T:System.AggregateException' /> is thrown.</p>
       </li>
       <li>
-        <p>When the deserializer builder can’t find a matching enumerator, <DotnetReference id='T:Chr.Avro.UnsupportedTypeException' /> is thrown.</p>
+        <p>When the deserializer builder can’t find a matching enumerator, <DotnetReference id='T:System.AggregateException' /> is thrown.</p>
       </li>
     </ul>
     <p>By default, Chr.Avro also honors data contract attributes if a <DotnetReference id='T:System.Runtime.Serialization.DataContractAttribute' /> is present on the enumeration. In that case, if <DotnetReference id='P:System.Runtime.Serialization.EnumMemberAttribute.Value' /> is set on an enumerator, the custom value must match the symbol exactly. If it’s not set, the enumerator name will be compared inexactly as described above.</p>
@@ -399,13 +399,13 @@ deserializer.Deserialize(bytes); // throws OverflowException`}</Highlight>
         <p>Type member names don’t need to match the schema exactly—all non-alphanumeric characters are stripped and comparisons are case-insensitive. So, for example, a record field named <code>addressLine1</code> will match type members named <code>AddressLine1</code>, <code>AddressLine_1</code>, <code>ADDRESS_LINE_1</code>, etc.</p>
       </li>
       <li>
-        <p>When the serializer builder and deserializer builder find multiple matching type members, <DotnetReference id='T:Chr.Avro.UnsupportedTypeException' /> is thrown.</p>
+        <p>When the serializer builder and deserializer builder find multiple matching type members, <DotnetReference id='T:System.AggregateException' /> is thrown.</p>
       </li>
       <li>
-        <p>When the serializer builder can’t find a matching type member, <DotnetReference id='T:Chr.Avro.UnsupportedTypeException' /> is thrown. When the deserializer can’t find a matching type member, the field is ignored.</p>
+        <p>When the serializer builder can’t find a matching type member, <DotnetReference id='T:System.AggregateException' /> is thrown. When the deserializer can’t find a matching type member, the field is ignored.</p>
       </li>
       <li>
-        <p>The deserializer builder throws <DotnetReference id='T:Chr.Avro.UnsupportedTypeException' /> if a type doesn’t have a parameterless public constructor.</p>
+        <p>The deserializer builder throws <DotnetReference id='T:System.AggregateException' /> if a type doesn’t have a parameterless public constructor.</p>
       </li>
     </ul>
     <p>By default, Chr.Avro also honors data contract attributes if a <DotnetReference id='T:System.Runtime.Serialization.DataContractAttribute' /> is present on the type. In that case, two additional rules apply:</p>

--- a/src/Chr.Avro.Binary/BinaryDeserializerBuilder.cs
+++ b/src/Chr.Avro.Binary/BinaryDeserializerBuilder.cs
@@ -37,7 +37,7 @@ namespace Chr.Avro.Serialization
         /// <returns>
         /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
         /// </returns>
-        Func<Stream, T> BuildDelegate<T>(Schema schema, IDictionary<(Type, Schema), Delegate> cache = null);
+        Func<Stream, T> BuildDelegate<T>(Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache = null);
 
         /// <summary>
         /// Builds a binary deserializer.
@@ -75,7 +75,7 @@ namespace Chr.Avro.Serialization
         /// A function that accepts a <see cref="Stream" /> and returns a deserialized object. Since
         /// this is not a typed method, the general <see cref="Delegate" /> type is used.
         /// </returns>
-        Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache);
+        Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache);
     }
 
     /// <summary>
@@ -150,7 +150,7 @@ namespace Chr.Avro.Serialization
         /// Thrown when no case matches the schema or type. <see cref="AggregateException.InnerExceptions" />
         /// will be contain the exceptions thrown by each case.
         /// </exception>
-        public virtual Func<Stream, T> BuildDelegate<T>(Schema schema, IDictionary<(Type, Schema), Delegate> cache = null)
+        public virtual Func<Stream, T> BuildDelegate<T>(Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache = null)
         {
             if (cache == null)
             {
@@ -267,7 +267,7 @@ namespace Chr.Avro.Serialization
         /// A function that accepts a <see cref="Stream" /> and returns a deserialized object. Since
         /// this is not a typed method, the general <see cref="Delegate" /> type is used.
         /// </returns>
-        public abstract Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache);
+        public abstract Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache);
     }
 
     /// <summary>
@@ -323,7 +323,7 @@ namespace Chr.Avro.Serialization
         /// Thrown when the resolved type is neither an array type nor a type assignable from
         /// <see cref="List{T}" />.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(resolution is ArrayResolution arrayResolution))
             {
@@ -388,9 +388,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "array deserializer", new[] { stream });
             var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((target, schema), compiled);
         }
     }
 
@@ -437,7 +436,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no conversion from <see cref="bool" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is BooleanSchema))
             {
@@ -469,9 +468,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "boolean deserializer", new[] { stream });
             var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((target, schema), compiled);
         }
     }
 
@@ -518,7 +516,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no conversion from <see cref="T:System.Byte[]" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is BytesSchema))
             {
@@ -563,9 +561,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "bytes deserializer", new[] { stream });
             var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((target, schema), compiled);
         }
     }
 
@@ -613,7 +610,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no conversion from <see cref="decimal" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema.LogicalType is DecimalLogicalType decimalLogicalType))
             {
@@ -693,9 +690,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "decimal deserializer", new[] { stream });
             var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((target, schema), compiled);
         }
     }
 
@@ -742,7 +738,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no conversion from <see cref="double" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is DoubleSchema))
             {
@@ -774,9 +770,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "double deserializer", new[] { stream });
             var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((target, schema), compiled);
         }
     }
 
@@ -824,7 +819,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when the type is not <see cref="TimeSpan" />.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema.LogicalType is DurationLogicalType))
             {
@@ -891,9 +886,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, $"duration deserializer", new[] { stream });
             var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((target, schema), compiled);
         }
     }
 
@@ -941,7 +935,7 @@ namespace Chr.Avro.Serialization
         /// Thrown when the resolution is not an <see cref="EnumResolution" /> or the type does not
         /// contain a matching symbol for each symbol in the schema.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(resolution is EnumResolution enumResolution))
             {
@@ -989,9 +983,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, $"{enumSchema.Name} deserializer", new[] { stream });
             var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((target, schema), compiled);
         }
     }
 
@@ -1038,7 +1031,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no conversion from <see cref="T:System.Byte[]" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is FixedSchema fixedSchema))
             {
@@ -1083,9 +1076,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, $"{fixedSchema.Name} deserializer", new[] { stream });
             var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((target, schema), compiled);
         }
     }
 
@@ -1132,7 +1124,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no conversion from <see cref="float" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is FloatSchema))
             {
@@ -1164,9 +1156,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "float deserializer", new[] { stream });
             var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((target, schema), compiled);
         }
     }
 
@@ -1213,7 +1204,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no conversion from <see cref="long" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is IntSchema || schema is LongSchema))
             {
@@ -1245,9 +1236,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "integer deserializer", new[] { stream });
             var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((target, schema), compiled);
         }
     }
 
@@ -1304,7 +1294,7 @@ namespace Chr.Avro.Serialization
         /// Thrown when the resolution is not a <see cref="MapResolution" /> or the resolved type
         /// is not assignable from <see cref="Dictionary{TKey, TValue}" />.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(resolution is MapResolution mapResolution))
             {
@@ -1377,9 +1367,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "map deserializer", new[] { stream });
             var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((target, schema), compiled);
         }
     }
 
@@ -1406,7 +1395,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedSchemaException">
         /// Thrown when the schema is not a <see cref="NullSchema" />.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is NullSchema))
             {
@@ -1420,9 +1409,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "null deserializer", new[] { stream });
             var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((target, schema), compiled);
         }
     }
 
@@ -1469,7 +1457,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when the resolution is not a <see cref="RecordResolution" />.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(resolution is RecordResolution recordResolution))
             {
@@ -1504,8 +1492,7 @@ namespace Chr.Avro.Serialization
             );
 
             var lambda = Expression.Lambda(result, $"{recordSchema.Name} deserializer", new[] { stream });
-            var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
+            var compiled = cache.GetOrAdd((target, schema), lambda.Compile());
 
             // now that an infinite cycle won’t happen, build the assign function:
             var assignments = recordSchema.Fields.Select(field =>
@@ -1644,7 +1631,7 @@ namespace Chr.Avro.Serialization
         /// <see cref="Guid" />, <see cref="TimeSpan"/>, <see cref="Uri" />) can be applied and no
         /// conversion from <see cref="string" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is StringSchema))
             {
@@ -1729,9 +1716,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "string deserializer", new[] { stream });
             var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((target, schema), compiled);
         }
     }
 
@@ -1780,7 +1766,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when the type is not <see cref="DateTime" /> or <see cref="DateTimeOffset" />.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is LongSchema))
             {
@@ -1829,9 +1815,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "timestamp deserializer", new[] { stream });
             var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((target, schema), compiled);
         }
     }
 
@@ -1887,7 +1872,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when the type cannot be mapped to each schema in the union.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is UnionSchema unionSchema && unionSchema.Schemas.Count > 0))
             {
@@ -1950,9 +1935,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "union deserializer", new[] { stream });
             var compiled = lambda.Compile();
-            cache.Add((target, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((target, schema), compiled);
         }
     }
 }

--- a/src/Chr.Avro.Binary/BinarySerializerBuilder.cs
+++ b/src/Chr.Avro.Binary/BinarySerializerBuilder.cs
@@ -37,7 +37,7 @@ namespace Chr.Avro.Serialization
         /// An action that accepts an object and a <see cref="Stream" /> and writes the serialized
         /// object to the stream.
         /// </returns>
-        Action<T, Stream> BuildDelegate<T>(Schema schema, IDictionary<(Type, Schema), Delegate> cache = null);
+        Action<T, Stream> BuildDelegate<T>(Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache = null);
 
         /// <summary>
         /// Builds a binary serializer.
@@ -74,7 +74,7 @@ namespace Chr.Avro.Serialization
         /// An action that accepts an object and a <see cref="Stream" /> and writes the serialized
         /// object to the stream.
         /// </returns>
-        Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache);
+        Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache);
     }
 
     /// <summary>
@@ -149,7 +149,7 @@ namespace Chr.Avro.Serialization
         /// Thrown when no case matches the schema or type. <see cref="AggregateException.InnerExceptions" />
         /// will be contain the exceptions thrown by each case.
         /// </exception>
-        public Action<T, Stream> BuildDelegate<T>(Schema schema, IDictionary<(Type, Schema), Delegate> cache = null)
+        public Action<T, Stream> BuildDelegate<T>(Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache = null)
         {
             if (cache == null)
             {
@@ -266,7 +266,7 @@ namespace Chr.Avro.Serialization
         /// object to the stream. Since this is not a typed method, the general <see cref="Delegate" />
         /// type is used.
         /// </returns>
-        public abstract Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache);
+        public abstract Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache);
     }
 
     /// <summary>
@@ -323,7 +323,7 @@ namespace Chr.Avro.Serialization
         /// Thrown when the resolution is not an <see cref="ArrayResolution" /> or the resolved
         /// type does not implement <see cref="IEnumerable{T}" />.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(resolution is ArrayResolution arrayResolution))
             {
@@ -378,9 +378,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "array serializer", new[] { value, stream });
             var compiled = lambda.Compile();
-            cache.Add((source, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((source, schema), compiled);
         }
     }
 
@@ -428,7 +427,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no conversion to <see cref="bool" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is BooleanSchema))
             {
@@ -463,9 +462,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "boolean serializer", new[] { value, stream });
             var compiled = lambda.Compile();
-            cache.Add((source, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((source, schema), compiled);
         }
     }
 
@@ -513,7 +511,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no conversion to <see cref="T:System.Byte[]" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is BytesSchema))
             {
@@ -564,9 +562,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "bytes serializer", new[] { value, stream });
             var compiled = lambda.Compile();
-            cache.Add((source, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((source, schema), compiled);
         }
     }
 
@@ -615,7 +612,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no conversion to <see cref="decimal" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema.LogicalType is DecimalLogicalType decimalLogicalType))
             {
@@ -712,9 +709,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "decimal serializer", new[] { value, stream });
             var compiled = lambda.Compile();
-            cache.Add((source, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((source, schema), compiled);
         }
     }
 
@@ -762,7 +758,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no conversion to <see cref="double" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is DoubleSchema))
             {
@@ -797,9 +793,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "double serializer", new[] { value, stream });
             var compiled = lambda.Compile();
-            cache.Add((source, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((source, schema), compiled);
         }
     }
 
@@ -848,7 +843,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when the type is not <see cref="TimeSpan" />.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema.LogicalType is DurationLogicalType))
             {
@@ -890,9 +885,7 @@ namespace Chr.Avro.Serialization
                 write(milliseconds, stream);
             };
 
-            cache.Add((source, schema), result);
-
-            return result;
+            return cache.GetOrAdd((source, schema), result);
         }
     }
 
@@ -941,7 +934,7 @@ namespace Chr.Avro.Serialization
         /// Thrown when the resolution is not an <see cref="EnumResolution" /> or the schema does
         /// not contain a matching symbol for each symbol in the type.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(resolution is EnumResolution enumResolution))
             {
@@ -991,9 +984,8 @@ namespace Chr.Avro.Serialization
             var result = Expression.Switch(value, cases.ToArray());
             var lambda = Expression.Lambda(result, $"{enumSchema.Name} serializer", new[] { value, stream });
             var compiled = lambda.Compile();
-            cache.Add((source, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((source, schema), compiled);
         }
     }
 
@@ -1041,7 +1033,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no conversion to <see cref="T:System.Byte[]" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is FixedSchema fixedSchema))
             {
@@ -1100,9 +1092,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, $"{fixedSchema.Name} serializer", new[] { value, stream });
             var compiled = lambda.Compile();
-            cache.Add((source, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((source, schema), compiled);
         }
     }
 
@@ -1150,7 +1141,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no conversion to <see cref="float" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is FloatSchema))
             {
@@ -1185,9 +1176,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "float serializer", new[] { value, stream });
             var compiled = lambda.Compile();
-            cache.Add((source, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((source, schema), compiled);
         }
     }
 
@@ -1235,7 +1225,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no conversion to <see cref="long" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is IntSchema || schema is LongSchema))
             {
@@ -1270,9 +1260,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "integer serializer", new[] { value, stream });
             var compiled = lambda.Compile();
-            cache.Add((source, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((source, schema), compiled);
         }
     }
 
@@ -1330,7 +1319,7 @@ namespace Chr.Avro.Serialization
         /// Thrown when the resolution is not a <see cref="MapResolution" /> or the resolved type
         /// is not a <see cref="KeyValuePair{TKey, TValue}" /> enumerable.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(resolution is MapResolution mapResolution))
             {
@@ -1389,9 +1378,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "map serializer", new[] { value, stream });
             var compiled = lambda.Compile();
-            cache.Add((source, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((source, schema), compiled);
         }
     }
 
@@ -1418,7 +1406,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedSchemaException">
         /// Thrown when the schema is not a <see cref="NullSchema" />.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is NullSchema))
             {
@@ -1432,9 +1420,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(Expression.Empty(), "null serializer", new[] { value, stream });
             var compiled = lambda.Compile();
-            cache.Add((source, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((source, schema), compiled);
         }
     }
 
@@ -1482,7 +1469,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when the resolution is not a <see cref="RecordResolution" />.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(resolution is RecordResolution recordResolution))
             {
@@ -1512,8 +1499,7 @@ namespace Chr.Avro.Serialization
             result = Expression.Invoke(result, value, stream);
 
             var lambda = Expression.Lambda(result, $"{recordSchema.Name} serializer", new[] { value, stream });
-            var compiled = lambda.Compile();
-            cache.Add((source, schema), compiled);
+            var compiled = cache.GetOrAdd((source, schema), lambda.Compile());
 
             // now that an infinite cycle won’t happen, build the write function:
             var writes = recordSchema.Fields.Select(field =>
@@ -1606,7 +1592,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no conversion to <see cref="string" /> exists.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is StringSchema))
             {
@@ -1693,9 +1679,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "string serializer", new[] { value, stream });
             var compiled = lambda.Compile();
-            cache.Add((source, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((source, schema), compiled);
         }
     }
 
@@ -1745,7 +1730,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when the type is not <see cref="DateTime" /> or <see cref="DateTimeOffset" />.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is LongSchema))
             {
@@ -1794,9 +1779,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "timestamp serializer", new[] { value, stream });
             var compiled = lambda.Compile();
-            cache.Add((source, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((source, schema), compiled);
         }
     }
 
@@ -1853,7 +1837,7 @@ namespace Chr.Avro.Serialization
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when the type cannot be mapped to at least one schema in the union.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, IDictionary<(Type, Schema), Delegate> cache)
+        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
             if (!(schema is UnionSchema unionSchema && unionSchema.Schemas.Count > 0))
             {
@@ -1940,9 +1924,8 @@ namespace Chr.Avro.Serialization
 
             var lambda = Expression.Lambda(result, "union serializer", new[] { value, stream });
             var compiled = lambda.Compile();
-            cache.Add((source, schema), compiled);
 
-            return compiled;
+            return cache.GetOrAdd((source, schema), compiled);
         }
     }
 }

--- a/src/Chr.Avro.Cli/Verb.cs
+++ b/src/Chr.Avro.Cli/Verb.cs
@@ -6,6 +6,7 @@ using Chr.Avro.Representation;
 using Chr.Avro.Resolution;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Chr.Avro.Serialization;
 
@@ -87,7 +88,7 @@ namespace Chr.Avro.Cli
             {
                 return builder.BuildSchema(type);
             }
-            catch (UnsupportedTypeException inner)
+            catch (AggregateException inner) when (inner.InnerExceptions.All(e => e is UnsupportedTypeException))
             {
                 throw new ProgramException(message: $"Failed to create a schema for {type}: The type is not supported by the resolver.", inner: inner);
             }

--- a/src/Chr.Avro.Confluent/AsyncSchemaRegistrySerializer.cs
+++ b/src/Chr.Avro.Confluent/AsyncSchemaRegistrySerializer.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Chr.Avro.Confluent
@@ -208,7 +209,7 @@ namespace Chr.Avro.Confluent
                 }
                 catch (Exception e) when (_registerAutomatically && (
                     (e is SchemaRegistryException sre && sre.ErrorCode == 40401) ||
-                    (e is UnsupportedTypeException)
+                    (e is AggregateException a && a.InnerExceptions.All(e => e is UnsupportedTypeException))
                 ))
                 {
                     var schema = _schemaBuilder.BuildSchema<T>();

--- a/src/Chr.Avro.Confluent/AsyncSchemaRegistrySerializer.cs
+++ b/src/Chr.Avro.Confluent/AsyncSchemaRegistrySerializer.cs
@@ -23,23 +23,44 @@ namespace Chr.Avro.Confluent
     /// </remarks>
     public class AsyncSchemaRegistrySerializer<T> : IAsyncSerializer<T>
     {
+        /// <summary>
+        /// Whether to automatically register schemas that match the type being serialized.
+        /// </summary>
+        public bool RegisterAutomatically { get; }
+
+        /// <summary>
+        /// The schema builder used to create a schema for a C# type when registering automatically.
+        /// </summary>
+        public Abstract.ISchemaBuilder SchemaBuilder { get; }
+
+        /// <summary>
+        /// The JSON schema reader used to convert schemas received from the registry into abstract
+        /// representations.
+        /// </summary>
+        public IJsonSchemaReader SchemaReader { get; }
+
+        /// <summary>
+        /// The JSON schema writer used to convert abstract schema representations when registering
+        /// automatically.
+        /// </summary>
+        public IJsonSchemaWriter SchemaWriter { get; }
+
+        /// <summary>
+        /// The deserializer builder to use to build serialization functions for C# types.
+        /// </summary>
+        public IBinarySerializerBuilder SerializerBuilder { get; }
+
+        /// <summary>
+        /// A function that determines the subject name given the topic name and a component type
+        /// (key or value).
+        /// </summary>
+        public Func<SerializationContext, string> SubjectNameBuilder { get; }
+
         private readonly ConcurrentDictionary<string, Task<Func<T, byte[]>>> _cache;
 
         private readonly Func<string, string, Task<int>> _register;
 
-        private readonly bool _registerAutomatically;
-
         private readonly Func<string, Task<Schema>> _resolve;
-
-        private readonly Abstract.ISchemaBuilder _schemaBuilder;
-
-        private readonly IJsonSchemaReader _schemaReader;
-
-        private readonly IJsonSchemaWriter _schemaWriter;
-
-        private readonly IBinarySerializerBuilder _serializerBuilder;
-
-        private readonly Func<SerializationContext, string> _subjectNameBuilder;
 
         /// <summary>
         /// Creates a serializer.
@@ -52,20 +73,20 @@ namespace Chr.Avro.Confluent
         /// Whether to automatically register schemas that match the type being serialized.
         /// </param>
         /// <param name="schemaBuilder">
-        /// A schema builder (used to build a schema for a C# type when registering automatically).
+        /// The schema builder to use to create a schema for a C# type when registering automatically.
         /// If none is provided, the default schema builder will be used.
         /// </param>
         /// <param name="schemaReader">
-        /// A JSON schema reader (used to convert schemas received from the registry into abstract
-        /// representations). If none is provided, the default schema reader will be used.
+        /// The JSON schema reader to use to convert schemas received from the registry into abstract
+        /// representations. If none is provided, the default schema reader will be used.
         /// </param>
         /// <param name="schemaWriter">
-        /// A JSON schema writer (used to convert abstract schema representations when registering
-        /// automatically). If none is provided, the default schema writer will be used.
+        /// The JSON schema writer to use to convert abstract schema representations when registering
+        /// automatically. If none is provided, the default schema writer will be used.
         /// </param>
         /// <param name="serializerBuilder">
-        /// A deserializer builder (used to build serialization functions for C# types). If none is
-        /// provided, the default serializer builder will be used.
+        /// The deserializer builder to use to build serialization functions for C# types. If none
+        /// is provided, the default serializer builder will be used.
         /// </param>
         /// <param name="subjectNameBuilder">
         /// A function that determines the subject name given the topic name and a component type
@@ -117,26 +138,26 @@ namespace Chr.Avro.Confluent
         /// Creates a serializer.
         /// </summary>
         /// <param name="registryClient">
-        /// A client to use for Schema Registry operations. (The client will not be disposed.)
+        /// The client to use for Schema Registry operations. (The client will not be disposed.)
         /// </param>
         /// <param name="registerAutomatically">
         /// Whether to automatically register schemas that match the type being serialized.
         /// </param>
         /// <param name="schemaBuilder">
-        /// A schema builder (used to build a schema for a C# type when registering automatically).
+        /// The schema builder to use to create a schema for a C# type when registering automatically.
         /// If none is provided, the default schema builder will be used.
         /// </param>
         /// <param name="schemaReader">
-        /// A JSON schema reader (used to convert schemas received from the registry into abstract
-        /// representations). If none is provided, the default schema reader will be used.
+        /// The JSON schema reader to use to convert schemas received from the registry into abstract
+        /// representations. If none is provided, the default schema reader will be used.
         /// </param>
         /// <param name="schemaWriter">
-        /// A JSON schema writer (used to convert abstract schema representations when registering
-        /// automatically). If none is provided, the default schema writer will be used.
+        /// The JSON schema writer to use to convert abstract schema representations when registering
+        /// automatically. If none is provided, the default schema writer will be used.
         /// </param>
         /// <param name="serializerBuilder">
-        /// A deserializer builder (used to build serialization functions for C# types). If none is
-        /// provided, the default serializer builder will be used.
+        /// The deserializer builder to use to build serialization functions for C# types. If none
+        /// is provided, the default serializer builder will be used.
         /// </param>
         /// <param name="subjectNameBuilder">
         /// A function that determines the subject name given the topic name and a component type
@@ -180,12 +201,13 @@ namespace Chr.Avro.Confluent
             Func<SerializationContext, string> subjectNameBuilder = null
         ) {
             _cache = new ConcurrentDictionary<string, Task<Func<T, byte[]>>>();
-            _registerAutomatically = registerAutomatically;
-            _schemaBuilder = schemaBuilder ?? new Abstract.SchemaBuilder();
-            _schemaReader = schemaReader ?? new JsonSchemaReader();
-            _schemaWriter = schemaWriter ?? new JsonSchemaWriter();
-            _serializerBuilder = serializerBuilder ?? new BinarySerializerBuilder();
-            _subjectNameBuilder = subjectNameBuilder ??
+
+            RegisterAutomatically = registerAutomatically;
+            SchemaBuilder = schemaBuilder ?? new Abstract.SchemaBuilder();
+            SchemaReader = schemaReader ?? new JsonSchemaReader();
+            SchemaWriter = schemaWriter ?? new JsonSchemaWriter();
+            SerializerBuilder = serializerBuilder ?? new BinarySerializerBuilder();
+            SubjectNameBuilder = subjectNameBuilder ??
                 (c => $"{c.Topic}-{(c.Component == MessageComponentType.Key ? "key" : "value")}");
         }
 
@@ -194,7 +216,7 @@ namespace Chr.Avro.Confluent
         /// </summary>
         public virtual async Task<byte[]> SerializeAsync(T data, SerializationContext context)
         {
-            var serialize = await (_cache.GetOrAdd(_subjectNameBuilder(context), async subject =>
+            var serialize = await (_cache.GetOrAdd(SubjectNameBuilder(context), async subject =>
             {
                 int id;
                 Action<T, Stream> @delegate;
@@ -202,20 +224,23 @@ namespace Chr.Avro.Confluent
                 try
                 {
                     var existing = await _resolve(subject).ConfigureAwait(false);
-                    var schema = _schemaReader.Read(existing.SchemaString);
+                    var schema = SchemaReader.Read(existing.SchemaString);
 
-                    @delegate = _serializerBuilder.BuildDelegate<T>(schema);
+                    @delegate = SerializerBuilder.BuildDelegate<T>(schema);
                     id = existing.Id;
                 }
-                catch (Exception e) when (_registerAutomatically && (
+                catch (Exception e) when (RegisterAutomatically && (
                     (e is SchemaRegistryException sre && sre.ErrorCode == 40401) ||
-                    (e is AggregateException a && a.InnerExceptions.All(e => e is UnsupportedTypeException))
+                    (e is AggregateException a && a.InnerExceptions.All(i =>
+                        i is UnsupportedSchemaException ||
+                        i is UnsupportedTypeException
+                    ))
                 ))
                 {
-                    var schema = _schemaBuilder.BuildSchema<T>();
-                    var json = _schemaWriter.Write(schema);
+                    var schema = SchemaBuilder.BuildSchema<T>();
+                    var json = SchemaWriter.Write(schema);
 
-                    @delegate = _serializerBuilder.BuildDelegate<T>(schema);
+                    @delegate = SerializerBuilder.BuildDelegate<T>(schema);
                     id = await _register(subject, json).ConfigureAwait(false);
                 }
 

--- a/src/Chr.Avro.Confluent/ConsumerBuilderExtensions.cs
+++ b/src/Chr.Avro.Confluent/ConsumerBuilderExtensions.cs
@@ -1,7 +1,6 @@
 using Confluent.Kafka;
 using Confluent.Kafka.SyncOverAsync;
 using Confluent.SchemaRegistry;
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -20,7 +19,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ConsumerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use for Schema Registry operations. The client should only be disposed
+        /// The client to use for Schema Registry operations. The client should only be disposed
         /// after the consumer; the deserializer will use it to request schemas as messages are
         /// being consumed.
         /// </param>
@@ -55,7 +54,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ConsumerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use to resolve the schema. (The client will not be disposed.)
+        /// The client to use to resolve the schema. (The client will not be disposed.)
         /// </param>
         /// <param name="id">
         /// The ID of the schema that should be used to deserialize keys.
@@ -120,7 +119,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ConsumerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use to resolve the schema. (The client will not be disposed.)
+        /// The client to use to resolve the schema. (The client will not be disposed.)
         /// </param>
         /// <param name="subject">
         /// The subject of the schema that should be used to deserialize keys. The latest version
@@ -189,7 +188,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ConsumerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use to resolve the schema. (The client will not be disposed.)
+        /// The client to use to resolve the schema. (The client will not be disposed.)
         /// </param>
         /// <param name="subject">
         /// The subject of the schema that should be used to deserialize keys.
@@ -266,7 +265,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ConsumerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use for Schema Registry operations. The client should only be disposed
+        /// The client to use for Schema Registry operations. The client should only be disposed
         /// after the consumer; the deserializer will use it to request schemas as messages are
         /// being consumed.
         /// </param>
@@ -301,7 +300,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ConsumerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use to resolve the schema. (The client will not be disposed.)
+        /// The client to use to resolve the schema. (The client will not be disposed.)
         /// </param>
         /// <param name="id">
         /// The ID of the schema that should be used to deserialize values.
@@ -366,7 +365,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ConsumerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use to resolve the schema. (The client will not be disposed.)
+        /// The client to use to resolve the schema. (The client will not be disposed.)
         /// </param>
         /// <param name="subject">
         /// The subject of the schema that should be used to deserialize values. The latest version
@@ -434,7 +433,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ConsumerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use to resolve the schema. (The client will not be disposed.)
+        /// The client to use to resolve the schema. (The client will not be disposed.)
         /// </param>
         /// <param name="subject">
         /// The subject of the schema that should be used to deserialize values.

--- a/src/Chr.Avro.Confluent/ProducerBuilderExtensions.cs
+++ b/src/Chr.Avro.Confluent/ProducerBuilderExtensions.cs
@@ -19,7 +19,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ProducerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use for Schema Registry operations. The client should only be disposed
+        /// The client to use for Schema Registry operations. The client should only be disposed
         /// after the producer; the serializer will use it to request schemas as messages are being
         /// produced.
         /// </param>
@@ -78,7 +78,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ProducerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use to resolve the schema. (The client will not be disposed.)
+        /// The client to use to resolve the schema. (The client will not be disposed.)
         /// </param>
         /// <param name="id">
         /// The ID of the schema that should be used to serialize keys.
@@ -143,7 +143,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ProducerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use to resolve the schema. (The client will not be disposed.)
+        /// The client to use to resolve the schema. (The client will not be disposed.)
         /// </param>
         /// <param name="subject">
         /// The subject of the schema that should be used to serialize keys. The latest version of
@@ -227,7 +227,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ProducerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use to resolve the schema. (The client will not be disposed.)
+        /// The client to use to resolve the schema. (The client will not be disposed.)
         /// </param>
         /// <param name="subject">
         /// The subject of the schema that should be used to serialize keys.
@@ -304,7 +304,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ProducerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use for Schema Registry operations. The client should only be disposed
+        /// The client to use for Schema Registry operations. The client should only be disposed
         /// after the producer; the serializer will use it to request schemas as messages are being
         /// produced.
         /// </param>
@@ -363,7 +363,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ProducerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use to resolve the schema. (The client will not be disposed.)
+        /// The client to use to resolve the schema. (The client will not be disposed.)
         /// </param>
         /// <param name="id">
         /// The ID of the schema that should be used to serialize values.
@@ -428,7 +428,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ProducerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use to resolve the schema. (The client will not be disposed.)
+        /// The client to use to resolve the schema. (The client will not be disposed.)
         /// </param>
         /// <param name="subject">
         /// The subject of the schema that should be used to serialize values. The latest version
@@ -511,7 +511,7 @@ namespace Chr.Avro.Confluent
         /// The <see cref="ProducerBuilder{TKey, TValue}" /> instance to be configured.
         /// </param>
         /// <param name="registryClient">
-        /// A client to use to resolve the schema. (The client will not be disposed.)
+        /// The client to use to resolve the schema. (The client will not be disposed.)
         /// </param>
         /// <param name="subject">
         /// The subject of the schema that should be used to serialize values.

--- a/src/Chr.Avro.Confluent/SchemaRegistryDeserializerBuilder.cs
+++ b/src/Chr.Avro.Confluent/SchemaRegistryDeserializerBuilder.cs
@@ -87,7 +87,7 @@ namespace Chr.Avro.Confluent
         /// <param name="id">
         /// The ID of the schema that should be used to deserialize data.
         /// </param>
-        /// <exception cref="UnsupportedTypeException">
+        /// <exception cref="AggregateException">
         /// Thrown when the type is incompatible with the retrieved schema.
         /// </exception>
         public virtual async Task<IDeserializer<T>> Build<T>(int id)
@@ -102,7 +102,7 @@ namespace Chr.Avro.Confluent
         /// The subject of the schema that should be used to deserialize data. The latest version
         /// of the subject will be resolved.
         /// </param>
-        /// <exception cref="UnsupportedTypeException">
+        /// <exception cref="AggregateException">
         /// Thrown when the type is incompatible with the retrieved schema.
         /// </exception>
         public virtual async Task<IDeserializer<T>> Build<T>(string subject)
@@ -121,7 +121,7 @@ namespace Chr.Avro.Confluent
         /// <param name="version">
         /// The version of the subject to be resolved.
         /// </param>
-        /// <exception cref="UnsupportedTypeException">
+        /// <exception cref="AggregateException">
         /// Thrown when the type is incompatible with the retrieved schema.
         /// </exception>
         public virtual async Task<IDeserializer<T>> Build<T>(string subject, int version)

--- a/src/Chr.Avro.Confluent/SchemaRegistrySerializerBuilder.cs
+++ b/src/Chr.Avro.Confluent/SchemaRegistrySerializerBuilder.cs
@@ -3,7 +3,6 @@ using Confluent.Kafka;
 using Confluent.SchemaRegistry;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -15,20 +14,34 @@ namespace Chr.Avro.Confluent
     /// </summary>
     public class SchemaRegistrySerializerBuilder : IDisposable
     {
-        private readonly bool _disposeRegistryClient;
-
-        private readonly Abstract.ISchemaBuilder _schemaBuilder;
-
-        private readonly IJsonSchemaReader _schemaReader;
-
-        private readonly IJsonSchemaWriter _schemaWriter;
-
-        private readonly Serialization.IBinarySerializerBuilder _serializerBuilder;
-
         /// <summary>
         /// The client to use for Schema Registry operations.
         /// </summary>
-        protected readonly ISchemaRegistryClient RegistryClient;
+        public ISchemaRegistryClient RegistryClient { get; }
+
+        /// <summary>
+        /// The schema builder used to create a schema for a C# type when registering automatically.
+        /// </summary>
+        public Abstract.ISchemaBuilder SchemaBuilder { get; }
+
+        /// <summary>
+        /// The JSON schema reader used to convert schemas received from the registry into abstract
+        /// representations.
+        /// </summary>
+        public IJsonSchemaReader SchemaReader { get; }
+
+        /// <summary>
+        /// The JSON schema writer used to convert abstract schema representations when registering
+        /// automatically.
+        /// </summary>
+        public IJsonSchemaWriter SchemaWriter { get; }
+
+        /// <summary>
+        /// The deserializer builder to use to build serialization functions for C# types.
+        /// </summary>
+        public Serialization.IBinarySerializerBuilder SerializerBuilder { get; }
+
+        private readonly bool _disposeRegistryClient;
 
         /// <summary>
         /// Creates a serializer builder.
@@ -38,20 +51,20 @@ namespace Chr.Avro.Confluent
         /// highly recommended.
         /// </param>
         /// <param name="schemaBuilder">
-        /// A schema builder (used to build a schema for a C# type when registering automatically).
+        /// The schema builder to use to create a schema for a C# type when registering automatically.
         /// If none is provided, the default schema builder will be used.
         /// </param>
         /// <param name="schemaReader">
-        /// A JSON schema reader (used to convert schemas received from the registry into abstract
-        /// representations). If none is provided, the default schema reader will be used.
+        /// The JSON schema reader to use to convert schemas received from the registry into abstract
+        /// representations. If none is provided, the default schema reader will be used.
         /// </param>
         /// <param name="schemaWriter">
-        /// A JSON schema writer (used to convert abstract schema representations when registering
-        /// automatically). If none is provided, the default schema writer will be used.
+        /// The JSON schema writer to use to convert abstract schema representations when registering
+        /// automatically. If none is provided, the default schema writer will be used.
         /// </param>
         /// <param name="serializerBuilder">
-        /// A serializer builder (used to build serialization functions for C# types). If none is
-        /// provided, the default serializer builder will be used.
+        /// The deserializer builder to use to build serialization functions for C# types. If none
+        /// is provided, the default serializer builder will be used.
         /// </param>
         public SchemaRegistrySerializerBuilder(
             IEnumerable<KeyValuePair<string, string>> registryConfiguration,
@@ -73,23 +86,23 @@ namespace Chr.Avro.Confluent
         /// Creates a serializer builder.
         /// </summary>
         /// <param name="registryClient">
-        /// A client to use for Schema Registry operations. (The client will not be disposed.)
+        /// The client to use for Schema Registry operations. (The client will not be disposed.)
         /// </param>
         /// <param name="schemaBuilder">
-        /// A schema builder (used to build a schema for a C# type when registering automatically).
+        /// The schema builder to use to create a schema for a C# type when registering automatically.
         /// If none is provided, the default schema builder will be used.
         /// </param>
         /// <param name="schemaReader">
-        /// A JSON schema reader (used to convert schemas received from the registry into abstract
-        /// representations). If none is provided, the default schema reader will be used.
+        /// The JSON schema reader to use to convert schemas received from the registry into abstract
+        /// representations. If none is provided, the default schema reader will be used.
         /// </param>
         /// <param name="schemaWriter">
-        /// A JSON schema writer (used to convert abstract schema representations when registering
-        /// automatically). If none is provided, the default schema writer will be used.
+        /// The JSON schema writer to use to convert abstract schema representations when registering
+        /// automatically. If none is provided, the default schema writer will be used.
         /// </param>
         /// <param name="serializerBuilder">
-        /// A serializer builder (used to build serialization functions for C# types). If none is
-        /// provided, the default serializer builder will be used.
+        /// The deserializer builder to use to build serialization functions for C# types. If none
+        /// is provided, the default serializer builder will be used.
         /// </param>
         /// <exception cref="ArgumentNullException">
         /// Thrown when the registry client is null.
@@ -101,13 +114,14 @@ namespace Chr.Avro.Confluent
             IJsonSchemaWriter schemaWriter = null,
             Serialization.IBinarySerializerBuilder serializerBuilder = null
         ) {
-            RegistryClient = registryClient ?? throw new ArgumentNullException(nameof(registryClient));
 
             _disposeRegistryClient = false;
-            _schemaBuilder = schemaBuilder ?? new Abstract.SchemaBuilder();
-            _schemaReader = schemaReader ?? new JsonSchemaReader();
-            _schemaWriter = schemaWriter ?? new JsonSchemaWriter();
-            _serializerBuilder = serializerBuilder ?? new Serialization.BinarySerializerBuilder();
+
+            RegistryClient = registryClient ?? throw new ArgumentNullException(nameof(registryClient));
+            SchemaBuilder = schemaBuilder ?? new Abstract.SchemaBuilder();
+            SchemaReader = schemaReader ?? new JsonSchemaReader();
+            SchemaWriter = schemaWriter ?? new JsonSchemaWriter();
+            SerializerBuilder = serializerBuilder ?? new Serialization.BinarySerializerBuilder();
         }
 
         /// <summary>
@@ -149,11 +163,14 @@ namespace Chr.Avro.Confluent
             }
             catch (Exception e) when (registerAutomatically && (
                 (e is SchemaRegistryException sre && sre.ErrorCode == 40401) ||
-                (e is AggregateException a && a.InnerExceptions.All(e => e is UnsupportedTypeException))
+                (e is AggregateException a && a.InnerExceptions.All(i =>
+                    i is UnsupportedSchemaException ||
+                    i is UnsupportedTypeException
+                ))
             ))
             {
-                var schema = _schemaBuilder.BuildSchema<T>();
-                var json = _schemaWriter.Write(schema);
+                var schema = SchemaBuilder.BuildSchema<T>();
+                var json = SchemaWriter.Write(schema);
 
                 var id = await RegistryClient.RegisterSchemaAsync(subject, json);
 
@@ -222,7 +239,7 @@ namespace Chr.Avro.Confluent
                 Array.Reverse(bytes);
             }
 
-            var serialize = _serializerBuilder.BuildDelegate<T>(_schemaReader.Read(schema));
+            var serialize = SerializerBuilder.BuildDelegate<T>(SchemaReader.Read(schema));
 
             return new DelegateSerializer<T>((data, stream) =>
             {

--- a/src/Chr.Avro.Confluent/SchemaRegistrySerializerBuilder.cs
+++ b/src/Chr.Avro.Confluent/SchemaRegistrySerializerBuilder.cs
@@ -4,6 +4,7 @@ using Confluent.SchemaRegistry;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Chr.Avro.Confluent
@@ -115,7 +116,7 @@ namespace Chr.Avro.Confluent
         /// <param name="id">
         /// The ID of the schema that should be used to serialize data.
         /// </param>
-        /// <exception cref="UnsupportedTypeException">
+        /// <exception cref="AggregateException">
         /// Thrown when the type is incompatible with the retrieved schema.
         /// </exception>
         public async Task<ISerializer<T>> Build<T>(int id)
@@ -134,7 +135,7 @@ namespace Chr.Avro.Confluent
         /// Whether to automatically register a schema that matches <typeparamref name="T" /> if
         /// one does not already exist.
         /// </param>
-        /// <exception cref="UnsupportedTypeException">
+        /// <exception cref="AggregateException">
         /// Thrown when the type is incompatible with the retrieved schema or a matching schema
         /// cannot be generated.
         /// </exception>
@@ -148,7 +149,7 @@ namespace Chr.Avro.Confluent
             }
             catch (Exception e) when (registerAutomatically && (
                 (e is SchemaRegistryException sre && sre.ErrorCode == 40401) ||
-                (e is UnsupportedTypeException)
+                (e is AggregateException a && a.InnerExceptions.All(e => e is UnsupportedTypeException))
             ))
             {
                 var schema = _schemaBuilder.BuildSchema<T>();
@@ -169,7 +170,7 @@ namespace Chr.Avro.Confluent
         /// <param name="version">
         /// The version of the subject to be resolved.
         /// </param>
-        /// <exception cref="UnsupportedTypeException">
+        /// <exception cref="AggregateException">
         /// Thrown when the type is incompatible with the retrieved schema.
         /// </exception>
         public virtual async Task<ISerializer<T>> Build<T>(string subject, int version)

--- a/src/Chr.Avro/Abstract/LogicalType.cs
+++ b/src/Chr.Avro/Abstract/LogicalType.cs
@@ -19,7 +19,7 @@ namespace Chr.Avro.Abstract
     /// See the <a href="https://avro.apache.org/docs/current/spec.html#Date">Avro spec</a> for
     /// details.
     /// </remarks>
-    public sealed class DateLogicalType : LogicalType { }
+    public class DateLogicalType : LogicalType { }
 
     /// <summary>
     /// A logical type representing an arbitrary-precision signed decimal number.
@@ -28,7 +28,7 @@ namespace Chr.Avro.Abstract
     /// See the <a href="https://avro.apache.org/docs/current/spec.html#Decimal">Avro spec</a> for
     /// details.
     /// </remarks>
-    public sealed class DecimalLogicalType : LogicalType
+    public class DecimalLogicalType : LogicalType
     {
         private int precision;
 
@@ -118,7 +118,7 @@ namespace Chr.Avro.Abstract
     /// See the <a href="https://avro.apache.org/docs/current/spec.html#Duration">Avro spec</a> for
     /// details.
     /// </remarks>
-    public sealed class DurationLogicalType : LogicalType
+    public class DurationLogicalType : LogicalType
     {
         /// <summary>
         /// The size of a duration (three 32-bit unsigned integers).
@@ -139,7 +139,7 @@ namespace Chr.Avro.Abstract
     /// See the <a href="https://avro.apache.org/docs/current/spec.html#Time+(microsecond+precision)">Avro spec</a>
     /// for details.
     /// </remarks>
-    public sealed class MicrosecondTimeLogicalType : TimeLogicalType { }
+    public class MicrosecondTimeLogicalType : TimeLogicalType { }
 
     /// <summary>
     /// A logical type representing a time of day (with no reference to a particular time zone) as
@@ -149,7 +149,7 @@ namespace Chr.Avro.Abstract
     /// See the <a href="https://avro.apache.org/docs/current/spec.html#Time+(millisecond+precision)">Avro spec</a>
     /// for details.
     /// </remarks>
-    public sealed class MillisecondTimeLogicalType : TimeLogicalType { }
+    public class MillisecondTimeLogicalType : TimeLogicalType { }
 
     /// <summary>
     /// A logical type that represents an instant in time.
@@ -163,7 +163,7 @@ namespace Chr.Avro.Abstract
     /// See the <a href="https://avro.apache.org/docs/current/spec.html#Timestamp+(microsecond+precision)">Avro spec</a>
     /// for details.
     /// </remarks>
-    public sealed class MicrosecondTimestampLogicalType : TimestampLogicalType { }
+    public class MicrosecondTimestampLogicalType : TimestampLogicalType { }
 
     /// <summary>
     /// A logical type representing an instant in time as milliseconds from the Unix epoch.
@@ -172,7 +172,7 @@ namespace Chr.Avro.Abstract
     /// See the <a href="https://avro.apache.org/docs/current/spec.html#Timestamp+(millisecond+precision)">Avro spec</a>
     /// for details.
     /// </remarks>
-    public sealed class MillisecondTimestampLogicalType : TimestampLogicalType { }
+    public class MillisecondTimestampLogicalType : TimestampLogicalType { }
 
     /// <summary>
     /// A logical type representing a universally unique identifier as defined by RFC 4122.
@@ -181,5 +181,5 @@ namespace Chr.Avro.Abstract
     /// See the <a href="https://avro.apache.org/docs/current/spec.html#UUID">Avro spec</a> for
     /// details.
     /// </remarks>
-    public sealed class UuidLogicalType : LogicalType { }
+    public class UuidLogicalType : LogicalType { }
 }

--- a/src/Chr.Avro/Abstract/SchemaBuilder.cs
+++ b/src/Chr.Avro/Abstract/SchemaBuilder.cs
@@ -70,11 +70,6 @@ namespace Chr.Avro.Abstract
     public class SchemaBuilder : ISchemaBuilder
     {
         /// <summary>
-        /// A default list of cases to apply.
-        /// </summary>
-        public static readonly IEnumerable<Func<ISchemaBuilder, ISchemaBuilderCase>> DefaultCaseBuilders;
-
-        /// <summary>
         /// A list of cases that the schema builder will attempt to apply. If the first case does
         /// not match, the schema builder will try the next case, and so on until all cases have
         /// been tested.
@@ -86,35 +81,12 @@ namespace Chr.Avro.Abstract
         /// </summary>
         public ITypeResolver Resolver { get; }
 
-        static SchemaBuilder()
-        {
-            DefaultCaseBuilders = new Func<ISchemaBuilder, ISchemaBuilderCase>[]
-            {
-                builder => new ArraySchemaBuilderCase(builder),
-                builder => new BooleanSchemaBuilderCase(),
-                builder => new BytesSchemaBuilderCase(),
-                builder => new DecimalSchemaBuilderCase(),
-                builder => new DoubleSchemaBuilderCase(),
-                builder => new DurationSchemaBuilderCase(),
-                builder => new EnumSchemaBuilderCase(),
-                builder => new FloatSchemaBuilderCase(),
-                builder => new IntSchemaBuilderCase(),
-                builder => new LongSchemaBuilderCase(),
-                builder => new MapSchemaBuilderCase(builder),
-                builder => new RecordSchemaBuilderCase(builder),
-                builder => new StringSchemaBuilderCase(),
-                builder => new TimestampSchemaBuilderCase(),
-                builder => new UriSchemaBuilderCase(),
-                builder => new UuidSchemaBuilderCase()
-            };
-        }
-
         /// <summary>
         /// Creates a new schema builder.
         /// </summary>
         /// <param name="caseBuilders">
-        /// An optional list of cases builders. If provided, this collection will replace the
-        /// default list, <see cref="DefaultCaseBuilders" />.
+        /// An optional list of case builders. If provided, this collection will replace the
+        /// default list.
         /// </param>
         /// <param name="typeResolver">
         /// A resolver to retrieve type information from. If no resolver is provided, the schema
@@ -128,7 +100,7 @@ namespace Chr.Avro.Abstract
             Resolver = typeResolver ?? new DataContractResolver();
 
             // initialize cases last so that the schema builder is fully ready:
-            foreach (var builder in caseBuilders ?? DefaultCaseBuilders)
+            foreach (var builder in caseBuilders ?? CreateCaseBuilders())
             {
                 cases.Add(builder(this));
             }
@@ -203,6 +175,32 @@ namespace Chr.Avro.Abstract
             }
 
             return schema;
+        }
+
+        /// <summary>
+        /// Creates a default list of case builders.
+        /// </summary>
+        public static IEnumerable<Func<ISchemaBuilder, ISchemaBuilderCase>> CreateCaseBuilders()
+        {
+            return new Func<ISchemaBuilder, ISchemaBuilderCase>[]
+            {
+                builder => new ArraySchemaBuilderCase(builder),
+                builder => new BooleanSchemaBuilderCase(),
+                builder => new BytesSchemaBuilderCase(),
+                builder => new DecimalSchemaBuilderCase(),
+                builder => new DoubleSchemaBuilderCase(),
+                builder => new DurationSchemaBuilderCase(),
+                builder => new EnumSchemaBuilderCase(),
+                builder => new FloatSchemaBuilderCase(),
+                builder => new IntSchemaBuilderCase(),
+                builder => new LongSchemaBuilderCase(),
+                builder => new MapSchemaBuilderCase(builder),
+                builder => new RecordSchemaBuilderCase(builder),
+                builder => new StringSchemaBuilderCase(),
+                builder => new TimestampSchemaBuilderCase(),
+                builder => new UriSchemaBuilderCase(),
+                builder => new UuidSchemaBuilderCase()
+            };
         }
     }
 

--- a/src/Chr.Avro/Abstract/SchemaBuilder.cs
+++ b/src/Chr.Avro/Abstract/SchemaBuilder.cs
@@ -84,15 +84,23 @@ namespace Chr.Avro.Abstract
         /// <summary>
         /// Creates a new schema builder.
         /// </summary>
+        /// <param name="typeResolver">
+        /// A resolver to retrieve type information from. If no resolver is provided, the schema
+        /// builder will use the default <see cref="DataContractResolver" />.
+        /// </param>
+        public SchemaBuilder(ITypeResolver typeResolver = null) : this(CreateCaseBuilders(), typeResolver) { }
+
+        /// <summary>
+        /// Creates a new schema builder.
+        /// </summary>
         /// <param name="caseBuilders">
-        /// An optional list of case builders. If provided, this collection will replace the
-        /// default list.
+        /// A list of case builders.
         /// </param>
         /// <param name="typeResolver">
         /// A resolver to retrieve type information from. If no resolver is provided, the schema
         /// builder will use the default <see cref="DataContractResolver" />.
         /// </param>
-        public SchemaBuilder(IEnumerable<Func<ISchemaBuilder, ISchemaBuilderCase>> caseBuilders = null, ITypeResolver typeResolver = null)
+        public SchemaBuilder(IEnumerable<Func<ISchemaBuilder, ISchemaBuilderCase>> caseBuilders, ITypeResolver typeResolver = null)
         {
             var cases = new List<ISchemaBuilderCase>();
 
@@ -119,6 +127,10 @@ namespace Chr.Avro.Abstract
         /// <returns>
         /// A schema that matches the type.
         /// </returns>
+        /// <exception cref="AggregateException">
+        /// Thrown when no case matches the type. <see cref="AggregateException.InnerExceptions" />
+        /// will be contain the exceptions thrown by each case.
+        /// </exception>
         public Schema BuildSchema<T>(IDictionary<Type, Schema> cache = null)
         {
             return BuildSchema(typeof(T), cache);
@@ -137,6 +149,10 @@ namespace Chr.Avro.Abstract
         /// <returns>
         /// A schema that matches the type.
         /// </returns>
+        /// <exception cref="AggregateException">
+        /// Thrown when no case matches the type. <see cref="AggregateException.InnerExceptions" />
+        /// will be contain the exceptions thrown by each case.
+        /// </exception>
         public Schema BuildSchema(Type type, IDictionary<Type, Schema> cache = null)
         {
             if (cache == null)
@@ -165,7 +181,7 @@ namespace Chr.Avro.Abstract
 
                 if (schema == null)
                 {
-                    throw new UnsupportedTypeException(type, $"No schema builder case could be applied to {resolution.Type.FullName} ({resolution.GetType().Name}).", new AggregateException(exceptions));
+                    throw new AggregateException($"No schema builder case could be applied to {resolution.Type.FullName} ({resolution.GetType().Name}).");
                 }
             }
 

--- a/src/Chr.Avro/UnsupportedSchemaException.cs
+++ b/src/Chr.Avro/UnsupportedSchemaException.cs
@@ -4,7 +4,7 @@ using System;
 namespace Chr.Avro
 {
     /// <summary>
-    /// The exception that is thrown when an operation does not support a .NET type.
+    /// The exception that is thrown when an operation does not support a schema.
     /// </summary>
     [Serializable]
     public class UnsupportedSchemaException : Exception
@@ -12,7 +12,7 @@ namespace Chr.Avro
         /// <summary>
         /// The schema that caused the exception to be thrown.
         /// </summary>
-        public Schema UnsupportedSchema { get; private set; }
+        public Schema UnsupportedSchema { get; }
 
         /// <summary>
         /// Creates an exception describing the error.

--- a/src/Chr.Avro/UnsupportedTypeException.cs
+++ b/src/Chr.Avro/UnsupportedTypeException.cs
@@ -11,7 +11,7 @@ namespace Chr.Avro
         /// <summary>
         /// The type that caused the exception to be thrown.
         /// </summary>
-        public Type UnsupportedType { get; private set; }
+        public Type UnsupportedType { get; }
 
         /// <summary>
         /// Creates an exception describing the error.

--- a/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
@@ -1,4 +1,5 @@
 using Chr.Avro.Abstract;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -59,7 +60,7 @@ namespace Chr.Avro.Serialization.Tests
             var serializer = SerializerBuilder.BuildSerializer<ISet<string>>(schema);
             var encoding = serializer.Serialize(value);
 
-            Assert.Throws<UnsupportedTypeException>(() => DeserializerBuilder.BuildDeserializer<ISet<string>>(schema));
+            Assert.Throws<AggregateException>(() => DeserializerBuilder.BuildDeserializer<ISet<string>>(schema));
         }
 
         [Theory]

--- a/tests/Chr.Avro.Binary.Tests/EnumSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/EnumSerializationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Chr.Avro.Abstract;
 using Xunit;
 
@@ -33,10 +34,10 @@ namespace Chr.Avro.Serialization.Tests
         public void MissingValues()
         {
             var schema = new EnumSchema("suit", new[] { "CLUBS", "DIAMONDS", "HEARTS", "SPADES", "EAGLES" });
-            Assert.Throws<UnsupportedTypeException>(() => DeserializerBuilder.BuildDeserializer<Suit>(schema));
+            Assert.Throws<AggregateException>(() => DeserializerBuilder.BuildDeserializer<Suit>(schema));
 
             schema = new EnumSchema("suit", new[] { "CLUBS", "DIAMONDS", "HEARTS" });
-            Assert.Throws<UnsupportedTypeException>(() => SerializerBuilder.BuildSerializer<Suit>(schema));
+            Assert.Throws<AggregateException>(() => SerializerBuilder.BuildSerializer<Suit>(schema));
         }
 
         [Theory]

--- a/tests/Chr.Avro.Binary.Tests/FixedSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/FixedSerializationTests.cs
@@ -60,8 +60,8 @@ namespace Chr.Avro.Serialization.Tests
         {
             var schema = new FixedSchema("test", 8);
 
-            Assert.Throws<UnsupportedSchemaException>(() => DeserializerBuilder.BuildDeserializer<Guid>(schema));
-            Assert.Throws<UnsupportedSchemaException>(() => SerializerBuilder.BuildSerializer<Guid>(schema));
+            Assert.Throws<AggregateException>(() => DeserializerBuilder.BuildDeserializer<Guid>(schema));
+            Assert.Throws<AggregateException>(() => SerializerBuilder.BuildSerializer<Guid>(schema));
         }
 
         public static IEnumerable<object[]> GuidData => new List<object[]>

--- a/tests/Chr.Avro.Binary.Tests/UnionSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/UnionSerializationTests.cs
@@ -1,4 +1,5 @@
 using Chr.Avro.Abstract;
+using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -21,8 +22,8 @@ namespace Chr.Avro.Serialization.Tests
         {
             var schema = new UnionSchema();
 
-            Assert.Throws<UnsupportedSchemaException>(() => SerializerBuilder.BuildSerializer<object>(schema));
-            Assert.Throws<UnsupportedSchemaException>(() => DeserializerBuilder.BuildDeserializer<object>(schema));
+            Assert.Throws<AggregateException>(() => SerializerBuilder.BuildSerializer<object>(schema));
+            Assert.Throws<AggregateException>(() => DeserializerBuilder.BuildDeserializer<object>(schema));
         }
 
         [Theory]
@@ -42,7 +43,7 @@ namespace Chr.Avro.Serialization.Tests
                 Assert.Equal(encoding, serializer.Serialize(value.Value));
             }
 
-            Assert.Throws<UnsupportedTypeException>(() => DeserializerBuilder.BuildDeserializer<int>(schema));
+            Assert.Throws<AggregateException>(() => DeserializerBuilder.BuildDeserializer<int>(schema));
         }
 
         [Theory]
@@ -71,8 +72,8 @@ namespace Chr.Avro.Serialization.Tests
                 new IntSchema()
             });
 
-            Assert.Throws<UnsupportedTypeException>(() => SerializerBuilder.BuildSerializer<string>(schema));
-            Assert.Throws<UnsupportedTypeException>(() => DeserializerBuilder.BuildDeserializer<string>(schema));
+            Assert.Throws<AggregateException>(() => SerializerBuilder.BuildSerializer<string>(schema));
+            Assert.Throws<AggregateException>(() => DeserializerBuilder.BuildDeserializer<string>(schema));
         }
 
         [Theory]

--- a/tests/Chr.Avro.Tests/Abstract/SchemaBuilderTests.cs
+++ b/tests/Chr.Avro.Tests/Abstract/SchemaBuilderTests.cs
@@ -438,7 +438,7 @@ namespace Chr.Avro.Tests
         [InlineData(typeof(int[,]))]
         public void ThrowsWhenNoCaseMatches(Type type)
         {
-            Assert.Throws<UnsupportedTypeException>(() => Builder.BuildSchema(type));
+            Assert.Throws<AggregateException>(() => Builder.BuildSchema(type));
         }
     }
 }

--- a/tests/Chr.Avro.Tests/Resolution/CommonResolverTests.cs
+++ b/tests/Chr.Avro.Tests/Resolution/CommonResolverTests.cs
@@ -511,7 +511,7 @@ namespace Chr.Avro.Tests
         [InlineData(typeof(int[,]))]
         public void ThrowsWhenNoCaseMatches(Type type)
         {
-            Assert.Throws<UnsupportedTypeException>(() => Resolver.ResolveType(type));
+            Assert.Throws<AggregateException>(() => Resolver.ResolveType(type));
         }
     }
 }


### PR DESCRIPTION
Resolves #26:

- [x] unseal logical type classes
- [x] refactor all case patterns (two constructors: one w/ case options, one w/ case builders)
- [x] `protected readonly T X` -> `public T X { get; }`
- [x] remove `IsMatch` test on cases (cuts down on a bunch of code and paves the way for more detailed errors)