### PR TITLE
Stop using exceptions to control case flow

### DIFF
--- a/src/Chr.Avro.Binary/BinaryDeserializerBuilder.cs
+++ b/src/Chr.Avro.Binary/BinaryDeserializerBuilder.cs
@@ -37,7 +37,7 @@ namespace Chr.Avro.Serialization
         /// <returns>
         /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
         /// </returns>
-        Func<Stream, T> BuildDelegate<T>(Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache = null);
+        Func<Stream, T> BuildDelegate<T>(Schema schema, ConcurrentDictionary<(Type, Schema), Delegate>? cache = null);
 
         /// <summary>
         /// Builds a binary deserializer.
@@ -53,8 +53,30 @@ namespace Chr.Avro.Serialization
     }
 
     /// <summary>
-    /// Builds Avro deserializers for specific type-schema combinations. Used by
-    /// <see cref="BinaryDeserializerBuilder" /> to break apart deserializer building logic.
+    /// Represents the outcome of a deserializer builder case.
+    /// </summary>
+    public interface IBinaryDeserializerBuildResult
+    {
+        /// <summary>
+        /// The result of applying the case. If null, the case was not applied successfully.
+        /// </summary>
+        /// <remarks>
+        /// The delegate should be a function that accepts a <see cref="Stream" /> and returns a
+        /// deserialized object. Since this is not a typed method, the general <see cref="Delegate" />
+        /// type is used.
+        /// </remarks>
+        Delegate? Delegate { get; }
+
+        /// <summary>
+        /// Any exceptions related to the applicability of the case. If <see cref="Delegate" /> is
+        /// not null, these exceptions should be interpreted as warnings.
+        /// </summary>
+        ICollection<Exception> Exceptions { get; }
+    }
+
+    /// <summary>
+    /// Builds Avro deserializers for specific type-schema combinations. See
+    /// <see cref="BinaryDeserializerBuilder" /> for implementation details.
     /// </summary>
     public interface IBinaryDeserializerBuilderCase
     {
@@ -68,14 +90,13 @@ namespace Chr.Avro.Serialization
         /// The schema to map to the type.
         /// </param>
         /// <param name="cache">
-        /// A delegate cache. If a delegate is cached for a specific type-schema pair, that delegate
-        /// will be returned for all subsequent occurrences of the pair.
+        /// A delegate cache. If a delegate is cached for a specific type-schema pair, that same
+        /// delegate will be returned for all occurrences of the pair.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object. Since
-        /// this is not a typed method, the general <see cref="Delegate" /> type is used.
+        /// A build result.
         /// </returns>
-        Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache);
+        IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache);
     }
 
     /// <summary>
@@ -90,7 +111,7 @@ namespace Chr.Avro.Serialization
         public IEnumerable<IBinaryDeserializerBuilderCase> Cases { get; }
 
         /// <summary>
-        /// A resolver to obtain type information from.
+        /// A resolver to retrieve type information from.
         /// </summary>
         public ITypeResolver Resolver { get; }
 
@@ -102,9 +123,10 @@ namespace Chr.Avro.Serialization
         /// no codec is provided, <see cref="BinaryCodec" /> will be used.
         /// </param>
         /// <param name="resolver">
-        /// A resolver to obtain type information from.
+        /// A resolver to retrieve type information from. If no resolver is provided, the deserializer
+        /// builder will use the default <see cref="DataContractResolver" />.
         /// </param>
-        public BinaryDeserializerBuilder(IBinaryCodec codec = null, ITypeResolver resolver = null)
+        public BinaryDeserializerBuilder(IBinaryCodec? codec = null, ITypeResolver? resolver = null)
             : this(CreateBinaryDeserializerCaseBuilders(codec ?? new BinaryCodec()), resolver) { }
 
         /// <summary>
@@ -114,9 +136,10 @@ namespace Chr.Avro.Serialization
         /// A list of case builders.
         /// </param>
         /// <param name="resolver">
-        /// A resolver to obtain type information from.
+        /// A resolver to retrieve type information from. If no resolver is provided, the deserializer
+        /// builder will use the default <see cref="DataContractResolver" />.
         /// </param>
-        public BinaryDeserializerBuilder(IEnumerable<Func<IBinaryDeserializerBuilder, IBinaryDeserializerBuilderCase>> caseBuilders, ITypeResolver resolver = null)
+        public BinaryDeserializerBuilder(IEnumerable<Func<IBinaryDeserializerBuilder, IBinaryDeserializerBuilderCase>> caseBuilders, ITypeResolver? resolver = null)
         {
             var cases = new List<IBinaryDeserializerBuilderCase>();
 
@@ -133,8 +156,7 @@ namespace Chr.Avro.Serialization
         /// Builds a delegate that reads a serialized object from a stream.
         /// </summary>
         /// <typeparam name="T">
-        /// The type of object to be deserialized. If the type is a class or a struct, it must have
-        /// a parameterless public constructor.
+        /// The type of object to be deserialized.
         /// </typeparam>
         /// <param name="schema">
         /// The schema to map to the type.
@@ -146,11 +168,10 @@ namespace Chr.Avro.Serialization
         /// <returns>
         /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
         /// </returns>
-        /// <exception cref="AggregateException">
-        /// Thrown when no case matches the schema or type. <see cref="AggregateException.InnerExceptions" />
-        /// will be contain the exceptions thrown by each case.
+        /// <exception cref="UnsupportedTypeException">
+        /// Thrown when no case can map the type to the schema.
         /// </exception>
-        public virtual Func<Stream, T> BuildDelegate<T>(Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache = null)
+        public virtual Func<Stream, T> BuildDelegate<T>(Schema schema, ConcurrentDictionary<(Type, Schema), Delegate>? cache = null)
         {
             if (cache == null)
             {
@@ -159,45 +180,43 @@ namespace Chr.Avro.Serialization
 
             var resolution = Resolver.ResolveType(typeof(T));
 
-            if (cache.TryGetValue((resolution.Type, schema), out var existing))
+            if (!cache.TryGetValue((resolution.Type, schema), out var @delegate))
             {
-                return existing as Func<Stream, T>;
+                var exceptions = new List<Exception>();
+
+                foreach (var @case in Cases)
+                {
+                    var result = @case.BuildDelegate(resolution, schema, cache);
+
+                    if (result.Delegate != null)
+                    {
+                        @delegate = result.Delegate;
+                        break;
+                    }
+
+                    exceptions.AddRange(result.Exceptions);
+                }
+
+                if (@delegate == null)
+                {
+                    throw new UnsupportedTypeException(resolution.Type, $"No deserializer builder case matched {resolution.GetType().Name}.", new AggregateException(exceptions));
+                }
             }
 
-            var exceptions = new List<Exception>();
-
-            foreach (var @case in Cases)
-            {
-                try
-                {
-                    return @case.BuildDelegate(resolution, schema, cache) as Func<Stream, T>;
-                }
-                catch (UnsupportedSchemaException exception)
-                {
-                    exceptions.Add(exception);
-                }
-                catch (UnsupportedTypeException exception)
-                {
-                    exceptions.Add(exception);
-                }
-            }
-
-            throw new AggregateException($"No deserializer builder case matched {resolution.GetType().Name}.", exceptions);
+            return (Func<Stream, T>)@delegate;
         }
 
         /// <summary>
         /// Builds a binary deserializer.
         /// </summary>
         /// <typeparam name="T">
-        /// The type of object to be deserialized. If the type is a class or a struct, it must have
-        /// a parameterless public constructor.
+        /// The type of object to be deserialized.
         /// </typeparam>
         /// <param name="schema">
         /// The schema to map to the type.
         /// </param>
-        /// <exception cref="AggregateException">
-        /// Thrown when no case matches the schema or type. <see cref="AggregateException.InnerExceptions" />
-        /// will be contain the exceptions thrown by each case.
+        /// <exception cref="UnsupportedTypeException">
+        /// Thrown when no case can map the type to the schema.
         /// </exception>
         public virtual IBinaryDeserializer<T> BuildDeserializer<T>(Schema schema)
         {
@@ -247,7 +266,29 @@ namespace Chr.Avro.Serialization
     }
 
     /// <summary>
-    /// A base deserializer builder case.
+    /// A base <see cref="IBinaryDeserializerBuildResult" /> implementation.
+    /// </summary>
+    public class BinaryDeserializerBuildResult : IBinaryDeserializerBuildResult
+    {
+        /// <summary>
+        /// The result of applying the case. If null, the case was not applied successfully.
+        /// </summary>
+        /// <remarks>
+        /// The delegate should be a function that accepts a <see cref="Stream" /> and returns a
+        /// deserialized object. Since this is not a typed method, the general <see cref="Delegate" />
+        /// type is used.
+        /// </remarks>
+        public Delegate? Delegate { get; set; }
+
+        /// <summary>
+        /// Any exceptions related to the applicability of the case. If <see cref="Delegate" /> is
+        /// not null, these exceptions should be interpreted as warnings.
+        /// </summary>
+        public ICollection<Exception> Exceptions { get; set; } = new List<Exception>();
+    }
+
+    /// <summary>
+    /// A base <see cref="IBinaryDeserializerBuilderCase" /> implementation.
     /// </summary>
     public abstract class BinaryDeserializerBuilderCase : IBinaryDeserializerBuilderCase
     {
@@ -261,14 +302,36 @@ namespace Chr.Avro.Serialization
         /// The schema to map to the type.
         /// </param>
         /// <param name="cache">
-        /// A delegate cache. If a delegate is cached for a specific type-schema pair, that delegate
-        /// will be returned for all subsequent occurrences of the pair.
+        /// A delegate cache. If a delegate is cached for a specific type-schema pair, that same
+        /// delegate will be returned for all occurrences of the pair.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object. Since
-        /// this is not a typed method, the general <see cref="Delegate" /> type is used.
+        /// A build result.
         /// </returns>
-        public abstract Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache);
+        public abstract IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache);
+
+        /// <summary>
+        /// Generates a conversion from the intermediate type to the target type.
+        /// </summary>
+        /// <remarks>
+        /// See the remarks for <see cref="Expression.ConvertChecked(Expression, Type)" />.
+        /// </remarks>
+        protected virtual Expression GenerateConversion(Expression input, Type target)
+        {
+            if (input.Type == target)
+            {
+                return input;
+            }
+
+            try
+            {
+                return Expression.ConvertChecked(input, target);
+            }
+            catch (InvalidOperationException inner)
+            {
+                throw new UnsupportedTypeException(target, inner: inner);
+            }
+        }
     }
 
     /// <summary>
@@ -298,8 +361,8 @@ namespace Chr.Avro.Serialization
         /// </param>
         public ArrayDeserializerBuilderCase(IBinaryCodec codec, IBinaryDeserializerBuilder deserializerBuilder)
         {
-            Codec = codec;
-            DeserializerBuilder = deserializerBuilder;
+            Codec = codec ?? throw new ArgumentNullException(nameof(codec), "Binary codec cannot be null.");
+            DeserializerBuilder = deserializerBuilder ?? throw new ArgumentNullException(nameof(deserializerBuilder), "Binary deserializer builder cannot be null.");
         }
 
         /// <summary>
@@ -315,119 +378,120 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the resolution is an <see cref="ArrayResolution" /> and the
+        /// schema is an <see cref="ArraySchema" />; an unsuccessful result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedSchemaException">
-        /// Thrown when the schema is not an <see cref="ArraySchema" />.
-        /// </exception>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the resolved type is neither an array type nor a type assignable from
-        /// <see cref="List{T}" />.
+        /// Thrown when the resolved type does not have an enumerable constructor and is not
+        /// assignable from <see cref="List{T}" />.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(resolution is ArrayResolution arrayResolution))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema is ArraySchema arraySchema)
             {
-                throw new UnsupportedTypeException(resolution.Type, "An array deserializer can only be built for an array resolution.");
-            }
+                if (resolution is ArrayResolution arrayResolution)
+                {
+                    var target = arrayResolution.Type;
+                    var item = arrayResolution.ItemType;
 
-            if (!(schema is ArraySchema arraySchema))
-            {
-                throw new UnsupportedSchemaException(schema, "An array deserializer can only be built for an array schema.");
-            }
+                    var codec = Expression.Constant(Codec);
+                    var stream = Expression.Parameter(typeof(Stream));
 
-            var target = arrayResolution.Type;
-            var item = arrayResolution.ItemType;
+                    Expression expression = null!;
 
-            var codec = Expression.Constant(Codec);
-            var stream = Expression.Parameter(typeof(Stream));
+                    try
+                    {
+                        var build = typeof(IBinaryDeserializerBuilder)
+                            .GetMethod(nameof(IBinaryDeserializerBuilder.BuildDelegate))
+                            .MakeGenericMethod(item);
 
-            Expression result = null;
+                        var readBlocks = typeof(IBinaryCodec)
+                            .GetMethods()
+                            .Single(m => m.Name == nameof(IBinaryCodec.ReadBlocks)
+                                && m.GetGenericArguments().Length == 1
+                            )
+                            .MakeGenericMethod(item);
 
-            try
-            {
-                var build = typeof(IBinaryDeserializerBuilder)
-                    .GetMethod(nameof(IBinaryDeserializerBuilder.BuildDelegate))
-                    .MakeGenericMethod(item);
+                        expression = Expression.Call(
+                            codec,
+                            readBlocks,
+                            stream,
+                            Expression.Constant(
+                                build.Invoke(DeserializerBuilder, new object[] { arraySchema.Item, cache }),
+                                typeof(Func<,>).MakeGenericType(typeof(Stream), item)
+                            )
+                        );
+                    }
+                    catch (TargetInvocationException indirect)
+                    {
+                        ExceptionDispatchInfo.Capture(indirect.InnerException).Throw();
+                    }
 
-                var readBlocks = typeof(IBinaryCodec)
-                    .GetMethods()
-                    .Single(m => m.Name == nameof(IBinaryCodec.ReadBlocks)
-                        && m.GetGenericArguments().Length == 1
-                    )
-                    .MakeGenericMethod(item);
+                    if (FindEnumerableConstructor(arrayResolution, item) is ConstructorResolution constructorResolution)
+                    {
+                        expression = Expression.New(constructorResolution.Constructor, new[] { expression });
+                    }
+                    else
+                    {
+                        expression = GenerateConversion(expression, target);
+                    }
 
-                result = Expression.Call(
-                    codec,
-                    readBlocks,
-                    stream,
-                    Expression.Constant(
-                        build.Invoke(DeserializerBuilder, new object[] { arraySchema.Item, cache }),
-                        typeof(Func<,>).MakeGenericType(typeof(Stream), item)
-                    )
-                );
-            }
-            catch (TargetInvocationException indirect)
-            {
-                ExceptionDispatchInfo.Capture(indirect.InnerException).Throw();
-            }
+                    var lambda = Expression.Lambda(expression, "array deserializer", new[] { stream });
+                    var compiled = lambda.Compile();
 
-            var constructor = FindEnumerableConstructor(arrayResolution, item);
+                    if (!cache.TryAdd((target, schema), compiled))
+                    {
+                        throw new InvalidOperationException();
+                    }
 
-            if (constructor != null)
-            {
-                var value = Expression.Parameter(target);
-                result = Expression.Block(
-                    new[] { value },
-                    Expression.Assign(value, Expression.New(constructor.Constructor, new[] { result })),
-                    value
-                );
+                    result.Delegate = compiled;
+                }
+                else
+                {
+                    result.Exceptions.Add(new UnsupportedTypeException(resolution.Type));
+                }
             }
             else
             {
-                var convert = typeof(Enumerable).GetMethods()
-                    .Where(m => m.Name == (target.IsArray
-                        ? nameof(Enumerable.ToArray)
-                        : nameof(Enumerable.ToList)
-                    ))
-                    .Single()
-                    .MakeGenericMethod(item);
-
-                if (!target.IsAssignableFrom(convert.ReturnType))
-                {
-                    throw new UnsupportedTypeException(target, $"An array deserializer cannot be built for type {target.FullName}.");
-                }
-
-                result = Expression.ConvertChecked(Expression.Call(null, convert, result), target);
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
             }
 
-            var lambda = Expression.Lambda(result, "array deserializer", new[] { stream });
-            var compiled = lambda.Compile();
-
-            return cache.GetOrAdd((target, schema), compiled);
+            return result;
         }
 
-        private ConstructorResolution FindEnumerableConstructor(ArrayResolution arrayResolution, Type type)
+        /// <summary>
+        /// Attempts to find a constructor that takes a single enumerable parameter.
+        /// </summary>
+        protected virtual ConstructorResolution? FindEnumerableConstructor(ArrayResolution resolution, Type itemType)
         {
-            ConstructorResolution match = null;
-            foreach (var constructor in arrayResolution.Constructors)
+            return resolution.Constructors
+                .Where(c => c.Parameters.Count == 1)
+                .FirstOrDefault(c => c.Parameters.First().Type.IsAssignableFrom(typeof(IEnumerable<>).MakeGenericType(itemType)));
+        }
+
+        /// <summary>
+        /// Generates a conversion from the intermediate type to the target type. This override
+        /// will convert the intermediate type to an array or list (depending on the target) prior
+        /// to applying the base implementation.
+        /// </summary>
+        protected override Expression GenerateConversion(Expression input, Type target)
+        {
+            var convert = target.IsArray
+                ? typeof(Enumerable)
+                    .GetMethod(nameof(Enumerable.ToArray))
+                    .MakeGenericMethod(target.GetElementType())
+                : typeof(Enumerable)
+                    .GetMethod(nameof(Enumerable.ToList))
+                    .MakeGenericMethod(target.GetGenericArguments().Single());
+
+            if (!target.IsAssignableFrom(convert.ReturnType))
             {
-                if (constructor.Parameters.Count == 1)
-                {
-                    var parameterType = constructor.Parameters.First().Type;
-                    if (parameterType.IsGenericType && parameterType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
-                    {
-                        var arguments = parameterType.GetGenericArguments();
-                        if (arguments.Count() == 1 && arguments[0] == type)
-                        {
-                            match = constructor;
-                            break;
-                        }
-                    }
-                }
+                throw new UnsupportedTypeException(target);
             }
 
-            return match;
+            return base.GenerateConversion(Expression.Call(null, convert, input), target);
         }
     }
 
@@ -466,48 +530,43 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the schema is a <see cref="BooleanSchema" />; an unsuccessful
+        /// result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedSchemaException">
-        /// Thrown when the schema is not a <see cref="BooleanSchema" />.
-        /// </exception>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when no conversion from <see cref="bool" /> exists.
+        /// Thrown when <see cref="bool" /> cannot be converted to the resolved type.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(schema is BooleanSchema))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema is BooleanSchema)
             {
-                throw new UnsupportedSchemaException(schema, "A boolean deserializer can only be built for a boolean schema.");
+                var target = resolution.Type;
+
+                var codec = Expression.Constant(Codec);
+                var stream = Expression.Parameter(typeof(Stream));
+
+                var readValue = typeof(IBinaryCodec)
+                    .GetMethod(nameof(IBinaryCodec.ReadBoolean));
+
+                var expression = GenerateConversion(Expression.Call(codec, readValue, stream), target);
+                var lambda = Expression.Lambda(expression, "boolean deserializer", new[] { stream });
+                var compiled = lambda.Compile();
+
+                if (!cache.TryAdd((target, schema), compiled))
+                {
+                    throw new InvalidOperationException();
+                }
+
+                result.Delegate = compiled;
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
             }
 
-            var source = typeof(bool);
-            var target = resolution.Type;
-
-            var codec = Expression.Constant(Codec);
-            var stream = Expression.Parameter(typeof(Stream));
-
-            var readValue = typeof(IBinaryCodec)
-                .GetMethod(nameof(IBinaryCodec.ReadBoolean));
-
-            Expression result = Expression.Call(codec, readValue, stream);
-
-            if (source != target)
-            {
-                try
-                {
-                    result = Expression.ConvertChecked(result, target);
-                }
-                catch (InvalidOperationException inner)
-                {
-                    throw new UnsupportedTypeException(target, $"A boolean deserializer cannot be built for type {target.FullName}.", inner);
-                }
-            }
-
-            var lambda = Expression.Lambda(result, "boolean deserializer", new[] { stream });
-            var compiled = lambda.Compile();
-
-            return cache.GetOrAdd((target, schema), compiled);
+            return result;
         }
     }
 
@@ -546,61 +605,67 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the schema is a <see cref="BytesSchema" />; an unsuccessful
+        /// result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedSchemaException">
-        /// Thrown when the schema is not a <see cref="BytesSchema" />.
-        /// </exception>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when no conversion from <see cref="T:System.Byte[]" /> exists.
+        /// Thrown when <see cref="T:System.Byte[]" /> cannot be converted to the resolved type.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(schema is BytesSchema))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema is BytesSchema)
             {
-                throw new UnsupportedSchemaException(schema, "A bytes deserializer can only be built for a bytes schema.");
+                var target = resolution.Type;
+
+                var codec = Expression.Constant(Codec);
+                var stream = Expression.Parameter(typeof(Stream));
+
+                var readLength = typeof(IBinaryCodec)
+                    .GetMethod(nameof(IBinaryCodec.ReadInteger));
+
+                Expression expression = Expression.ConvertChecked(Expression.Call(codec, readLength, stream), typeof(int));
+
+                var readValue = typeof(IBinaryCodec)
+                    .GetMethod(nameof(IBinaryCodec.Read));
+
+                expression = GenerateConversion(Expression.Call(codec, readValue, stream, expression), target);
+
+                var lambda = Expression.Lambda(expression, "bytes deserializer", new[] { stream });
+                var compiled = lambda.Compile();
+
+                if (!cache.TryAdd((target, schema), compiled))
+                {
+                    throw new InvalidOperationException();
+                }
+
+                result.Delegate = compiled;
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
             }
 
-            var source = typeof(byte[]);
-            var target = resolution.Type;
+            return result;
+        }
 
-            var codec = Expression.Constant(Codec);
-            var stream = Expression.Parameter(typeof(Stream));
-
-            var readLength = typeof(IBinaryCodec)
-                .GetMethod(nameof(IBinaryCodec.ReadInteger));
-
-            Expression result = Expression.ConvertChecked(Expression.Call(codec, readLength, stream), typeof(int));
-
-            var readValue = typeof(IBinaryCodec)
-                .GetMethod(nameof(IBinaryCodec.Read));
-
-            result = Expression.Call(codec, readValue, stream, result);
-
-            if (source != target)
+        /// <summary>
+        /// Generates a conversion from the source type to the intermediate type. This override
+        /// will convert a bytes value to <see cref="Guid" /> prior to applying the base
+        /// implementation.
+        /// </summary>
+        protected override Expression GenerateConversion(Expression input, Type target)
+        {
+            if (target == typeof(Guid) || target == typeof(Guid?))
             {
-                if (target == typeof(Guid) || target == typeof(Guid?))
-                {
-                    var guidConstructor = typeof(Guid)
-                        .GetConstructor(new[] { typeof(byte[]) });
+                var guidConstructor = typeof(Guid)
+                    .GetConstructor(new[] { input.Type });
 
-                    result = Expression.New(guidConstructor, result);
-                }
-
-                try
-                {
-                    result = Expression.ConvertChecked(result, target);
-                }
-                catch (InvalidOperationException inner)
-                {
-                    throw new UnsupportedTypeException(target, $"A bytes deserializer cannot be built for type {target.FullName}.", inner);
-                }
+                input = Expression.New(guidConstructor, input);
             }
 
-            var lambda = Expression.Lambda(result, "bytes deserializer", new[] { stream });
-            var compiled = lambda.Compile();
-
-            return cache.GetOrAdd((target, schema), compiled);
+            return base.GenerateConversion(input, target);
         }
     }
 
@@ -639,97 +704,97 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the schema’s logical type is <see cref="DecimalLogicalType" />;
+        /// an unsuccessful result otherwise.
         /// </returns>
         /// <exception cref="UnsupportedSchemaException">
-        /// Thrown when the schema is not a <see cref="BytesSchema" /> or a <see cref="FixedSchema "/>
-        /// with logical type <see cref="DecimalLogicalType" />.
+        /// Thrown when the schema is not a <see cref="BytesSchema" /> or a <see cref="FixedSchema "/>.
         /// </exception>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when no conversion from <see cref="decimal" /> exists.
+        /// Thrown when <see cref="decimal" /> cannot be converted to the resolved type.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(schema.LogicalType is DecimalLogicalType decimalLogicalType))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema.LogicalType is DecimalLogicalType decimalLogicalType)
             {
-                throw new UnsupportedSchemaException(schema, "A decimal deserializer can only be built for schema with a decimal logical type.");
-            }
+                var precision = decimalLogicalType.Precision;
+                var scale = decimalLogicalType.Scale;
+                var target = resolution.Type;
 
-            var precision = decimalLogicalType.Precision;
-            var scale = decimalLogicalType.Scale;
-            var source = typeof(decimal);
-            var target = resolution.Type;
+                var codec = Expression.Constant(Codec);
+                var stream = Expression.Parameter(typeof(Stream));
 
-            var codec = Expression.Constant(Codec);
-            var stream = Expression.Parameter(typeof(Stream));
+                Expression expression;
 
-            Expression result;
+                // figure out the size:
+                if (schema is BytesSchema)
+                {
+                    var readLength = typeof(IBinaryCodec)
+                        .GetMethod(nameof(IBinaryCodec.ReadInteger));
 
-            // figure out the size:
-            if (schema is BytesSchema)
-            {
-                var readLength = typeof(IBinaryCodec)
-                    .GetMethod(nameof(IBinaryCodec.ReadInteger));
+                    expression = Expression.ConvertChecked(Expression.Call(codec, readLength, stream), typeof(int));
+                }
+                else if (schema is FixedSchema fixedSchema)
+                {
+                    expression = Expression.Constant(fixedSchema.Size);
+                }
+                else
+                {
+                    throw new UnsupportedSchemaException(schema);
+                }
 
-                result = Expression.ConvertChecked(Expression.Call(codec, readLength, stream), typeof(int));
-            }
-            else if (schema is FixedSchema fixedSchema)
-            {
-                result = Expression.Constant(fixedSchema.Size);
+                var readValue = typeof(IBinaryCodec)
+                    .GetMethod(nameof(IBinaryCodec.Read));
+
+                // read the bytes:
+                expression = Expression.Call(codec, readValue, stream, expression);
+
+                // declare some variables for in-place transformation:
+                var bytes = Expression.Variable(typeof(byte[]));
+
+                var integerConstructor = typeof(BigInteger)
+                    .GetConstructor(new[] { typeof(byte[]) });
+
+                var reverse = typeof(Array)
+                    .GetMethod(nameof(Array.Reverse), new[] { typeof(Array) });
+
+                expression = Expression.Block(
+                    new[] { bytes },
+
+                    // store the bytes in a variable:
+                    Expression.Assign(bytes, expression),
+
+                    // BigInteger is little-endian, so reverse before creating:
+                    Expression.Call(null, reverse, bytes),
+
+                    // return (decimal)new BigInteger(bytes) / (decimal)Math.Pow(10, scale);
+                    Expression.Divide(
+                        Expression.ConvertChecked(
+                            Expression.New(integerConstructor, bytes),
+                            typeof(decimal)),
+                        Expression.Constant((decimal)Math.Pow(10, scale)))
+                );
+
+                expression = GenerateConversion(expression, target);
+
+                var lambda = Expression.Lambda(expression, "decimal deserializer", new[] { stream });
+                var compiled = lambda.Compile();
+
+                if (!cache.TryAdd((target, schema), compiled))
+                {
+                    throw new InvalidOperationException();
+                }
+
+                result.Delegate = compiled;
             }
             else
             {
-                throw new UnsupportedSchemaException(schema, "A decimal deserializer can only be built for a bytes or a fixed schema.");
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
             }
 
-            var readValue = typeof(IBinaryCodec)
-                .GetMethod(nameof(IBinaryCodec.Read));
-
-            // read the bytes:
-            result = Expression.Call(codec, readValue, stream, result);
-
-            // declare some variables for in-place transformation:
-            var bytes = Expression.Variable(typeof(byte[]));
-
-            var integerConstructor = typeof(BigInteger)
-                .GetConstructor(new[] { typeof(byte[]) });
-
-            var reverse = typeof(Array)
-                .GetMethod(nameof(Array.Reverse), new[] { typeof(Array) });
-
-            result = Expression.Block(
-                new[] { bytes },
-
-                // store the bytes in a variable:
-                Expression.Assign(bytes, result),
-
-                // BigInteger is little-endian, so reverse before creating:
-                Expression.Call(null, reverse, bytes),
-
-                // return (decimal)new BigInteger(bytes) / (decimal)Math.Pow(10, scale);
-                Expression.Divide(
-                    Expression.ConvertChecked(
-                        Expression.New(integerConstructor, bytes),
-                        typeof(decimal)),
-                    Expression.Constant((decimal)Math.Pow(10, scale)))
-            );
-
-            if (source != target)
-            {
-                try
-                {
-                    result = Expression.ConvertChecked(result, target);
-                }
-                catch (InvalidOperationException inner)
-                {
-                    throw new UnsupportedTypeException(target, $"A decimal deserializer cannot be built for type {target.FullName}.", inner);
-                }
-            }
-
-            var lambda = Expression.Lambda(result, "decimal deserializer", new[] { stream });
-            var compiled = lambda.Compile();
-
-            return cache.GetOrAdd((target, schema), compiled);
+            return result;
         }
     }
 
@@ -768,48 +833,43 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the schema is a <see cref="DoubleSchema" />; an unsuccessful
+        /// result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedSchemaException">
-        /// Thrown when the schema is not a <see cref="DoubleSchema" />.
-        /// </exception>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when no conversion from <see cref="double" /> exists.
+        /// Thrown when <see cref="double" /> cannot be converted to the resolved type.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(schema is DoubleSchema))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema is DoubleSchema)
             {
-                throw new UnsupportedSchemaException(schema, "A double deserializer can only be built for a double schema.");
+                var target = resolution.Type;
+
+                var codec = Expression.Constant(Codec);
+                var stream = Expression.Parameter(typeof(Stream));
+
+                var readValue = typeof(IBinaryCodec)
+                    .GetMethod(nameof(IBinaryCodec.ReadDouble));
+
+                var expression = GenerateConversion(Expression.Call(codec, readValue, stream), target);
+                var lambda = Expression.Lambda(expression, "double deserializer", new[] { stream });
+                var compiled = lambda.Compile();
+
+                if (!cache.TryAdd((target, schema), compiled))
+                {
+                    throw new InvalidOperationException();
+                }
+
+                result.Delegate = compiled;
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
             }
 
-            var source = typeof(double);
-            var target = resolution.Type;
-
-            var codec = Expression.Constant(Codec);
-            var stream = Expression.Parameter(typeof(Stream));
-
-            var readValue = typeof(IBinaryCodec)
-                .GetMethod(nameof(IBinaryCodec.ReadDouble));
-
-            Expression result = Expression.Call(codec, readValue, stream);
-
-            if (source != target)
-            {
-                try
-                {
-                    result = Expression.ConvertChecked(result, target);
-                }
-                catch (InvalidOperationException inner)
-                {
-                    throw new UnsupportedTypeException(target, $"A double deserializer cannot be built for type {target.FullName}.", inner);
-                }
-            }
-
-            var lambda = Expression.Lambda(result, "double deserializer", new[] { stream });
-            var compiled = lambda.Compile();
-
-            return cache.GetOrAdd((target, schema), compiled);
+            return result;
         }
     }
 
@@ -848,84 +908,96 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the resolution is a <see cref="DurationResolution" /> and the
+        /// schema’s logical type is a <see cref="DurationLogicalType" />; an unsuccessful result
+        /// otherwise.
         /// </returns>
         /// <exception cref="UnsupportedSchemaException">
         /// Thrown when the schema is not a <see cref="FixedSchema" /> with size 12 and logical
         /// type <see cref="DurationLogicalType" />.
         /// </exception>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="TimeSpan" />.
+        /// Thrown when <see cref="TimeSpan" /> cannot be converted to the resolved type.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(schema.LogicalType is DurationLogicalType))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema.LogicalType is DurationLogicalType)
             {
-                throw new UnsupportedSchemaException(schema, "A duration deserializer can only be built for a schema with a duration logical type.");
-            }
-
-            if (!(schema is FixedSchema fixedSchema && fixedSchema.Size == 12))
-            {
-                throw new UnsupportedSchemaException(schema, "A duration deserializer can only be built for a fixed schema with size 12.");
-            }
-
-            var target = resolution.Type;
-
-            if (!(target == typeof(TimeSpan) || target == typeof(TimeSpan?)))
-            {
-                throw new UnsupportedTypeException(target, $"A duration deserializer cannot be built for {target.Name}.");
-            }
-
-            Func<Stream, long> read = input =>
-            {
-                var bytes = Codec.Read(input, 4);
-
-                if (!BitConverter.IsLittleEndian)
+                if (resolution is DurationResolution)
                 {
-                    Array.Reverse(bytes);
-                }
+                    if (!(schema is FixedSchema fixedSchema && fixedSchema.Size == 12))
+                    {
+                        throw new UnsupportedSchemaException(schema);
+                    }
 
-                return BitConverter.ToUInt32(bytes, 0);
-            };
+                    Func<Stream, long> read = input =>
+                    {
+                        var bytes = Codec.Read(input, 4);
 
-            var codec = Expression.Constant(Codec);
-            var stream = Expression.Parameter(typeof(Stream));
+                        if (!BitConverter.IsLittleEndian)
+                        {
+                            Array.Reverse(bytes);
+                        }
 
-            Expression result = Expression.Block(
-                Expression.IfThen(
-                    Expression.NotEqual(
-                        Expression.Invoke(Expression.Constant(read), stream),
-                        Expression.Constant(0L)
-                    ),
-                    Expression.Throw(
-                        Expression.New(
-                            typeof(OverflowException).GetConstructor(new[] { typeof(string )}),
-                            Expression.Constant("Durations containing months cannot be accurately deserialized to a TimeSpan.")
-                        )
-                    )
-                ),
-                Expression.ConvertChecked(
-                    Expression.New(
-                        typeof(TimeSpan).GetConstructor(new[] { typeof(long) }),
-                        Expression.AddChecked(
-                            Expression.MultiplyChecked(
+                        return BitConverter.ToUInt32(bytes, 0);
+                    };
+
+                    var target = resolution.Type;
+
+                    var codec = Expression.Constant(Codec);
+                    var stream = Expression.Parameter(typeof(Stream));
+
+                    var expression = GenerateConversion(Expression.Block(
+                        Expression.IfThen(
+                            Expression.NotEqual(
                                 Expression.Invoke(Expression.Constant(read), stream),
-                                Expression.Constant(TimeSpan.TicksPerDay)
+                                Expression.Constant(0L)
                             ),
-                            Expression.MultiplyChecked(
-                                Expression.Invoke(Expression.Constant(read), stream),
-                                Expression.Constant(TimeSpan.TicksPerMillisecond)
+                            Expression.Throw(
+                                Expression.New(
+                                    typeof(OverflowException).GetConstructor(new[] { typeof(string )}),
+                                    Expression.Constant("Durations containing months cannot be accurately deserialized to a TimeSpan.")
+                                )
+                            )
+                        ),
+                        Expression.New(
+                            typeof(TimeSpan).GetConstructor(new[] { typeof(long) }),
+                            Expression.AddChecked(
+                                Expression.MultiplyChecked(
+                                    Expression.Invoke(Expression.Constant(read), stream),
+                                    Expression.Constant(TimeSpan.TicksPerDay)
+                                ),
+                                Expression.MultiplyChecked(
+                                    Expression.Invoke(Expression.Constant(read), stream),
+                                    Expression.Constant(TimeSpan.TicksPerMillisecond)
+                                )
                             )
                         )
-                    ),
-                    target
-                )
-            );
+                    ), target);
 
-            var lambda = Expression.Lambda(result, $"duration deserializer", new[] { stream });
-            var compiled = lambda.Compile();
+                    var lambda = Expression.Lambda(expression, $"duration deserializer", new[] { stream });
+                    var compiled = lambda.Compile();
 
-            return cache.GetOrAdd((target, schema), compiled);
+                    if (!cache.TryAdd((target, schema), compiled))
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    result.Delegate = compiled;
+                }
+                else
+                {
+                    result.Exceptions.Add(new UnsupportedTypeException(resolution.Type));
+                }
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
+            }
+
+            return result;
         }
     }
 
@@ -964,65 +1036,76 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the resolution is an <see cref="EnumResolution" /> and the
+        /// schema is an <see cref="EnumSchema" />; an unsuccessful result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedSchemaException">
-        /// Thrown when the schema is not an <see cref="EnumSchema" />.
-        /// </exception>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the resolution is not an <see cref="EnumResolution" /> or the type does not
-        /// contain a matching symbol for each symbol in the schema.
+        /// Thrown when the the type does not contain a matching symbol for each symbol in the
+        /// schema.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(resolution is EnumResolution enumResolution))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema is EnumSchema enumSchema)
             {
-                throw new UnsupportedTypeException(resolution.Type, "An enum deserializer can only be built for an enum resolution.");
-            }
-
-            if (!(schema is EnumSchema enumSchema))
-            {
-                throw new UnsupportedSchemaException(schema, "An enum deserializer can only be built for an enum schema.");
-            }
-
-            var target = resolution.Type;
-
-            var codec = Expression.Constant(Codec);
-            var stream = Expression.Parameter(typeof(Stream));
-
-            var readIndex = typeof(IBinaryCodec)
-                .GetMethod(nameof(IBinaryCodec.ReadInteger));
-
-            Expression result = Expression.ConvertChecked(Expression.Call(codec, readIndex, stream), typeof(int));
-
-            // find a match for each enum in the schema:
-            var cases = enumSchema.Symbols.Select((name, index) =>
-            {
-                var match = enumResolution.Symbols.SingleOrDefault(s => s.Name.IsMatch(name));
-
-                if (match == null)
+                if (resolution is EnumResolution enumResolution)
                 {
-                    throw new UnsupportedTypeException(target, $"{target.Name} has no value that matches {name}.");
+                    var target = resolution.Type;
+
+                    var codec = Expression.Constant(Codec);
+                    var stream = Expression.Parameter(typeof(Stream));
+
+                    var readIndex = typeof(IBinaryCodec)
+                        .GetMethod(nameof(IBinaryCodec.ReadInteger));
+
+                    Expression expression = Expression.ConvertChecked(Expression.Call(codec, readIndex, stream), typeof(int));
+
+                    // find a match for each enum in the schema:
+                    var cases = enumSchema.Symbols.Select((name, index) =>
+                    {
+                        var match = enumResolution.Symbols.SingleOrDefault(s => s.Name.IsMatch(name));
+
+                        if (match == null)
+                        {
+                            throw new UnsupportedTypeException(target, $"{target.Name} has no value that matches {name}.");
+                        }
+
+                        return Expression.SwitchCase(
+                            GenerateConversion(Expression.Constant(match.Value), target),
+                            Expression.Constant(index)
+                        );
+                    });
+
+                    var exceptionConstructor = typeof(OverflowException)
+                        .GetConstructor(new[] { typeof(string) });
+
+                    var exception = Expression.New(exceptionConstructor, Expression.Constant("Enum index out of range."));
+
+                    // generate a switch on the index:
+                    expression = Expression.Switch(expression, Expression.Throw(exception, target), cases.ToArray());
+
+                    var lambda = Expression.Lambda(expression, $"{enumSchema.Name} deserializer", new[] { stream });
+                    var compiled = lambda.Compile();
+
+                    if (!cache.TryAdd((target, schema), compiled))
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    result.Delegate = compiled;
                 }
+                else
+                {
+                    result.Exceptions.Add(new UnsupportedTypeException(resolution.Type));
+                }
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
+            }
 
-                return Expression.SwitchCase(
-                    Expression.ConvertChecked(Expression.Constant(match.Value), target),
-                    Expression.Constant(index)
-                );
-            });
-
-            var exceptionConstructor = typeof(OverflowException)
-                .GetConstructor(new[] { typeof(string) });
-
-            var exception = Expression.New(exceptionConstructor, Expression.Constant("Enum index out of range."));
-
-            // generate a switch on the index:
-            result = Expression.Switch(result, Expression.Throw(exception, target), cases.ToArray());
-
-            var lambda = Expression.Lambda(result, $"{enumSchema.Name} deserializer", new[] { stream });
-            var compiled = lambda.Compile();
-
-            return cache.GetOrAdd((target, schema), compiled);
+            return result;
         }
     }
 
@@ -1061,61 +1144,61 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the schema is a <see cref="FixedSchema" />; an unsuccessful
+        /// result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedSchemaException">
-        /// Thrown when the schema is not a <see cref="FixedSchema" />.
-        /// </exception>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when no conversion from <see cref="T:System.Byte[]" /> exists.
+        /// Thrown when <see cref="T:System.Byte[]" /> cannot be converted to the resolved type.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(schema is FixedSchema fixedSchema))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema is FixedSchema fixedSchema)
             {
-                throw new UnsupportedSchemaException(schema, "A fixed deserializer can only be built for a fixed schema.");
+                var target = resolution.Type;
+
+                var codec = Expression.Constant(Codec);
+                var stream = Expression.Parameter(typeof(Stream));
+
+                var readValue = typeof(IBinaryCodec)
+                    .GetMethod(nameof(IBinaryCodec.Read));
+
+                var expression = GenerateConversion(Expression.Call(codec, readValue, stream, Expression.Constant(fixedSchema.Size)), target);
+                var lambda = Expression.Lambda(expression, $"{fixedSchema.Name} deserializer", new[] { stream });
+                var compiled = lambda.Compile();
+
+                if (!cache.TryAdd((target, schema), compiled))
+                {
+                    throw new InvalidOperationException();
+                }
+
+                result.Delegate = compiled;
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
             }
 
-            var source = typeof(byte[]);
-            var target = resolution.Type;
+            return result;
+        }
 
-            var codec = Expression.Constant(Codec);
-            var stream = Expression.Parameter(typeof(Stream));
-
-            var readValue = typeof(IBinaryCodec)
-                .GetMethod(nameof(IBinaryCodec.Read));
-
-            Expression result = Expression.Call(codec, readValue, stream, Expression.Constant(fixedSchema.Size));
-
-            if (source != target)
+        /// <summary>
+        /// Generates a conversion from the source type to the intermediate type. This override
+        /// will convert a bytes value to <see cref="Guid" /> prior to applying the base
+        /// implementation.
+        /// </summary>
+        protected override Expression GenerateConversion(Expression input, Type target)
+        {
+            if (target == typeof(Guid) || target == typeof(Guid?))
             {
-                if (target == typeof(Guid) || target == typeof(Guid?))
-                {
-                    if (fixedSchema.Size != 16)
-                    {
-                        throw new UnsupportedSchemaException(schema, $"A fixed schema cannot be mapped to a Guid unless its size is 16.");
-                    }
+                var guidConstructor = typeof(Guid)
+                    .GetConstructor(new[] { input.Type });
 
-                    var guidConstructor = typeof(Guid)
-                        .GetConstructor(new[] { typeof(byte[]) });
-
-                    result = Expression.New(guidConstructor, result);
-                }
-
-                try
-                {
-                    result = Expression.ConvertChecked(result, target);
-                }
-                catch (InvalidOperationException inner)
-                {
-                    throw new UnsupportedTypeException(target, $"A fixed deserializer cannot be built for type {target.FullName}.", inner);
-                }
+                input = Expression.New(guidConstructor, input);
             }
 
-            var lambda = Expression.Lambda(result, $"{fixedSchema.Name} deserializer", new[] { stream });
-            var compiled = lambda.Compile();
-
-            return cache.GetOrAdd((target, schema), compiled);
+            return base.GenerateConversion(input, target);
         }
     }
 
@@ -1154,48 +1237,43 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the schema is a <see cref="FloatSchema" />; an unsuccessful
+        /// result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedSchemaException">
-        /// Thrown when the schema is not a <see cref="FloatSchema" />.
-        /// </exception>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when no conversion from <see cref="float" /> exists.
+        /// Thrown when <see cref="float" /> cannot be converted to the resolved type.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(schema is FloatSchema))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema is FloatSchema)
             {
-                throw new UnsupportedSchemaException(schema, "A float deserializer can only be built for a float schema.");
+                var target = resolution.Type;
+
+                var codec = Expression.Constant(Codec);
+                var stream = Expression.Parameter(typeof(Stream));
+
+                var readValue = typeof(IBinaryCodec)
+                    .GetMethod(nameof(IBinaryCodec.ReadSingle));
+
+                var expression = GenerateConversion(Expression.Call(codec, readValue, stream), target);
+                var lambda = Expression.Lambda(expression, "float deserializer", new[] { stream });
+                var compiled = lambda.Compile();
+
+                if (!cache.TryAdd((target, schema), compiled))
+                {
+                    throw new InvalidOperationException();
+                }
+
+                result.Delegate = compiled;
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
             }
 
-            var source = typeof(float);
-            var target = resolution.Type;
-
-            var codec = Expression.Constant(Codec);
-            var stream = Expression.Parameter(typeof(Stream));
-
-            var readValue = typeof(IBinaryCodec)
-                .GetMethod(nameof(IBinaryCodec.ReadSingle));
-
-            Expression result = Expression.Call(codec, readValue, stream);
-
-            if (source != target)
-            {
-                try
-                {
-                    result = Expression.ConvertChecked(result, target);
-                }
-                catch (InvalidOperationException inner)
-                {
-                    throw new UnsupportedTypeException(target, $"A float deserializer cannot be built for type {target.FullName}.", inner);
-                }
-            }
-
-            var lambda = Expression.Lambda(result, "float deserializer", new[] { stream });
-            var compiled = lambda.Compile();
-
-            return cache.GetOrAdd((target, schema), compiled);
+            return result;
         }
     }
 
@@ -1234,48 +1312,43 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the schema is an <see cref="IntSchema" /> or a <see cref="LongSchema" />;
+        /// an unsuccessful result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedSchemaException">
-        /// Thrown when the schema is not an <see cref="IntSchema" /> or a <see cref="LongSchema" />.
-        /// </exception>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when no conversion from <see cref="long" /> exists.
+        /// Thrown when <see cref="long" /> cannot be converted to the resolved type.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(schema is IntSchema || schema is LongSchema))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema is IntSchema || schema is LongSchema)
             {
-                throw new UnsupportedSchemaException(schema, "An integer deserializer can only be built for an int or long schema.");
+                var target = resolution.Type;
+
+                var codec = Expression.Constant(Codec);
+                var stream = Expression.Parameter(typeof(Stream));
+
+                var readValue = typeof(IBinaryCodec)
+                    .GetMethod(nameof(IBinaryCodec.ReadInteger));
+
+                var expression = GenerateConversion(Expression.Call(codec, readValue, stream), target);
+                var lambda = Expression.Lambda(expression, "integer deserializer", new[] { stream });
+                var compiled = lambda.Compile();
+
+                if (!cache.TryAdd((target, schema), compiled))
+                {
+                    throw new InvalidOperationException();
+                }
+
+                result.Delegate = compiled;
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
             }
 
-            var source = typeof(long);
-            var target = resolution.Type;
-
-            var codec = Expression.Constant(Codec);
-            var stream = Expression.Parameter(typeof(Stream));
-
-            var readValue = typeof(IBinaryCodec)
-                .GetMethod(nameof(IBinaryCodec.ReadInteger));
-
-            Expression result = Expression.Call(codec, readValue, stream);
-
-            if (source != target)
-            {
-                try
-                {
-                    result = Expression.ConvertChecked(result, target);
-                }
-                catch (InvalidOperationException inner)
-                {
-                    throw new UnsupportedTypeException(target, $"An integer deserializer cannot be built for type {target.FullName}.", inner);
-                }
-            }
-
-            var lambda = Expression.Lambda(result, "integer deserializer", new[] { stream });
-            var compiled = lambda.Compile();
-
-            return cache.GetOrAdd((target, schema), compiled);
+            return result;
         }
     }
 
@@ -1306,8 +1379,8 @@ namespace Chr.Avro.Serialization
         /// </param>
         public MapDeserializerBuilderCase(IBinaryCodec codec, IBinaryDeserializerBuilder deserializerBuilder)
         {
-            Codec = codec;
-            DeserializerBuilder = deserializerBuilder;
+            Codec = codec ?? throw new ArgumentNullException(nameof(codec), "Binary codec cannot be null.");
+            DeserializerBuilder = deserializerBuilder ?? throw new ArgumentNullException(nameof(deserializerBuilder), "Binary deserializer builder cannot be null.");
         }
 
         /// <summary>
@@ -1323,90 +1396,100 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the resolution is a <see cref="MapResolution" /> and the schema
+        /// is a <see cref="MapSchema" />; an unsuccessful result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedSchemaException">
-        /// Thrown when the schema is not a <see cref="MapSchema" />.
-        /// </exception>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the resolution is not a <see cref="MapResolution" /> or the resolved type
-        /// is not assignable from <see cref="Dictionary{TKey, TValue}" />.
+        /// Thrown when the resolved type is not assignable from <see cref="Dictionary{TKey, TValue}" />.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(resolution is MapResolution mapResolution))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema is MapSchema mapSchema)
             {
-                throw new UnsupportedTypeException(resolution.Type, "A map deserializer can only be built for a map resolution.");
+                if (resolution is MapResolution mapResolution)
+                {
+                    var target = mapResolution.Type;
+                    var key = mapResolution.KeyType;
+                    var item = mapResolution.ValueType;
+
+                    var codec = Expression.Constant(Codec);
+                    var stream = Expression.Parameter(typeof(Stream));
+
+                    Expression expression = null!;
+
+                    try
+                    {
+                        var build = typeof(IBinaryDeserializerBuilder)
+                            .GetMethod(nameof(IBinaryDeserializerBuilder.BuildDelegate));
+
+                        var buildKey = build.MakeGenericMethod(key);
+                        var buildItem = build.MakeGenericMethod(item);
+
+                        var readBlocks = typeof(IBinaryCodec)
+                            .GetMethods()
+                            .Single(m => m.Name == nameof(IBinaryCodec.ReadBlocks)
+                                && m.GetGenericArguments().Length == 2
+                            )
+                            .MakeGenericMethod(key, item);
+
+                        expression = Expression.Call(
+                            codec,
+                            readBlocks,
+                            stream,
+                            Expression.Constant(
+                                buildKey.Invoke(DeserializerBuilder, new object[] { new StringSchema(), cache }),
+                                typeof(Func<,>).MakeGenericType(typeof(Stream), key)
+                            ),
+                            Expression.Constant(
+                                buildItem.Invoke(DeserializerBuilder, new object[] { mapSchema.Value, cache }),
+                                typeof(Func<,>).MakeGenericType(typeof(Stream), item)
+                            )
+                        );
+                    }
+                    catch (TargetInvocationException indirect)
+                    {
+                        ExceptionDispatchInfo.Capture(indirect.InnerException).Throw();
+                    }
+
+                    var idictionary = typeof(IDictionary<,>)
+                        .MakeGenericType(key, item);
+
+                    var dictionary = typeof(Dictionary<,>)
+                        .MakeGenericType(key, item);
+
+                    var dictionaryConstructor = dictionary
+                        .GetConstructor(new[] { idictionary });
+
+                    if (!target.IsAssignableFrom(dictionary))
+                    {
+                        throw new UnsupportedTypeException(target);
+                    }
+
+                    expression = GenerateConversion(Expression.New(dictionaryConstructor, expression), target);
+
+                    var lambda = Expression.Lambda(expression, "map deserializer", new[] { stream });
+                    var compiled = lambda.Compile();
+
+                    if (!cache.TryAdd((target, schema), compiled))
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    result.Delegate = compiled;
+                }
+                else
+                {
+                    result.Exceptions.Add(new UnsupportedTypeException(resolution.Type));
+                }
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
             }
 
-            if (!(schema is MapSchema mapSchema))
-            {
-                throw new UnsupportedSchemaException(schema, "A map deserializer can only be built for a map schema.");
-            }
-
-            var target = mapResolution.Type;
-            var key = mapResolution.KeyType;
-            var item = mapResolution.ValueType;
-
-            var codec = Expression.Constant(Codec);
-            var stream = Expression.Parameter(typeof(Stream));
-
-            Expression result = null;
-
-            try
-            {
-                var build = typeof(IBinaryDeserializerBuilder)
-                    .GetMethod(nameof(IBinaryDeserializerBuilder.BuildDelegate));
-
-                var buildKey = build.MakeGenericMethod(key);
-                var buildItem = build.MakeGenericMethod(item);
-
-                var readBlocks = typeof(IBinaryCodec)
-                    .GetMethods()
-                    .Single(m => m.Name == nameof(IBinaryCodec.ReadBlocks)
-                        && m.GetGenericArguments().Length == 2
-                    )
-                    .MakeGenericMethod(key, item);
-
-                result = Expression.Call(
-                    codec,
-                    readBlocks,
-                    stream,
-                    Expression.Constant(
-                        buildKey.Invoke(DeserializerBuilder, new object[] { new StringSchema(), cache }),
-                        typeof(Func<,>).MakeGenericType(typeof(Stream), key)
-                    ),
-                    Expression.Constant(
-                        buildItem.Invoke(DeserializerBuilder, new object[] { mapSchema.Value, cache }),
-                        typeof(Func<,>).MakeGenericType(typeof(Stream), item)
-                    )
-                );
-            }
-            catch (TargetInvocationException indirect)
-            {
-                ExceptionDispatchInfo.Capture(indirect.InnerException).Throw();
-            }
-
-            var idictionary = typeof(IDictionary<,>)
-                .MakeGenericType(key, item);
-
-            var dictionary = typeof(Dictionary<,>)
-                .MakeGenericType(key, item);
-
-            var dictionaryConstructor = dictionary
-                .GetConstructor(new[] { idictionary });
-
-            if (!target.IsAssignableFrom(dictionary))
-            {
-                throw new UnsupportedTypeException(target, $"A map deserializer cannot be built for type {target.FullName}.");
-            }
-
-            result = Expression.ConvertChecked(Expression.New(dictionaryConstructor, result), target);
-
-            var lambda = Expression.Lambda(result, "map deserializer", new[] { stream });
-            var compiled = lambda.Compile();
-
-            return cache.GetOrAdd((target, schema), compiled);
+            return result;
         }
     }
 
@@ -1428,27 +1511,36 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a null value.
+        /// A successful result if the schema is a <see cref="NullSchema" />; an unsuccessful
+        /// result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedSchemaException">
-        /// Thrown when the schema is not a <see cref="NullSchema" />.
-        /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(schema is NullSchema))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema is NullSchema)
             {
-                throw new UnsupportedSchemaException(schema, "A null deserializer can only be built for a null schema.");
+                var target = resolution.Type;
+
+                var stream = Expression.Parameter(typeof(Stream));
+
+                var expression = Expression.Default(target);
+                var lambda = Expression.Lambda(expression, "null deserializer", new[] { stream });
+                var compiled = lambda.Compile();
+
+                if (!cache.TryAdd((target, schema), compiled))
+                {
+                    throw new InvalidOperationException();
+                }
+
+                result.Delegate = compiled;
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
             }
 
-            var target = resolution.Type;
-
-            var result = Expression.Default(target);
-            var stream = Expression.Parameter(typeof(Stream));
-
-            var lambda = Expression.Lambda(result, "null deserializer", new[] { stream });
-            var compiled = lambda.Compile();
-
-            return cache.GetOrAdd((target, schema), compiled);
+            return result;
         }
     }
 
@@ -1458,7 +1550,6 @@ namespace Chr.Avro.Serialization
     /// </summary>
     public class RecordConstructorDeserializerBuilderCase : BinaryDeserializerBuilderCase
     {
-
         /// <summary>
         /// The deserializer builder to use to build field deserializers.
         /// </summary>
@@ -1472,7 +1563,7 @@ namespace Chr.Avro.Serialization
         /// </param>
         public RecordConstructorDeserializerBuilderCase(IBinaryDeserializerBuilder deserializerBuilder)
         {
-            DeserializerBuilder = deserializerBuilder;
+            DeserializerBuilder = deserializerBuilder ?? throw new ArgumentNullException(nameof(deserializerBuilder), "Binary deserializer builder cannot be null.");
         }
 
         /// <summary>
@@ -1488,121 +1579,129 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the resolution is a <see cref="RecordResolution" />, the
+        /// schema is a <see cref="RecordSchema" />, and the resolved type has a constructor with
+        /// a matching parameter for each field on the schema; an unsuccessful result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedSchemaException">
-        /// Thrown when the schema is not a <see cref="RecordSchema" />.
-        /// </exception>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the resolution is not a <see cref="RecordResolution" />.
-        /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(resolution is RecordResolution recordResolution))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema is RecordSchema recordSchema)
             {
-                throw new UnsupportedTypeException(resolution.Type, "A record constructor deserializer can only be built for a record resolution.");
-            }
-
-            if (!(schema is RecordSchema recordSchema))
-            {
-                throw new UnsupportedSchemaException(schema, "A record constructor deserializer can only be built for a record schema.");
-            }
-            
-            var schemaFields = recordSchema.Fields.ToList();
-
-            // attempt to find a constructor with arguments fully inclusive of all schema fields by name allowing for extra optional arguments
-            ConstructorResolution constructorResolution = recordResolution.Constructors.FirstOrDefault(constructor => IsMatch(constructor, schemaFields));
-
-            if (constructorResolution == null)
-            {
-                throw new UnsupportedTypeException(recordResolution.Type, "A record constructor deserializer can only be built for a type that has a constructor with all non-optional arguments matching the schema fields name and type.");
-            }
-
-            var target = resolution.Type;
-
-            var stream = Expression.Parameter(typeof(Stream));
-            var value = Expression.Parameter(target);
-
-            // declare a delegate to construct the object
-            Delegate construct = null;
-
-            // bind to this scope:
-            Expression result = Expression.Invoke(Expression.Constant((Func<Delegate>)(() => construct)));
-
-            result = Expression.ConvertChecked(result, typeof(Func<,>).MakeGenericType(typeof(Stream), target));
-
-            result = Expression.Block(
-                new[] { value },
-                Expression.Assign(value, Expression.Invoke(result, stream)),
-                value
-            );
-
-            var lambda = Expression.Lambda(result, $"{recordSchema.Name} deserializer", new[] { stream });
-            var compiled = cache.GetOrAdd((target, schema), lambda.Compile());
-
-            var constructorArguments = new List<(ParameterResolution, ParameterExpression)>();
-            // now that an infinite loop won't happen, build the expressions to extract the parameters from the serialized data            
-            var extractParameters = recordSchema.Fields.Select(field =>
-            {
-                // there will be a match or we wouldn't have made it this far.
-                var match = constructorResolution.Parameters.Single(f => f.Name.IsMatch(field.Name));
-
-                Expression action = null;
-                try
+                if (resolution is RecordResolution recordResolution)
                 {
-                    var build = typeof(IBinaryDeserializerBuilder)
-                        .GetMethod(nameof(IBinaryDeserializerBuilder.BuildDelegate))
-                        .MakeGenericMethod(match.Type);
+                    var schemaFields = recordSchema.Fields.ToList();
 
-                    action = Expression.Constant(
-                        build.Invoke(DeserializerBuilder, new object[] { field.Type, cache }),
-                        typeof(Func<,>).MakeGenericType(typeof(Stream), match.Type)
-                    );
-                }
-                catch (TargetInvocationException indirect)
-                {
-                    ExceptionDispatchInfo.Capture(indirect.InnerException).Throw();
-                }
+                    if (recordResolution.Constructors.FirstOrDefault(constructor => IsMatch(constructor, schemaFields)) is ConstructorResolution constructorResolution)
+                    {
+                        var target = resolution.Type;
 
-                // invoke the deserialization
-                action = Expression.Invoke(action, stream);
-                // create a variable to hold the deserialized data
-                var variable = Expression.Parameter(match.Type);
-                // assign the deserialized data to the variable
-                action = Expression.Assign(variable, action);
-                // create a separate list so they can be passed to the constructor in the correct order
-                constructorArguments.Add((match, variable));
+                        var stream = Expression.Parameter(typeof(Stream));
+                        var value = Expression.Parameter(target);
 
-                return action;
-            }).ToList();
+                        // declare a delegate to construct the object
+                        Delegate construct = null!;
 
-            // reorder the parameters to match the order in the constructor and add any default parameters
-            var parameters = constructorResolution.Parameters.ToArray();
-            Expression[] arguments = new Expression[parameters.Length];
-            for (int i = 0; i < parameters.Length; i++)
-            {
-                var match = constructorArguments.FirstOrDefault(argument => argument.Item1.Name.IsMatch(parameters[i].Name));
-                if (match != default)
-                {
-                    arguments[i] = (match.Item2);
+                        // bind to this scope:
+                        Expression expression = Expression.Invoke(Expression.Constant((Func<Delegate>)(() => construct)));
+
+                        expression = GenerateConversion(expression, typeof(Func<,>).MakeGenericType(typeof(Stream), target));
+
+                        expression = Expression.Block(
+                            new[] { value },
+                            Expression.Assign(value, Expression.Invoke(expression, stream)),
+                            value
+                        );
+
+                        var lambda = Expression.Lambda(expression, $"{recordSchema.Name} deserializer", new[] { stream });
+                        var compiled = lambda.Compile();
+
+                        if (!cache.TryAdd((target, schema), compiled))
+                        {
+                            throw new InvalidOperationException();
+                        }
+
+                        result.Delegate = compiled;
+
+                        // now that an infinite loop won't happen, build the expressions to extract the parameters from the serialized data
+                        var constructorArguments = new List<(ParameterResolution, ParameterExpression)>();
+                        var extractParameters = recordSchema.Fields.Select(field =>
+                        {
+                            // there will be a match or we wouldn't have made it this far.
+                            var match = constructorResolution.Parameters.Single(f => f.Name.IsMatch(field.Name));
+
+                            Expression action = null!;
+                            try
+                            {
+                                var build = typeof(IBinaryDeserializerBuilder)
+                                    .GetMethod(nameof(IBinaryDeserializerBuilder.BuildDelegate))
+                                    .MakeGenericMethod(match.Type);
+
+                                action = Expression.Constant(
+                                    build.Invoke(DeserializerBuilder, new object[] { field.Type, cache }),
+                                    typeof(Func<,>).MakeGenericType(typeof(Stream), match.Type)
+                                );
+                            }
+                            catch (TargetInvocationException indirect)
+                            {
+                                ExceptionDispatchInfo.Capture(indirect.InnerException).Throw();
+                            }
+
+                            // invoke the deserialization
+                            action = Expression.Invoke(action, stream);
+                            // create a variable to hold the deserialized data
+                            var variable = Expression.Parameter(match.Type);
+                            // assign the deserialized data to the variable
+                            action = Expression.Assign(variable, action);
+                            // create a separate list so they can be passed to the constructor in the correct order
+                            constructorArguments.Add((match, variable));
+
+                            return action;
+                        }).ToList();
+
+                        // reorder the parameters to match the order in the constructor and add any default parameters
+                        var parameters = constructorResolution.Parameters.ToArray();
+                        Expression[] arguments = new Expression[parameters.Length];
+                        for (int i = 0; i < parameters.Length; i++)
+                        {
+                            var match = constructorArguments.FirstOrDefault(argument => argument.Item1.Name.IsMatch(parameters[i].Name));
+                            if (match != default)
+                            {
+                                arguments[i] = (match.Item2);
+                            }
+                            else
+                            {
+                                arguments[i] = Expression.Constant(parameters[i].Parameter.DefaultValue, parameters[i].Type);
+                            }
+                        }
+
+                        // add constructing the object to the list of expressions
+                        extractParameters.Add(Expression.New(constructorResolution.Constructor, arguments));
+
+                        expression = Expression.Block(constructorArguments.Select(arg => arg.Item2).ToArray(), extractParameters);
+
+                        lambda = Expression.Lambda(expression, $"{recordSchema.Name} constructor", new[] { stream });
+                        construct = lambda.Compile();
+                    }
+                    else
+                    {
+                        result.Exceptions.Add(new UnsupportedTypeException(resolution.Type));
+                    }
                 }
                 else
                 {
-                    arguments[i] = Expression.Constant(parameters[i].Parameter.DefaultValue, parameters[i].Type);
+                    result.Exceptions.Add(new UnsupportedTypeException(resolution.Type));
                 }
             }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
+            }
 
-            // add constructing the object to the list of expressions
-            extractParameters.Add(Expression.New(constructorResolution.Constructor, arguments));
-
-            result = Expression.Block(constructorArguments.Select(arg => arg.Item2).ToArray(), extractParameters);
-
-            lambda = Expression.Lambda(result, $"{recordSchema.Name} constructor", new[] { stream });
-            construct = lambda.Compile();
-
-            return compiled;
+            return result;
         }
-               
+
         /// <summary>
         /// Whether the resolved constructor matches a record schema's fields.
         /// </summary>
@@ -1610,9 +1709,8 @@ namespace Chr.Avro.Serialization
         /// The constructor resolution to check for a match.
         /// </param>
         /// <param name="recordFields">
-        /// The record schema fields to match against the constructor parameters. 
+        /// The record schema fields to match against the constructor parameters.
         /// </param>
-        /// <returns></returns>
         protected bool IsMatch(ConstructorResolution constructor, ICollection<RecordField> recordFields)
         {
             if (constructor.Parameters.Count < recordFields.Count)
@@ -1661,7 +1759,7 @@ namespace Chr.Avro.Serialization
         /// </param>
         public RecordDeserializerBuilderCase(IBinaryDeserializerBuilder deserializerBuilder)
         {
-            DeserializerBuilder = deserializerBuilder;
+            DeserializerBuilder = deserializerBuilder ?? throw new ArgumentNullException(nameof(deserializerBuilder), "Binary deserializer builder cannot be null.");
         }
 
         /// <summary>
@@ -1677,93 +1775,101 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the resolution is a <see cref="RecordResolution" /> and the
+        /// schema is a <see cref="RecordSchema" />; an unsuccessful result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedSchemaException">
-        /// Thrown when the schema is not a <see cref="RecordSchema" />.
-        /// </exception>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the resolution is not a <see cref="RecordResolution" />.
-        /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(resolution is RecordResolution recordResolution))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema is RecordSchema recordSchema)
             {
-                throw new UnsupportedTypeException(resolution.Type, "A record deserializer can only be built for a record resolution.");
-            }
-
-            if (!(schema is RecordSchema recordSchema))
-            {
-                throw new UnsupportedSchemaException(schema, "A record deserializer can only be built for a record schema.");
-            }
-
-            var target = resolution.Type;
-
-            var stream = Expression.Parameter(typeof(Stream));
-            var value = Expression.Parameter(target);
-
-            // declare an action that reads/assigns the record fields in order:
-            Delegate assign = null;
-
-            // bind to this scope:
-            Expression result = Expression.Invoke(Expression.Constant((Func<Delegate>)(() => assign)));
-
-            // coerce Delegate to Action<Stream, TTarget>:
-            result = Expression.ConvertChecked(result, typeof(Action<,>).MakeGenericType(typeof(Stream), target));
-
-            // deserialize the record:
-            result = Expression.Block(
-                new[] { value },
-                Expression.Assign(value, Expression.New(target)), // create the thing
-                Expression.Invoke(result, stream, value),         // assign its fields
-                value                                             // return the thing
-            );
-
-            var lambda = Expression.Lambda(result, $"{recordSchema.Name} deserializer", new[] { stream });
-            var compiled = cache.GetOrAdd((target, schema), lambda.Compile());
-
-            // now that an infinite cycle won’t happen, build the assign function:
-            var assignments = recordSchema.Fields.Select(field =>
-            {
-                var match = recordResolution.Fields.SingleOrDefault(f => f.Name.IsMatch(field.Name));
-                var type = match?.Type ?? CreateSurrogateType(field.Type);
-
-                Expression action = null;
-
-                try
+                if (resolution is RecordResolution recordResolution)
                 {
-                    var build = typeof(IBinaryDeserializerBuilder)
-                        .GetMethod(nameof(IBinaryDeserializerBuilder.BuildDelegate))
-                        .MakeGenericMethod(type);
+                    var target = resolution.Type;
 
-                    // https://i.imgur.com/PBLYIc2.gifv
-                    action = Expression.Constant(
-                        build.Invoke(DeserializerBuilder, new object[] { field.Type, cache }),
-                        typeof(Func<,>).MakeGenericType(typeof(Stream), type)
+                    var stream = Expression.Parameter(typeof(Stream));
+                    var value = Expression.Parameter(target);
+
+                    // declare an action that reads/assigns the record fields in order:
+                    Delegate assign = null!;
+
+                    // bind to this scope:
+                    Expression expression = Expression.Invoke(Expression.Constant((Func<Delegate>)(() => assign)));
+
+                    // coerce Delegate to Action<Stream, TTarget>:
+                    expression = GenerateConversion(expression, typeof(Action<,>).MakeGenericType(typeof(Stream), target));
+
+                    // deserialize the record:
+                    expression = Expression.Block(
+                        new[] { value },
+                        Expression.Assign(value, Expression.New(target)), // create the thing
+                        Expression.Invoke(expression, stream, value),     // assign its fields
+                        value                                             // return the thing
                     );
+
+                    var lambda = Expression.Lambda(expression, $"{recordSchema.Name} deserializer", new[] { stream });
+                    var compiled = lambda.Compile();
+
+                    if (!cache.TryAdd((target, schema), compiled))
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    result.Delegate = compiled;
+
+                    // now that an infinite cycle won’t happen, build the assign function:
+                    var assignments = recordSchema.Fields.Select(field =>
+                    {
+                        var match = recordResolution.Fields.SingleOrDefault(f => f.Name.IsMatch(field.Name));
+                        var type = match?.Type ?? CreateSurrogateType(field.Type);
+
+                        Expression action = null!;
+
+                        try
+                        {
+                            var build = typeof(IBinaryDeserializerBuilder)
+                                .GetMethod(nameof(IBinaryDeserializerBuilder.BuildDelegate))
+                                .MakeGenericMethod(type);
+
+                            // https://i.imgur.com/PBLYIc2.gifv
+                            action = Expression.Constant(
+                                build.Invoke(DeserializerBuilder, new object[] { field.Type, cache }),
+                                typeof(Func<,>).MakeGenericType(typeof(Stream), type)
+                            );
+                        }
+                        catch (TargetInvocationException indirect)
+                        {
+                            ExceptionDispatchInfo.Capture(indirect.InnerException).Throw();
+                        }
+
+                        // always read to advance the stream:
+                        action = Expression.Invoke(action, stream);
+
+                        if (match != null)
+                        {
+                            // and assign if a field matches:
+                            action = Expression.Assign(Expression.PropertyOrField(value, match.Member.Name), action);
+                        }
+
+                        return action;
+                    }).ToList();
+
+                    expression = assignments.Count > 0 ? Expression.Block(typeof(void), assignments) : Expression.Empty() as Expression;
+                    lambda = Expression.Lambda(expression, $"{recordSchema.Name} field assigner", new[] { stream, value });
+                    assign = lambda.Compile();
                 }
-                catch (TargetInvocationException indirect)
+                else
                 {
-                    ExceptionDispatchInfo.Capture(indirect.InnerException).Throw();
+                    result.Exceptions.Add(new UnsupportedTypeException(resolution.Type, "A record deserializer can only be built for a record resolution."));
                 }
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
+            }
 
-                // always read to advance the stream:
-                action = Expression.Invoke(action, stream);
-
-                if (match != null)
-                {
-                    // and assign if a field matches:
-                    action = Expression.Assign(Expression.PropertyOrField(value, match.Member.Name), action);
-                }
-
-                return action;
-            }).ToList();
-
-            result = assignments.Count > 0 ? Expression.Block(typeof(void), assignments) : Expression.Empty() as Expression;
-            lambda = Expression.Lambda(result, $"{recordSchema.Name} field assigner", new[] { stream, value });
-            assign = lambda.Compile();
-
-            return compiled;
+            return result;
         }
 
         /// <summary>
@@ -1849,124 +1955,129 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the schema is a <see cref="StringSchema" />; an unsuccessful
+        /// result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedSchemaException">
-        /// Thrown when the schema is not a <see cref="StringSchema" />.
-        /// </exception>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when no known conversions (<see cref="DateTime" />/<see cref="DateTimeOffset" />,
-        /// <see cref="Guid" />, <see cref="TimeSpan"/>, <see cref="Uri" />) can be applied and no
-        /// conversion from <see cref="string" /> exists.
+        /// Thrown when <see cref="string" /> cannot be converted to the resolved type.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(schema is StringSchema))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema is StringSchema)
             {
-                throw new UnsupportedSchemaException(schema, "A string deserializer can only be built for a string schema.");
+                var target = resolution.Type;
+
+                var codec = Expression.Constant(Codec);
+                var stream = Expression.Parameter(typeof(Stream));
+
+                var readLength = typeof(IBinaryCodec)
+                    .GetMethod(nameof(IBinaryCodec.ReadInteger));
+
+                Expression expression = Expression.ConvertChecked(Expression.Call(codec, readLength, stream), typeof(int));
+
+                var readValue = typeof(IBinaryCodec)
+                    .GetMethod(nameof(IBinaryCodec.Read));
+
+                expression = Expression.Call(codec, readValue, stream, expression);
+
+                var decodeValue = typeof(Encoding)
+                    .GetMethod(nameof(Encoding.GetString), new[] { typeof(byte[]) });
+
+                expression = GenerateConversion(Expression.Call(Expression.Constant(Encoding.UTF8), decodeValue, expression), target);
+
+                var lambda = Expression.Lambda(expression, "string deserializer", new[] { stream });
+                var compiled = lambda.Compile();
+
+                if (!cache.TryAdd((target, schema), compiled))
+                {
+                    throw new InvalidOperationException();
+                }
+
+                result.Delegate = compiled;
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
             }
 
-            var source = typeof(string);
-            var target = resolution.Type;
+            return result;
+        }
 
-            var codec = Expression.Constant(Codec);
-            var stream = Expression.Parameter(typeof(Stream));
-
-            var readLength = typeof(IBinaryCodec)
-                .GetMethod(nameof(IBinaryCodec.ReadInteger));
-
-            Expression result = Expression.ConvertChecked(Expression.Call(codec, readLength, stream), typeof(int));
-
-            var readValue = typeof(IBinaryCodec)
-                .GetMethod(nameof(IBinaryCodec.Read));
-
-            result = Expression.Call(codec, readValue, stream, result);
-
-            var decodeValue = typeof(Encoding)
-                .GetMethod(nameof(Encoding.GetString), new[] { typeof(byte[]) });
-
-            result = Expression.Call(Expression.Constant(Encoding.UTF8), decodeValue, result);
-
-            if (source != target)
+        /// <summary>
+        /// Generates a conversion from the source type to the intermediate type. This override
+        /// will convert a string value to <see cref="DateTime" />, <see cref="DateTimeOffset" />,
+        /// <see cref="Guid" />, <see cref="TimeSpan" />, or <see cref="Uri" /> prior to applying
+        /// the base implementation.
+        /// </summary>
+        protected override Expression GenerateConversion(Expression input, Type target)
+        {
+            if (target == typeof(DateTime) || target == typeof(DateTime?))
             {
-                if (target == typeof(DateTime) || target == typeof(DateTime?))
-                {
-                    var parseDateTime = typeof(DateTime)
-                        .GetMethod(nameof(DateTime.Parse), new[]
-                        {
-                            typeof(string),
-                            typeof(IFormatProvider),
-                            typeof(DateTimeStyles)
-                        });
+                var parseDateTime = typeof(DateTime)
+                    .GetMethod(nameof(DateTime.Parse), new[]
+                    {
+                        input.Type,
+                        typeof(IFormatProvider),
+                        typeof(DateTimeStyles)
+                    });
 
-                    result = Expression.ConvertChecked(
-                        Expression.Call(
-                            null,
-                            parseDateTime,
-                            result,
-                            Expression.Constant(CultureInfo.InvariantCulture),
-                            Expression.Constant(DateTimeStyles.RoundtripKind)
-                        ),
-                        target
-                    );
-                }
-                else if (target == typeof(DateTimeOffset) || target == typeof(DateTimeOffset?))
-                {
-                    var parseDateTimeOffset = typeof(DateTimeOffset)
-                        .GetMethod(nameof(DateTimeOffset.Parse), new[]
-                        {
-                            typeof(string),
-                            typeof(IFormatProvider),
-                            typeof(DateTimeStyles)
-                        });
+                input = Expression.ConvertChecked(
+                    Expression.Call(
+                        null,
+                        parseDateTime,
+                        input,
+                        Expression.Constant(CultureInfo.InvariantCulture),
+                        Expression.Constant(DateTimeStyles.RoundtripKind)
+                    ),
+                    target
+                );
+            }
+            else if (target == typeof(DateTimeOffset) || target == typeof(DateTimeOffset?))
+            {
+                var parseDateTimeOffset = typeof(DateTimeOffset)
+                    .GetMethod(nameof(DateTimeOffset.Parse), new[]
+                    {
+                        input.Type,
+                        typeof(IFormatProvider),
+                        typeof(DateTimeStyles)
+                    });
 
-                    result = Expression.ConvertChecked(
-                        Expression.Call(
-                            null,
-                            parseDateTimeOffset,
-                            result,
-                            Expression.Constant(CultureInfo.InvariantCulture),
-                            Expression.Constant(DateTimeStyles.RoundtripKind)
-                        ),
-                        target
-                    );
-                }
-                else if (target == typeof(Guid) || target == typeof(Guid?))
-                {
-                    var guidConstructor = typeof(Guid)
-                        .GetConstructor(new[] { typeof(string) });
+                input = Expression.ConvertChecked(
+                    Expression.Call(
+                        null,
+                        parseDateTimeOffset,
+                        input,
+                        Expression.Constant(CultureInfo.InvariantCulture),
+                        Expression.Constant(DateTimeStyles.RoundtripKind)
+                    ),
+                    target
+                );
+            }
+            else if (target == typeof(Guid) || target == typeof(Guid?))
+            {
+                var guidConstructor = typeof(Guid)
+                    .GetConstructor(new[] { input.Type });
 
-                    result = Expression.New(guidConstructor, result);
-                }
-                else if (target == typeof(TimeSpan) || target == typeof(TimeSpan?))
-                {
-                    var parseTimeSpan = typeof(XmlConvert)
-                        .GetMethod(nameof(XmlConvert.ToTimeSpan));
+                input = Expression.New(guidConstructor, input);
+            }
+            else if (target == typeof(TimeSpan) || target == typeof(TimeSpan?))
+            {
+                var parseTimeSpan = typeof(XmlConvert)
+                    .GetMethod(nameof(XmlConvert.ToTimeSpan));
 
-                    result = Expression.Call(null, parseTimeSpan, result);
-                }
-                else if (target == typeof(Uri))
-                {
-                    var uriConstructor = typeof(Uri)
-                        .GetConstructor(new[] { typeof(string) });
+                input = Expression.Call(null, parseTimeSpan, input);
+            }
+            else if (target == typeof(Uri))
+            {
+                var uriConstructor = typeof(Uri)
+                    .GetConstructor(new[] { input.Type });
 
-                    result = Expression.New(uriConstructor, result);
-                }
-
-                try
-                {
-                    result = Expression.ConvertChecked(result, target);
-                }
-                catch (InvalidOperationException inner)
-                {
-                    throw new UnsupportedTypeException(target, $"A string deserializer cannot be built for type {target.FullName}.", inner);
-                }
+                input = Expression.New(uriConstructor, input);
             }
 
-            var lambda = Expression.Lambda(result, "string deserializer", new[] { stream });
-            var compiled = lambda.Compile();
-
-            return cache.GetOrAdd((target, schema), compiled);
+            return base.GenerateConversion(input, target);
         }
     }
 
@@ -2006,66 +2117,86 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the resolution is a <see cref="TimestampResolution" /> and the
+        /// schema’s logical type is a <see cref="TimestampLogicalType" />; an unsuccessful result
+        /// otherwise.
         /// </returns>
         /// <exception cref="UnsupportedSchemaException">
         /// Thrown when the schema is not a <see cref="LongSchema" /> with logical type
         /// <see cref="MicrosecondTimestampLogicalType" /> or <see cref="MillisecondTimestampLogicalType" />.
         /// </exception>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="DateTime" /> or <see cref="DateTimeOffset" />.
+        /// Thrown when <see cref="DateTime" /> cannot be converted to the resolved type.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(schema is LongSchema))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema.LogicalType is TimestampLogicalType)
             {
-                throw new UnsupportedSchemaException(schema, "A timestamp deserializer can only be built for a long schema.");
-            }
+                if (resolution is TimestampResolution)
+                {
+                    if (!(schema is LongSchema))
+                    {
+                        throw new UnsupportedSchemaException(schema);
+                    }
 
-            var target = resolution.Type;
+                    var target = resolution.Type;
 
-            if (!(target == typeof(DateTime) || target == typeof(DateTime?) || target == typeof(DateTimeOffset) || target == typeof(DateTimeOffset?)))
-            {
-                throw new UnsupportedTypeException(target, $"A timestamp serializer cannot be built for {target.Name}.");
-            }
+                    var codec = Expression.Constant(Codec);
+                    var stream = Expression.Parameter(typeof(Stream));
 
-            var codec = Expression.Constant(Codec);
-            var stream = Expression.Parameter(typeof(Stream));
+                    Expression epoch = Expression.Constant(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+                    Expression factor;
 
-            Expression epoch = Expression.Constant(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc));
-            Expression factor;
+                    if (schema.LogicalType is MicrosecondTimestampLogicalType)
+                    {
+                        factor = Expression.Constant(TimeSpan.TicksPerMillisecond / 1000);
+                    }
+                    else if (schema.LogicalType is MillisecondTimestampLogicalType)
+                    {
+                        factor = Expression.Constant(TimeSpan.TicksPerMillisecond);
+                    }
+                    else
+                    {
+                        throw new UnsupportedSchemaException(schema);
+                    }
 
-            if (schema.LogicalType is MicrosecondTimestampLogicalType)
-            {
-                factor = Expression.Constant(TimeSpan.TicksPerMillisecond / 1000);
-            }
-            else if (schema.LogicalType is MillisecondTimestampLogicalType)
-            {
-                factor = Expression.Constant(TimeSpan.TicksPerMillisecond);
+                    var readValue = typeof(IBinaryCodec)
+                        .GetMethod(nameof(IBinaryCodec.ReadInteger));
+
+                    Expression expression = Expression.Call(codec, readValue, stream);
+
+                    var addTicks = typeof(DateTime)
+                        .GetMethod(nameof(DateTime.AddTicks));
+
+                    // result = epoch.AddTicks(value * factor);
+                    expression = GenerateConversion(
+                        Expression.Call(epoch, addTicks, Expression.Multiply(expression, factor)),
+                        target
+                    );
+
+                    var lambda = Expression.Lambda(expression, "timestamp deserializer", new[] { stream });
+                    var compiled = lambda.Compile();
+
+                    if (!cache.TryAdd((target, schema), compiled))
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    result.Delegate = compiled;
+                }
+                else
+                {
+                    result.Exceptions.Add(new UnsupportedTypeException(resolution.Type));
+                }
             }
             else
             {
-                throw new UnsupportedSchemaException(schema, "A timestamp deserializer can only be built for a schema with a timestamp logical type.");
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
             }
 
-            var readValue = typeof(IBinaryCodec)
-                .GetMethod(nameof(IBinaryCodec.ReadInteger));
-
-            Expression result = Expression.Call(codec, readValue, stream);
-
-            var addTicks = typeof(DateTime)
-                .GetMethod(nameof(DateTime.AddTicks));
-
-            // result = epoch.AddTicks(value * factor);
-            result = Expression.ConvertChecked(
-                Expression.Call(epoch, addTicks, Expression.Multiply(result, factor)),
-                target
-            );
-
-            var lambda = Expression.Lambda(result, "timestamp deserializer", new[] { stream });
-            var compiled = lambda.Compile();
-
-            return cache.GetOrAdd((target, schema), compiled);
+            return result;
         }
     }
 
@@ -2096,8 +2227,8 @@ namespace Chr.Avro.Serialization
         /// </param>
         public UnionDeserializerBuilderCase(IBinaryCodec codec, IBinaryDeserializerBuilder deserializerBuilder)
         {
-            Codec = codec;
-            DeserializerBuilder = deserializerBuilder;
+            Codec = codec ?? throw new ArgumentNullException(nameof(codec), "Binary codec cannot be null.");
+            DeserializerBuilder = deserializerBuilder ?? throw new ArgumentNullException(nameof(deserializerBuilder), "Binary deserializer builder cannot be null.");
         }
 
         /// <summary>
@@ -2113,80 +2244,97 @@ namespace Chr.Avro.Serialization
         /// A delegate cache.
         /// </param>
         /// <returns>
-        /// A function that accepts a <see cref="Stream" /> and returns a deserialized object.
+        /// A successful result if the schema is a <see cref="UnionSchema" />; an unsuccessful
+        /// result otherwise.
         /// </returns>
         /// <exception cref="UnsupportedSchemaException">
-        /// Thrown when the schema is not a <see cref="UnionSchema" />.
+        /// Thrown when the union schema is empty.
         /// </exception>
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when the type cannot be mapped to each schema in the union.
         /// </exception>
-        public override Delegate BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
+        public override IBinaryDeserializerBuildResult BuildDelegate(TypeResolution resolution, Schema schema, ConcurrentDictionary<(Type, Schema), Delegate> cache)
         {
-            if (!(schema is UnionSchema unionSchema && unionSchema.Schemas.Count > 0))
+            var result = new BinaryDeserializerBuildResult();
+
+            if (schema is UnionSchema unionSchema)
             {
-                throw new UnsupportedSchemaException(schema, "A union deserializer can only be built for a union schema of one or more schemas.");
+                if (unionSchema.Schemas.Count < 1)
+                {
+                    throw new UnsupportedSchemaException(schema);
+                }
+
+                var target = resolution.Type;
+
+                var codec = Expression.Constant(Codec);
+                var stream = Expression.Parameter(typeof(Stream));
+
+                var readIndex = typeof(IBinaryCodec)
+                    .GetMethod(nameof(IBinaryCodec.ReadInteger));
+
+                Expression expression = Expression.ConvertChecked(Expression.Call(codec, readIndex, stream), typeof(int));
+
+                // create a mapping for each schema in the union:
+                var cases = unionSchema.Schemas.Select((child, index) =>
+                {
+                    var selected = SelectType(resolution, child);
+                    var underlying = Nullable.GetUnderlyingType(selected.Type);
+
+                    if (child is NullSchema && selected.Type.IsValueType && underlying == null)
+                    {
+                        throw new UnsupportedTypeException(target, $"A deserializer for a union containing {typeof(NullSchema)} cannot be built for {selected.Type.FullName}.");
+                    }
+
+                    underlying = selected.Type;
+
+                    Expression @case = null!;
+
+                    try
+                    {
+                        var build = typeof(IBinaryDeserializerBuilder)
+                            .GetMethod(nameof(IBinaryDeserializerBuilder.BuildDelegate))
+                            .MakeGenericMethod(underlying);
+
+                        @case = Expression.Constant(
+                            build.Invoke(DeserializerBuilder, new object[] { child, cache }),
+                            typeof(Func<,>).MakeGenericType(typeof(Stream), underlying)
+                        );
+                    }
+                    catch (TargetInvocationException indirect)
+                    {
+                        ExceptionDispatchInfo.Capture(indirect.InnerException).Throw();
+                    }
+
+                    return Expression.SwitchCase(
+                        GenerateConversion(Expression.Invoke(@case, stream), target),
+                        Expression.Constant(index)
+                    );
+                });
+
+                var exceptionConstructor = typeof(OverflowException)
+                    .GetConstructor(new[] { typeof(string) });
+
+                var exception = Expression.New(exceptionConstructor, Expression.Constant("Union index out of range."));
+
+                // generate a switch on the index:
+                expression = Expression.Switch(expression, Expression.Throw(exception, target), cases.ToArray());
+
+                var lambda = Expression.Lambda(expression, "union deserializer", new[] { stream });
+                var compiled = lambda.Compile();
+
+                if (!cache.TryAdd((target, schema), compiled))
+                {
+                    throw new InvalidOperationException();
+                }
+
+                result.Delegate = compiled;
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedSchemaException(schema));
             }
 
-            var target = resolution.Type;
-
-            var codec = Expression.Constant(Codec);
-            var stream = Expression.Parameter(typeof(Stream));
-
-            var readIndex = typeof(IBinaryCodec)
-                .GetMethod(nameof(IBinaryCodec.ReadInteger));
-
-            Expression result = Expression.ConvertChecked(Expression.Call(codec, readIndex, stream), typeof(int));
-
-            // create a mapping for each schema in the union:
-            var cases = unionSchema.Schemas.Select((child, index) =>
-            {
-                var selected = SelectType(resolution, child);
-                var underlying = Nullable.GetUnderlyingType(selected.Type);
-
-                if (child is NullSchema && selected.Type.IsValueType && underlying == null)
-                {
-                    throw new UnsupportedTypeException(target, $"A deserializer for a union containing {typeof(NullSchema)} cannot be built for {selected.Type.FullName}.");
-                }
-
-                underlying = selected.Type;
-
-                Expression @case = null;
-
-                try
-                {
-                    var build = typeof(IBinaryDeserializerBuilder)
-                        .GetMethod(nameof(IBinaryDeserializerBuilder.BuildDelegate))
-                        .MakeGenericMethod(underlying);
-
-                    @case = Expression.Constant(
-                        build.Invoke(DeserializerBuilder, new object[] { child, cache }),
-                        typeof(Func<,>).MakeGenericType(typeof(Stream), underlying)
-                    );
-                }
-                catch (TargetInvocationException indirect)
-                {
-                    ExceptionDispatchInfo.Capture(indirect.InnerException).Throw();
-                }
-
-                return Expression.SwitchCase(
-                    Expression.ConvertChecked(Expression.Invoke(@case, stream), target),
-                    Expression.Constant(index)
-                );
-            });
-
-            var exceptionConstructor = typeof(OverflowException)
-                .GetConstructor(new[] { typeof(string) });
-
-            var exception = Expression.New(exceptionConstructor, Expression.Constant("Union index out of range."));
-
-            // generate a switch on the index:
-            result = Expression.Switch(result, Expression.Throw(exception, target), cases.ToArray());
-
-            var lambda = Expression.Lambda(result, "union deserializer", new[] { stream });
-            var compiled = lambda.Compile();
-
-            return cache.GetOrAdd((target, schema), compiled);
+            return result;
         }
 
         /// <summary>

--- a/src/Chr.Avro.Binary/Chr.Avro.Binary.csproj
+++ b/src/Chr.Avro.Binary/Chr.Avro.Binary.csproj
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <Description>Avro binary serialization and deserialization</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Chr.Avro.Cli/Verb.cs
+++ b/src/Chr.Avro.Cli/Verb.cs
@@ -6,7 +6,6 @@ using Chr.Avro.Representation;
 using Chr.Avro.Resolution;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Chr.Avro.Serialization;
 
@@ -91,7 +90,7 @@ namespace Chr.Avro.Cli
             {
                 return builder.BuildSchema(type);
             }
-            catch (AggregateException inner) when (inner.InnerExceptions.All(e => e is UnsupportedTypeException))
+            catch (UnsupportedTypeException inner)
             {
                 throw new ProgramException(message: $"Failed to create a schema for {type}: The type is not supported by the resolver.", inner: inner);
             }

--- a/src/Chr.Avro.Codegen/Chr.Avro.Codegen.csproj
+++ b/src/Chr.Avro.Codegen/Chr.Avro.Codegen.csproj
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <Description>Experimental utilities to generate code from Avro schemas</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 

--- a/src/Chr.Avro.Codegen/CodeGenerator.cs
+++ b/src/Chr.Avro.Codegen/CodeGenerator.cs
@@ -80,7 +80,7 @@ namespace Chr.Avro.Codegen
 
                         if (!string.IsNullOrEmpty(field.Documentation))
                         {
-                            child = AddSummaryComment(child, field.Documentation);
+                            child = AddSummaryComment(child, field.Documentation!);
                         }
 
                         return child;
@@ -91,7 +91,7 @@ namespace Chr.Avro.Codegen
 
             if (!string.IsNullOrEmpty(schema.Documentation))
             {
-                declaration = AddSummaryComment(declaration, schema.Documentation);
+                declaration = AddSummaryComment(declaration, schema.Documentation!);
             }
 
             return declaration;
@@ -117,7 +117,7 @@ namespace Chr.Avro.Codegen
 
             if (!string.IsNullOrEmpty(schema.Documentation))
             {
-                declaration = AddSummaryComment(declaration, schema.Documentation);
+                declaration = AddSummaryComment(declaration, schema.Documentation!);
             }
 
             return declaration;
@@ -169,7 +169,7 @@ namespace Chr.Avro.Codegen
                                 return null;
                         }
                     })
-                    .Where(candidate => candidate != null)
+                    .OfType<MemberDeclarationSyntax>()
                     .ToArray();
 
                 if (!string.IsNullOrEmpty(group.Key))
@@ -314,7 +314,7 @@ namespace Chr.Avro.Codegen
                     break;
 
                 case NullSchema n:
-                    return null;
+                    break;
 
                 case RecordSchema r:
                     type = SyntaxFactory.ParseTypeName($"global::{r.FullName}");
@@ -367,7 +367,7 @@ namespace Chr.Avro.Codegen
             return node.WithLeadingTrivia(trivia);
         }
 
-        private static IEnumerable<NamedSchema> GetCandidateSchemas(Schema schema, ISet<Schema> seen = null)
+        private static IEnumerable<NamedSchema> GetCandidateSchemas(Schema schema, ISet<Schema>? seen = null)
         {
             seen = seen ?? new HashSet<Schema>();
 

--- a/src/Chr.Avro.Codegen/NamespaceRewriter.cs
+++ b/src/Chr.Avro.Codegen/NamespaceRewriter.cs
@@ -11,9 +11,9 @@ namespace Chr.Avro.Codegen
     {
         private readonly Stack<string> _breadcrumb;
 
-        private ISet<string> externals;
+        private ISet<string>? externals;
 
-        private ISet<string> internals;
+        private ISet<string>? internals;
 
         private NamespaceRewriter()
         {
@@ -35,10 +35,9 @@ namespace Chr.Avro.Codegen
                 .Select(n => StripGlobalAlias(n.Left).ToString())
                 .Where(n => !internals.Contains(n)));
 
-            var result = base.VisitCompilationUnit(node) as CompilationUnitSyntax;
-
-            result = result.WithUsings(new SyntaxList<UsingDirectiveSyntax>(externals
-                .Select(n => SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(n)))));
+            var result = (base.VisitCompilationUnit(node) as CompilationUnitSyntax)!
+                .WithUsings(new SyntaxList<UsingDirectiveSyntax>(externals
+                    .Select(n => SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(n)))));
 
             externals = null;
             internals = null;
@@ -49,7 +48,7 @@ namespace Chr.Avro.Codegen
         public override SyntaxNode VisitNamespaceDeclaration(NamespaceDeclarationSyntax node)
         {
             _breadcrumb.Push(node.Name.ToString());
-            var result = base.VisitNamespaceDeclaration(node);
+            var result = base.VisitNamespaceDeclaration(node)!;
             _breadcrumb.Pop();
 
             return result;
@@ -57,7 +56,7 @@ namespace Chr.Avro.Codegen
 
         public override SyntaxNode VisitPropertyDeclaration(PropertyDeclarationSyntax node)
         {
-            var result = base.VisitPropertyDeclaration(node) as PropertyDeclarationSyntax;
+            var result = (base.VisitPropertyDeclaration(node) as PropertyDeclarationSyntax)!;
 
             if (result.Type is NameSyntax name)
             {
@@ -69,7 +68,7 @@ namespace Chr.Avro.Codegen
 
         public override SyntaxNode VisitTypeArgumentList(TypeArgumentListSyntax node)
         {
-            var result = base.VisitTypeArgumentList(node) as TypeArgumentListSyntax;
+            var result = (base.VisitTypeArgumentList(node) as TypeArgumentListSyntax)!;
 
             // VisitQualifiedName doesn’t hit these
             var children = node.ChildNodes().OfType<NameSyntax>();
@@ -123,7 +122,7 @@ namespace Chr.Avro.Codegen
 
         internal static CompilationUnitSyntax Rewrite(CompilationUnitSyntax unit)
         {
-            return new NamespaceRewriter().Visit(unit) as CompilationUnitSyntax;
+            return (new NamespaceRewriter().Visit(unit) as CompilationUnitSyntax)!;
         }
 
         private static NameSyntax StripGlobalAlias(NameSyntax name)

--- a/src/Chr.Avro.Confluent/Chr.Avro.Confluent.csproj
+++ b/src/Chr.Avro.Confluent/Chr.Avro.Confluent.csproj
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <Description>Integration tools for the Confluent Kafka and Schema Registry clients</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Chr.Avro.Confluent/ProducerBuilderExtensions.cs
+++ b/src/Chr.Avro.Confluent/ProducerBuilderExtensions.cs
@@ -37,7 +37,7 @@ namespace Chr.Avro.Confluent
             this DependentProducerBuilder<TKey, TValue> producerBuilder,
             ISchemaRegistryClient registryClient,
             bool registerAutomatically = false,
-            Func<SerializationContext, string> subjectNameBuilder = null
+            Func<SerializationContext, string>? subjectNameBuilder = null
         ) => producerBuilder.SetKeySerializer(new AsyncSchemaRegistrySerializer<TKey>(
             registryClient,
             registerAutomatically: registerAutomatically,
@@ -67,7 +67,7 @@ namespace Chr.Avro.Confluent
             this ProducerBuilder<TKey, TValue> producerBuilder,
             ISchemaRegistryClient registryClient,
             bool registerAutomatically = false,
-            Func<SerializationContext, string> subjectNameBuilder = null
+            Func<SerializationContext, string>? subjectNameBuilder = null
         ) => producerBuilder.SetKeySerializer(new AsyncSchemaRegistrySerializer<TKey>(
             registryClient,
             registerAutomatically: registerAutomatically,
@@ -96,7 +96,7 @@ namespace Chr.Avro.Confluent
             this DependentProducerBuilder<TKey, TValue> producerBuilder,
             IEnumerable<KeyValuePair<string, string>> registryConfiguration,
             bool registerAutomatically = false,
-            Func<SerializationContext, string> subjectNameBuilder = null
+            Func<SerializationContext, string>? subjectNameBuilder = null
         ) => producerBuilder.SetKeySerializer(new AsyncSchemaRegistrySerializer<TKey>(
             registryConfiguration,
             registerAutomatically: registerAutomatically,
@@ -125,7 +125,7 @@ namespace Chr.Avro.Confluent
             this ProducerBuilder<TKey, TValue> producerBuilder,
             IEnumerable<KeyValuePair<string, string>> registryConfiguration,
             bool registerAutomatically = false,
-            Func<SerializationContext, string> subjectNameBuilder = null
+            Func<SerializationContext, string>? subjectNameBuilder = null
         ) => producerBuilder.SetKeySerializer(new AsyncSchemaRegistrySerializer<TKey>(
             registryConfiguration,
             registerAutomatically: registerAutomatically,
@@ -609,7 +609,7 @@ namespace Chr.Avro.Confluent
             this DependentProducerBuilder<TKey, TValue> producerBuilder,
             ISchemaRegistryClient registryClient,
             bool registerAutomatically = false,
-            Func<SerializationContext, string> subjectNameBuilder = null
+            Func<SerializationContext, string>? subjectNameBuilder = null
         ) => producerBuilder.SetValueSerializer(new AsyncSchemaRegistrySerializer<TValue>(
             registryClient,
             registerAutomatically: registerAutomatically,
@@ -639,7 +639,7 @@ namespace Chr.Avro.Confluent
             this ProducerBuilder<TKey, TValue> producerBuilder,
             ISchemaRegistryClient registryClient,
             bool registerAutomatically = false,
-            Func<SerializationContext, string> subjectNameBuilder = null
+            Func<SerializationContext, string>? subjectNameBuilder = null
         ) => producerBuilder.SetValueSerializer(new AsyncSchemaRegistrySerializer<TValue>(
             registryClient,
             registerAutomatically: registerAutomatically,
@@ -668,7 +668,7 @@ namespace Chr.Avro.Confluent
             this DependentProducerBuilder<TKey, TValue> producerBuilder,
             IEnumerable<KeyValuePair<string, string>> registryConfiguration,
             bool registerAutomatically = false,
-            Func<SerializationContext, string> subjectNameBuilder = null
+            Func<SerializationContext, string>? subjectNameBuilder = null
         ) => producerBuilder.SetValueSerializer(new AsyncSchemaRegistrySerializer<TValue>(
             registryConfiguration,
             registerAutomatically: registerAutomatically,
@@ -697,7 +697,7 @@ namespace Chr.Avro.Confluent
             this ProducerBuilder<TKey, TValue> producerBuilder,
             IEnumerable<KeyValuePair<string, string>> registryConfiguration,
             bool registerAutomatically = false,
-            Func<SerializationContext, string> subjectNameBuilder = null
+            Func<SerializationContext, string>? subjectNameBuilder = null
         ) => producerBuilder.SetValueSerializer(new AsyncSchemaRegistrySerializer<TValue>(
             registryConfiguration,
             registerAutomatically: registerAutomatically,

--- a/src/Chr.Avro.Confluent/SchemaRegistryDeserializerBuilder.cs
+++ b/src/Chr.Avro.Confluent/SchemaRegistryDeserializerBuilder.cs
@@ -49,8 +49,8 @@ namespace Chr.Avro.Confluent
         /// </param>
         public SchemaRegistryDeserializerBuilder(
             IEnumerable<KeyValuePair<string, string>> registryConfiguration,
-            Serialization.IBinaryDeserializerBuilder deserializerBuilder = null,
-            IJsonSchemaReader schemaReader = null
+            Serialization.IBinaryDeserializerBuilder? deserializerBuilder = null,
+            IJsonSchemaReader? schemaReader = null
         ) : this(
             new CachedSchemaRegistryClient(registryConfiguration),
             deserializerBuilder,
@@ -78,8 +78,8 @@ namespace Chr.Avro.Confluent
         /// </exception>
         public SchemaRegistryDeserializerBuilder(
             ISchemaRegistryClient registryClient,
-            Serialization.IBinaryDeserializerBuilder deserializerBuilder = null,
-            IJsonSchemaReader schemaReader = null
+            Serialization.IBinaryDeserializerBuilder? deserializerBuilder = null,
+            IJsonSchemaReader? schemaReader = null
         ) {
             _disposeRegistryClient = false;
 

--- a/src/Chr.Avro.Confluent/SchemaRegistrySerializerBuilder.cs
+++ b/src/Chr.Avro.Confluent/SchemaRegistrySerializerBuilder.cs
@@ -68,10 +68,10 @@ namespace Chr.Avro.Confluent
         /// </param>
         public SchemaRegistrySerializerBuilder(
             IEnumerable<KeyValuePair<string, string>> registryConfiguration,
-            Abstract.ISchemaBuilder schemaBuilder = null,
-            IJsonSchemaReader schemaReader = null,
-            IJsonSchemaWriter schemaWriter = null,
-            Serialization.IBinarySerializerBuilder serializerBuilder = null
+            Abstract.ISchemaBuilder? schemaBuilder = null,
+            IJsonSchemaReader? schemaReader = null,
+            IJsonSchemaWriter? schemaWriter = null,
+            Serialization.IBinarySerializerBuilder? serializerBuilder = null
         ) : this(
             new CachedSchemaRegistryClient(registryConfiguration),
             schemaBuilder,
@@ -109,10 +109,10 @@ namespace Chr.Avro.Confluent
         /// </exception>
         public SchemaRegistrySerializerBuilder(
             ISchemaRegistryClient registryClient,
-            Abstract.ISchemaBuilder schemaBuilder = null,
-            IJsonSchemaReader schemaReader = null,
-            IJsonSchemaWriter schemaWriter = null,
-            Serialization.IBinarySerializerBuilder serializerBuilder = null
+            Abstract.ISchemaBuilder? schemaBuilder = null,
+            IJsonSchemaReader? schemaReader = null,
+            IJsonSchemaWriter? schemaWriter = null,
+            Serialization.IBinarySerializerBuilder? serializerBuilder = null
         ) {
 
             _disposeRegistryClient = false;

--- a/src/Chr.Avro.Json/Chr.Avro.Json.csproj
+++ b/src/Chr.Avro.Json/Chr.Avro.Json.csproj
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <Description>Avro JSON serialization and deserialization</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Chr.Avro/Abstract/Schema.cs
+++ b/src/Chr.Avro/Abstract/Schema.cs
@@ -34,7 +34,7 @@ namespace Chr.Avro.Abstract
         /// <summary>
         /// The schema’s logical type.
         /// </summary>
-        public LogicalType LogicalType { get; set; }
+        public LogicalType? LogicalType { get; set; }
     }
 
     /// <summary>
@@ -56,14 +56,11 @@ namespace Chr.Avro.Abstract
     /// </remarks>
     public class ArraySchema : ComplexSchema
     {
-        private Schema item;
+        private Schema item = null!;
 
         /// <summary>
         /// The schema of the items in the array.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the schema is set to null.
-        /// </exception>
         public Schema Item
         {
             get
@@ -82,15 +79,12 @@ namespace Chr.Avro.Abstract
         /// <param name="item">
         /// The schema of the items in the array.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the item schema is null.
-        /// </exception>
         public ArraySchema(Schema item)
         {
             Item = item;
         }
     }
-    
+
     /// <summary>
     /// An Avro schema representing a map of string keys to values.
     /// </summary>
@@ -100,14 +94,11 @@ namespace Chr.Avro.Abstract
     /// </remarks>
     public class MapSchema : ComplexSchema
     {
-        private Schema value;
+        private Schema value = null!;
 
         /// <summary>
         /// The schema of the values in the map.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the schema is set to null.
-        /// </exception>
         public Schema Value
         {
             get
@@ -126,9 +117,6 @@ namespace Chr.Avro.Abstract
         /// <param name="value">
         /// The schema of the values in the map.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the value schema is null.
-        /// </exception>
         public MapSchema(Schema value)
         {
             Value = value;
@@ -144,7 +132,7 @@ namespace Chr.Avro.Abstract
     /// </remarks>
     public class UnionSchema : ComplexSchema
     {
-        private ConstrainedSet<Schema> schemas;
+        private ConstrainedSet<Schema> schemas = null!;
 
         /// <summary>
         /// The union members.
@@ -154,9 +142,6 @@ namespace Chr.Avro.Abstract
         /// contain other union schemas or multiple schemas of the same type. Duplicate name
         /// constraints, however, are not enforced.
         /// </remarks>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when a member is null.
-        /// </exception>
         /// <exception cref="InvalidSchemaException">
         /// Thrown when a schema of the same type already exists as a member of the union.
         /// </exception>
@@ -196,15 +181,12 @@ namespace Chr.Avro.Abstract
         /// <param name="schemas">
         /// The union members.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when a member of the union is null.
-        /// </exception>
         /// <exception cref="InvalidSchemaException">
         /// Thrown when a schema of the same type already exists as a member of the union.
         /// </exception>
-        public UnionSchema(ICollection<Schema> schemas = null)
+        public UnionSchema(ICollection<Schema>? schemas = null)
         {
-            Schemas = schemas ?? new Schema[0];
+            Schemas = schemas ?? new List<Schema>();
         }
     }
 
@@ -214,9 +196,9 @@ namespace Chr.Avro.Abstract
     /// </summary>
     public abstract class NamedSchema : ComplexSchema
     {
-        private ConstrainedSet<string> aliases;
+        private ConstrainedSet<string> aliases = null!;
 
-        private string name;
+        private string name = null!;
 
         /// <summary>
         /// The alternate names by which the schema can be identified.
@@ -225,9 +207,6 @@ namespace Chr.Avro.Abstract
         /// Aliases are fully-qualified; they do not inherit the schema’s namespace. Duplicate
         /// aliases will be filtered from the collection.
         /// </remarks>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when an alias is set to null.
-        /// </exception>
         /// <exception cref="InvalidNameException">
         /// Thrown when an alias does not conform to the Avro specification.
         /// </exception>
@@ -259,9 +238,6 @@ namespace Chr.Avro.Abstract
         /// <summary>
         /// The qualified schema name.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the name is set to null.
-        /// </exception>
         /// <exception cref="InvalidNameException">
         /// Thrown when the name is set to a value that does not conform to the Avro naming rules.
         /// </exception>
@@ -294,9 +270,6 @@ namespace Chr.Avro.Abstract
         /// Setting this property to a qualified name will update the full name. Setting this
         /// property to an unqualified name will retain the existing namespace.
         /// </remarks>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the name is set to null.
-        /// </exception>
         /// <exception cref="InvalidNameException">
         /// Thrown when the name is set to a value that does not conform to the Avro naming rules.
         /// </exception>
@@ -310,7 +283,7 @@ namespace Chr.Avro.Abstract
             {
                 FullName = Namespace != null && value?.IndexOf('.') < 0
                     ? $"{Namespace}.{value}"
-                    : value;
+                    : value!;
             }
         }
 
@@ -321,14 +294,11 @@ namespace Chr.Avro.Abstract
         /// This property will return null if no namespace is set. Setting this property to null
         /// or the empty string will clear the namespace.
         /// </remarks>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the namespace is set to null.
-        /// </exception>
         /// <exception cref="InvalidNameException">
         /// Thrown when the namespace is set to a value that does not conform to the Avro naming
         /// rules.
         /// </exception>
-        public string Namespace
+        public string? Namespace
         {
             get
             {
@@ -354,15 +324,12 @@ namespace Chr.Avro.Abstract
         /// <param name="name">
         /// The qualified schema name.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the schema name is null.
-        /// </exception>
         /// <exception cref="InvalidNameException">
         /// Thrown when the schema name does not conform to the Avro naming rules.
         /// </exception>
         public NamedSchema(string name)
         {
-            Aliases = new string[0];
+            Aliases = new List<string>();
             FullName = name;
         }
     }
@@ -377,19 +344,16 @@ namespace Chr.Avro.Abstract
     /// </remarks>
     public class EnumSchema : NamedSchema
     {
-        private ConstrainedSet<string> symbols;
+        private ConstrainedSet<string> symbols = null!;
 
         /// <summary>
         /// A human-readable description of the enum.
         /// </summary>
-        public string Documentation { get; set; }
+        public string? Documentation { get; set; }
 
         /// <summary>
         /// The enum symbols.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when a symbol is set to null.
-        /// </exception>
         /// <exception cref="InvalidSymbolException">
         /// Thrown when a symbol does not conform to the Avro specification.
         /// </exception>
@@ -427,18 +391,15 @@ namespace Chr.Avro.Abstract
         /// <param name="symbols">
         /// The enum symbols.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the schema name or one of the symbols is null.
-        /// </exception>
         /// <exception cref="InvalidNameException">
         /// Thrown when the schema name does not conform to the Avro naming rules.
         /// </exception>
         /// <exception cref="InvalidSymbolException">
         /// Thrown when a symbol does not conform to the Avro naming rules.
         /// </exception>
-        public EnumSchema(string name, ICollection<string> symbols = null) : base(name)
+        public EnumSchema(string name, ICollection<string>? symbols = null) : base(name)
         {
-            Symbols = symbols ?? new string[0];
+            Symbols = symbols ?? new List<string>();
         }
     }
 
@@ -485,9 +446,6 @@ namespace Chr.Avro.Abstract
         /// <param name="size">
         /// The number of bytes per value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the schema name is null.
-        /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown when the size is negative.
         /// </exception>
@@ -509,12 +467,12 @@ namespace Chr.Avro.Abstract
     /// </remarks>
     public class RecordSchema : NamedSchema
     {
-        private ConstrainedSet<RecordField> fields;
+        private ConstrainedSet<RecordField> fields = null!;
 
         /// <summary>
         /// A human-readable description of the record.
         /// </summary>
-        public string Documentation { get; set; }
+        public string? Documentation { get; set; }
 
         /// <summary>
         /// The record fields.
@@ -523,9 +481,6 @@ namespace Chr.Avro.Abstract
         /// Avro doesn’t allow duplicate field names, but that constraint isn’t enforced here—the
         /// onus is on the user to ensure that the record schema is valid.
         /// </remarks>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when a field is set to null.
-        /// </exception>
         public ICollection<RecordField> Fields
         {
             get
@@ -555,15 +510,12 @@ namespace Chr.Avro.Abstract
         /// <param name="fields">
         /// The record fields.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the schema name or one of the fields is null.
-        /// </exception>
         /// <exception cref="InvalidNameException">
         /// Thrown when the schema name does not conform to the Avro specification.
         /// </exception>
-        public RecordSchema(string name, ICollection<RecordField> fields = null) : base(name)
+        public RecordSchema(string name, ICollection<RecordField>? fields = null) : base(name)
         {
-            Fields = fields ?? new RecordField[0];
+            Fields = fields ?? new List<RecordField>();
         }
     }
 
@@ -572,21 +524,18 @@ namespace Chr.Avro.Abstract
     /// </summary>
     public sealed class RecordField : Declaration
     {
-        private string name;
+        private string name = null!;
 
-        private Schema type;
+        private Schema type = null!;
 
         /// <summary>
         /// A human-readable description of the field.
         /// </summary>
-        public string Documentation { get; set; }
+        public string? Documentation { get; set; }
 
         /// <summary>
         /// The name of the field.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the name is set to null.
-        /// </exception>
         /// <exception cref="InvalidNameException">
         /// Thrown when the name is set to a value that does not conform to the Avro naming rules.
         /// </exception>
@@ -615,9 +564,6 @@ namespace Chr.Avro.Abstract
         /// <summary>
         /// The type of the field.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the type is set to null.
-        /// </exception>
         public Schema Type
         {
             get
@@ -639,9 +585,6 @@ namespace Chr.Avro.Abstract
         /// <param name="type">
         /// The field type.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the field name type is null.
-        /// </exception>
         /// <exception cref="InvalidNameException">
         /// Thrown when the field name does not conform to the Avro naming rules.
         /// </exception>

--- a/src/Chr.Avro/Chr.Avro.csproj
+++ b/src/Chr.Avro/Chr.Avro.csproj
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <Description>Avro schema models</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Chr.Avro/Infrastructure/ConstrainedSet.cs
+++ b/src/Chr.Avro/Infrastructure/ConstrainedSet.cs
@@ -22,7 +22,7 @@ namespace Chr.Avro.Infrastructure
 
         public bool IsReadOnly => _dictionary.IsReadOnly;
 
-        public ConstrainedSet(IEnumerable<T> existing = null, Func<T, ConstrainedSet<T>, bool> predicate = null)
+        public ConstrainedSet(IEnumerable<T>? existing = null, Func<T, ConstrainedSet<T>, bool>? predicate = null)
         {
             _dictionary = new Dictionary<T, LinkedListNode<T>>();
             _list = new LinkedList<T>();
@@ -91,7 +91,7 @@ namespace Chr.Avro.Infrastructure
 
     internal static class ConstrainedSetExtensions
     {
-        internal static ConstrainedSet<T> ToConstrainedSet<T>(this IEnumerable<T> enumerable, Func<T, ConstrainedSet<T>, bool> predicate = null)
+        internal static ConstrainedSet<T> ToConstrainedSet<T>(this IEnumerable<T> enumerable, Func<T, ConstrainedSet<T>, bool>? predicate = null)
         {
             return new ConstrainedSet<T>(enumerable, predicate);
         }

--- a/src/Chr.Avro/Infrastructure/ReflectionExtensions.cs
+++ b/src/Chr.Avro/Infrastructure/ReflectionExtensions.cs
@@ -6,7 +6,7 @@ namespace Chr.Avro.Infrastructure
 {
     internal static class ReflectionExtensions
     {
-        public static Type GetEnumerableType(this Type type)
+        public static Type? GetEnumerableType(this Type type)
         {
             return new[] { type }
                 .Concat(type.GetInterfaces())

--- a/src/Chr.Avro/Representation/SchemaReader.cs
+++ b/src/Chr.Avro/Representation/SchemaReader.cs
@@ -25,6 +25,6 @@ namespace Chr.Avro.Representation
         /// <returns>
         /// Returns a deserialized schema object.
         /// </returns>
-        Schema Read(Stream stream, ConcurrentDictionary<string, Schema> cache = null, string scope = null);
+        Schema Read(Stream stream, ConcurrentDictionary<string, Schema>? cache = null, string? scope = null);
     }
 }

--- a/src/Chr.Avro/Representation/SchemaWriter.cs
+++ b/src/Chr.Avro/Representation/SchemaWriter.cs
@@ -26,6 +26,6 @@ namespace Chr.Avro.Representation
         /// An optional schema cache. The cache is populated as the schema is written and can be
         /// used to determine which named schemas have already been processed.
         /// </param>
-        void Write(Schema schema, Stream stream, bool canonical = false, ConcurrentDictionary<string, NamedSchema> names = null);
+        void Write(Schema schema, Stream stream, bool canonical = false, ConcurrentDictionary<string, NamedSchema>? names = null);
     }
 }

--- a/src/Chr.Avro/Representation/UnknownSchemaException.cs
+++ b/src/Chr.Avro/Representation/UnknownSchemaException.cs
@@ -17,6 +17,6 @@ namespace Chr.Avro.Representation
         /// <param name="inner">
         /// An underlying error that may provide additional context.
         /// </param>
-        public UnknownSchemaException(string message, Exception inner = null) : base(message, inner) { }
+        public UnknownSchemaException(string message, Exception? inner = null) : base(message, inner) { }
     }
 }

--- a/src/Chr.Avro/Resolution/ConstructorResolution.cs
+++ b/src/Chr.Avro/Resolution/ConstructorResolution.cs
@@ -1,7 +1,5 @@
-using Chr.Avro.Abstract;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace Chr.Avro.Resolution
@@ -11,14 +9,11 @@ namespace Chr.Avro.Resolution
     /// </summary>
     public class ConstructorResolution
     {
-        private ConstructorInfo constructor;
+        private ConstructorInfo constructor = null!;
 
         /// <summary>
         /// The resolved constructor reflection info.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the constructor info is set to null.
-        /// </exception>
         public virtual ConstructorInfo Constructor
         {
             get
@@ -45,10 +40,10 @@ namespace Chr.Avro.Resolution
         /// <param name="parameters">
         /// The constructors parameters.
         /// </param>
-        public ConstructorResolution(ConstructorInfo constructor, ICollection<ParameterResolution> parameters = null)
+        public ConstructorResolution(ConstructorInfo constructor, ICollection<ParameterResolution>? parameters = null)
         {
             Constructor = constructor;
-            Parameters = parameters;
+            Parameters = parameters ?? new List<ParameterResolution>();
         }
     }
 }

--- a/src/Chr.Avro/Resolution/FieldResolution.cs
+++ b/src/Chr.Avro/Resolution/FieldResolution.cs
@@ -8,18 +8,15 @@ namespace Chr.Avro.Resolution
     /// </summary>
     public class FieldResolution
     {
-        private MemberInfo member;
+        private MemberInfo member = null!;
 
-        private IdentifierResolution name;
+        private IdentifierResolution name = null!;
 
-        private Type type;
+        private Type type = null!;
 
         /// <summary>
         /// The resolved member reflection info.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the reflection info is set to null.
-        /// </exception>
         public virtual MemberInfo Member
         {
             get
@@ -35,9 +32,6 @@ namespace Chr.Avro.Resolution
         /// <summary>
         /// The field or property name.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the name is set to null.
-        /// </exception>
         public virtual IdentifierResolution Name
         {
             get
@@ -49,13 +43,10 @@ namespace Chr.Avro.Resolution
                 name = value ?? throw new ArgumentNullException(nameof(value), "Field name cannot be null.");
             }
         }
-        
+
         /// <summary>
         /// The field or property type.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the type is set to null.
-        /// </exception>
         public virtual Type Type
         {
             get
@@ -80,9 +71,6 @@ namespace Chr.Avro.Resolution
         /// <param name="name">
         /// The field or property name.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when reflection info, type, or name is null.
-        /// </exception>
         public FieldResolution(MemberInfo member, Type type, IdentifierResolution name)
         {
             Member = member;

--- a/src/Chr.Avro/Resolution/IdentifierResolution.cs
+++ b/src/Chr.Avro/Resolution/IdentifierResolution.cs
@@ -10,7 +10,7 @@ namespace Chr.Avro.Resolution
     {
         private static readonly Regex fuzzyCharacters = new Regex(@"[^A-Za-z0-9]");
 
-        private string value;
+        private string value = null!;
 
         /// <summary>
         /// Whether the name was set explicitly (e.g., in an annotation).
@@ -20,9 +20,6 @@ namespace Chr.Avro.Resolution
         /// <summary>
         /// The resolved name.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the name is set to null.
-        /// </exception>
         public virtual string Value
         {
             get

--- a/src/Chr.Avro/Resolution/ParameterResolution.cs
+++ b/src/Chr.Avro/Resolution/ParameterResolution.cs
@@ -8,18 +8,15 @@ namespace Chr.Avro.Resolution
     /// </summary>
     public class ParameterResolution
     {
-        private ParameterInfo parameter;
+        private ParameterInfo parameter = null!;
 
-        private IdentifierResolution name;
+        private IdentifierResolution name = null!;
 
-        private Type type;
+        private Type type = null!;
 
         /// <summary>
         /// The resolved parameter reflection info.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the reflection info is set to null.
-        /// </exception>
         public virtual ParameterInfo Parameter
         {
             get
@@ -35,9 +32,6 @@ namespace Chr.Avro.Resolution
         /// <summary>
         /// The parameter name.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the reflection info is set to null.
-        /// </exception>
         public virtual IdentifierResolution Name
         {
             get
@@ -53,9 +47,6 @@ namespace Chr.Avro.Resolution
         /// <summary>
         /// The parameter type.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the reflection info is set to null.
-        /// </exception>
         public virtual Type Type
         {
             get
@@ -80,9 +71,6 @@ namespace Chr.Avro.Resolution
         /// <param name="name">
         /// The parameter name.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when reflection info, type, or name is null.
-        /// </exception>
         public ParameterResolution(ParameterInfo parameter, Type type, IdentifierResolution name)
         {
             Parameter = parameter;

--- a/src/Chr.Avro/Resolution/ReflectionResolver.cs
+++ b/src/Chr.Avro/Resolution/ReflectionResolver.cs
@@ -97,7 +97,7 @@ namespace Chr.Avro.Resolution
         /// <returns>
         /// The attribute, or null if the attribute is not present.
         /// </returns>
-        protected virtual T GetAttribute<T>(MemberInfo member) where T : Attribute
+        protected virtual T? GetAttribute<T>(MemberInfo member) where T : Attribute
         {
             return member.GetCustomAttributes(typeof(T), true)
                 .OfType<T>()
@@ -110,7 +110,7 @@ namespace Chr.Avro.Resolution
         /// <returns>
         /// The attribute, or null if the attribute is not present.
         /// </returns>
-        protected virtual T GetAttribute<T>(Type type) where T : Attribute
+        protected virtual T? GetAttribute<T>(Type type) where T : Attribute
         {
             return type.GetCustomAttributes(typeof(T), true)
                 .OfType<T>()
@@ -154,19 +154,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// A <see cref="BooleanResolution" /> with information about the type.
+        /// A successful <see cref="BooleanResolution" /> result if the type is <see cref="bool" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="bool" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(bool))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(bool))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new BooleanResolution(type);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new BooleanResolution(type);
+            return result;
         }
     }
 
@@ -182,19 +186,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// An <see cref="IntegerResolution" /> with information about the type.
+        /// A successful <see cref="IntegerResolution" /> result if the type is <see cref="byte" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="byte" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(byte))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(byte))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new IntegerResolution(type, false, 8);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new IntegerResolution(type, false, 8);
+            return result;
         }
     }
 
@@ -210,19 +218,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// A <see cref="ByteArrayResolution" /> with information about the type.
+        /// A successful <see cref="ByteArrayResolution" /> result if the type is <see cref="T:System.Byte[]" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="T:System.Byte[]" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(byte[]))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(byte[]))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new ByteArrayResolution(type);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new ByteArrayResolution(type);
+            return result;
         }
     }
 
@@ -238,19 +250,24 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// A <see cref="TimestampResolution" /> with information about the type.
+        /// A successful <see cref="TimestampResolution" /> result if the type is <see cref="DateTime" />
+        /// or <see cref="DateTimeOffset" />; an unsuccessful <see cref="UnsupportedTypeException" />
+        /// result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="DateTime" /> or <see cref="DateTimeOffset" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (!(type == typeof(DateTime) || type == typeof(DateTimeOffset)))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(DateTime) || type == typeof(DateTimeOffset))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new TimestampResolution(type, 1m / TimeSpan.TicksPerSecond);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new TimestampResolution(type, 1m / TimeSpan.TicksPerSecond);
+            return result;
         }
     }
 
@@ -266,19 +283,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// A <see cref="DecimalResolution" /> with information about the type.
+        /// A successful <see cref="DecimalResolution" /> result if the type is <see cref="decimal" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="decimal" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(decimal))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(decimal))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new DecimalResolution(type, 29, 14);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new DecimalResolution(type, 29, 14);
+            return result;
         }
     }
 
@@ -294,23 +315,27 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// A <see cref="MapResolution" /> with information about the type.
+        /// A successful <see cref="MapResolution" /> result if the type is <see cref="T:System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair`2}" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="T:System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair`2}" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (!(type.GetEnumerableType() is Type pair && pair.IsGenericType && pair.GetGenericTypeDefinition() == typeof(KeyValuePair<,>)))
+            var result = new TypeResolutionResult();
+
+            if (type.GetEnumerableType() is Type pair && pair.IsGenericType && pair.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
             {
-                throw new UnsupportedTypeException(type);
+                var arguments = pair.GetGenericArguments();
+                var key = arguments.ElementAt(0);
+                var value = arguments.ElementAt(1);
+
+                result.TypeResolution = new MapResolution(type, key, value);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            var arguments = pair.GetGenericArguments();
-            var key = arguments.ElementAt(0);
-            var value = arguments.ElementAt(1);
-
-            return new MapResolution(type, key, value);
+            return result;
         }
     }
 
@@ -326,19 +351,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// A <see cref="FloatingPointResolution" /> with information about the type.
+        /// A successful <see cref="FloatingPointResolution" /> result if the type is <see cref="double" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="double" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(double))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(double))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new FloatingPointResolution(type, 16);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new FloatingPointResolution(type, 16);
+            return result;
         }
     }
 
@@ -354,38 +383,42 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// An <see cref="EnumResolution" /> with information about the type.
+        /// A successful <see cref="EnumResolution" /> result if the type is an <see cref="Enum" /> type;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not an enum type.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (!type.IsEnum)
+            var result = new TypeResolutionResult();
+
+            if (type.IsEnum)
             {
-                throw new UnsupportedTypeException(type);
+                var name = new IdentifierResolution(type.Name);
+
+                var @namespace = string.IsNullOrEmpty(type.Namespace)
+                    ? null
+                    : new IdentifierResolution(type.Namespace);
+
+                var isFlagEnum = GetAttribute<FlagsAttribute>(type) != null;
+
+                var symbols = type.GetFields(BindingFlags.Public | BindingFlags.Static)
+                    .Select(f => (
+                        MemberInfo: f as MemberInfo,
+                        Name: new IdentifierResolution(f.Name),
+                        Value: Enum.Parse(type, f.Name)
+                    ))
+                    .OrderBy(f => f.Value)
+                    .ThenBy(f => f.Name.Value)
+                    .Select(f => new SymbolResolution(f.MemberInfo, f.Name, f.Value))
+                    .ToList();
+
+                result.TypeResolution = new EnumResolution(type, type.GetEnumUnderlyingType(), name, @namespace, isFlagEnum, symbols);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            var name = new IdentifierResolution(type.Name);
-
-            var @namespace = string.IsNullOrEmpty(type.Namespace)
-                ? null
-                : new IdentifierResolution(type.Namespace);
-
-            var isFlagEnum = GetAttribute<FlagsAttribute>(type) != null;
-
-            var symbols = type.GetFields(BindingFlags.Public | BindingFlags.Static)
-                .Select(f => (
-                    MemberInfo: f as MemberInfo,
-                    Name: new IdentifierResolution(f.Name),
-                    Value: Enum.Parse(type, f.Name)
-                ))
-                .OrderBy(f => f.Value)
-                .ThenBy(f => f.Name.Value)
-                .Select(f => new SymbolResolution(f.MemberInfo, f.Name, f.Value))
-                .ToList();
-
-            return new EnumResolution(type, type.GetEnumUnderlyingType(), name, @namespace, isFlagEnum, symbols);
+            return result;
         }
     }
 
@@ -421,22 +454,27 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// A <see cref="TypeResolution" /> for the underlying type.
+        /// If the type is an <see cref="Enum" /> type, a successful <see cref="TypeResolution" />
+        /// for its underlying type; an unsuccessful <see cref="UnsupportedTypeException" /> result
+        /// otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not an enum type.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (!type.IsEnum)
+            var result = new TypeResolutionResult();
+
+            if (type.IsEnum)
             {
-                throw new UnsupportedTypeException(type);
+                var resolution = Resolver.ResolveType(type.GetEnumUnderlyingType());
+                resolution.Type = type;
+
+                result.TypeResolution = resolution;
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            var resolution = Resolver.ResolveType(type.GetEnumUnderlyingType());
-            resolution.Type = type;
-
-            return resolution;
+            return result;
         }
     }
 
@@ -468,32 +506,35 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// An <see cref="ArrayResolution" /> with information about the type.
+        /// A successful <see cref="ArrayResolution" /> result if the type is <see cref="IEnumerable{T}" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="IEnumerable{T}" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            var itemType = type.GetEnumerableType();
+            var result = new TypeResolutionResult();
 
-            if (itemType == null)
+            if (type.GetEnumerableType() is Type itemType)
             {
-                throw new UnsupportedTypeException(type);
+                var resolution = new ArrayResolution(type, itemType);
+
+                if (!type.IsArray)
+                {
+                    resolution.Constructors = GetConstructors(type, MemberVisibility)
+                        .Select(c => new ConstructorResolution(
+                            c.ConstructorInfo,
+                            c.Parameters.Select(p => new ParameterResolution(p, p.ParameterType, new IdentifierResolution(p.Name))).ToList()
+                        ))
+                        .ToList();
+                }
+
+                result.TypeResolution = resolution;
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            ICollection<ConstructorResolution> constructors = null;
-
-            if (!type.IsArray)
-            {
-                constructors = GetConstructors(type, MemberVisibility)
-                    .Select(c => new ConstructorResolution(
-                        c.ConstructorInfo,
-                        c.Parameters.Select(p => new ParameterResolution(p, p.ParameterType, new IdentifierResolution(p.Name))).ToList()
-                    )).ToList();
-            }
-
-            return new ArrayResolution(type, itemType, constructors);
+            return result;
         }
     }
 
@@ -509,19 +550,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// A <see cref="UuidResolution" /> with information about the type.
+        /// A successful <see cref="UuidResolution" /> result if the type is <see cref="Guid" />; an
+        /// unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="Guid" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(Guid))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(Guid))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new UuidResolution(type, 2, 4);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new UuidResolution(type, 2, 4);
+            return result;
         }
     }
 
@@ -537,19 +582,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// An <see cref="IntegerResolution" /> with information about the type.
+        /// A successful <see cref="IntegerResolution" /> result if the type is <see cref="short" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="short" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(short))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(short))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new IntegerResolution(type, true, 16);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new IntegerResolution(type, true, 16);
+            return result;
         }
     }
 
@@ -565,19 +614,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// An <see cref="IntegerResolution" /> with information about the type.
+        /// A successful <see cref="IntegerResolution" /> result if the type is <see cref="int" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="int" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(int))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(int))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new IntegerResolution(type, true, 32);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new IntegerResolution(type, true, 32);
+            return result;
         }
     }
 
@@ -593,19 +646,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// An <see cref="IntegerResolution" /> with information about the type.
+        /// A successful <see cref="IntegerResolution" /> result if the type is <see cref="long" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="long" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(long))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(long))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new IntegerResolution(type, true, 64);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new IntegerResolution(type, true, 64);
+            return result;
         }
     }
 
@@ -625,12 +682,9 @@ namespace Chr.Avro.Resolution
         /// <param name="resolver">
         /// The resolver instance to use to resolve underlying types.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the resolver is null.
-        /// </exception>
         public NullableResolverCase(ITypeResolver resolver)
         {
-            Resolver = resolver ?? throw new ArgumentNullException(nameof(resolver), "Resolver cannot be null.");
+            Resolver = resolver;
         }
 
         /// <summary>
@@ -640,25 +694,28 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// A <see cref="TypeResolution" /> for the underlying type.
+        /// If the type is <see cref="Nullable{T}" />, a successful <see cref="TypeResolution" />
+        /// for its underlying type; an unsuccessful <see cref="UnsupportedTypeException" /> result
+        /// otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="Nullable{T}" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            var underlyingType = Nullable.GetUnderlyingType(type);
+            var result = new TypeResolutionResult();
 
-            if (underlyingType == null)
+            if (Nullable.GetUnderlyingType(type) is Type underlyingType)
             {
-                throw new UnsupportedTypeException(type);
+                var resolution = Resolver.ResolveType(underlyingType);
+                resolution.IsNullable = true;
+                resolution.Type = type;
+
+                result.TypeResolution = resolution;
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            var resolution = Resolver.ResolveType(underlyingType);
-            resolution.IsNullable = true;
-            resolution.Type = type;
-
-            return resolution;
+            return result;
         }
     }
 
@@ -690,41 +747,44 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// A <see cref="RecordResolution" /> with information about the type.
+        /// An unsuccessful <see cref="UnsupportedTypeException" /> result if the type is an array
+        /// or primitive type; a successful <see cref="RecordResolution" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is an array type or a primitive type.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type.IsArray || type.IsPrimitive)
+            var result = new TypeResolutionResult();
+
+            if (!type.IsArray && !type.IsPrimitive)
             {
-                throw new UnsupportedTypeException(type);
+                var name = new IdentifierResolution(type.Name);
+                var @namespace = string.IsNullOrEmpty(type.Namespace)
+                    ? null
+                    : new IdentifierResolution(type.Namespace);
+
+                var fields = GetMembers(type, MemberVisibility)
+                    .Select(m => new FieldResolution(
+                        m.MemberInfo,
+                        m.Type,
+                        new IdentifierResolution(m.MemberInfo.Name)
+                    ))
+                    .OrderBy(m => m.Name.Value)
+                    .ToList();
+
+                var constructors = GetConstructors(type, MemberVisibility)
+                    .Select(c => new ConstructorResolution(
+                        c.ConstructorInfo,
+                        c.Parameters.Select(p => new ParameterResolution(p, p.ParameterType, new IdentifierResolution(p.Name))).ToList()
+                    ))
+                    .ToList();
+
+                result.TypeResolution = new RecordResolution(type, name, @namespace, fields, constructors);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            var name = new IdentifierResolution(type.Name);
-
-            var @namespace = string.IsNullOrEmpty(type.Namespace)
-                ? null
-                : new IdentifierResolution(type.Namespace);
-
-            var fields = GetMembers(type, MemberVisibility)
-                .Select(m => (
-                    m.MemberInfo,
-                    m.Type,
-                    Name: new IdentifierResolution(m.MemberInfo.Name)
-                ))
-                .OrderBy(m => m.Name.Value)
-                .Select(m => new FieldResolution(m.MemberInfo, m.Type, m.Name))
-                .ToList();
-
-            var constructors = GetConstructors(type, MemberVisibility)
-                .Select(c => new ConstructorResolution(
-                    c.ConstructorInfo,
-                    c.Parameters.Select(p => new ParameterResolution(p, p.ParameterType, new IdentifierResolution(p.Name))).ToList()
-                )).ToList();
-
-            return new RecordResolution(type, name, @namespace, fields, constructors);
+            return result;
         }
     }
 
@@ -740,19 +800,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// An <see cref="IntegerResolution" /> with information about the type.
+        /// A successful <see cref="IntegerResolution" /> result if the type is <see cref="sbyte" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="sbyte" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(sbyte))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(sbyte))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new IntegerResolution(type, true, 8);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new IntegerResolution(type, true, 8);
+            return result;
         }
     }
 
@@ -768,19 +832,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// A <see cref="FloatingPointResolution" /> with information about the type.
+        /// A successful <see cref="FloatingPointResolution" /> result if the type is <see cref="float" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="float" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(float))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(float))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new FloatingPointResolution(type, 8);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new FloatingPointResolution(type, 8);
+            return result;
         }
     }
 
@@ -796,19 +864,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// A <see cref="StringResolution" /> with information about the type.
+        /// A successful <see cref="StringResolution" /> result if the type is <see cref="string" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="string" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(string))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(string))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new StringResolution(type);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new StringResolution(type);
+            return result;
         }
     }
 
@@ -824,19 +896,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// A <see cref="DurationResolution" /> with information about the type.
+        /// A successful <see cref="DurationResolution" /> result if the type is <see cref="TimeSpan" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="TimeSpan" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(TimeSpan))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(TimeSpan))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new DurationResolution(type, 1m / TimeSpan.TicksPerSecond);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new DurationResolution(type, 1m / TimeSpan.TicksPerSecond);
+            return result;
         }
     }
 
@@ -852,19 +928,24 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// An <see cref="IntegerResolution" /> with information about the type.
+        /// A successful <see cref="IntegerResolution" /> result if the type is <see cref="char" />
+        /// or <see cref="ushort" />; an unsuccessful <see cref="UnsupportedTypeException" /> result
+        /// otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="char" /> or <see cref="ushort" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (!(type == typeof(char) || type == typeof(ushort)))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(char) || type == typeof(ushort))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new IntegerResolution(type, false, 16);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new IntegerResolution(type, false, 16);
+            return result;
         }
     }
 
@@ -880,19 +961,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// An <see cref="IntegerResolution" /> with information about the type.
+        /// A successful <see cref="IntegerResolution" /> result if the type is <see cref="uint" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="uint" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(uint))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(uint))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new IntegerResolution(type, false, 32);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new IntegerResolution(type, false, 32);
+            return result;
         }
     }
 
@@ -908,19 +993,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// An <see cref="IntegerResolution" /> with information about the type.
+        /// A successful <see cref="IntegerResolution" /> result if the type is <see cref="ulong" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="ulong" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(ulong))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(ulong))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new IntegerResolution(type, false, 64);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new IntegerResolution(type, false, 64);
+            return result;
         }
     }
 
@@ -936,19 +1025,23 @@ namespace Chr.Avro.Resolution
         /// The type to resolve.
         /// </param>
         /// <returns>
-        /// A <see cref="UriResolution" /> with information about the type.
+        /// A successful <see cref="UriResolution" /> result if the type is <see cref="Uri" />;
+        /// an unsuccessful <see cref="UnsupportedTypeException" /> result otherwise.
         /// </returns>
-        /// <exception cref="UnsupportedTypeException">
-        /// Thrown when the type is not <see cref="Uri" />.
-        /// </exception>
-        public override TypeResolution Resolve(Type type)
+        public override ITypeResolutionResult ResolveType(Type type)
         {
-            if (type != typeof(Uri))
+            var result = new TypeResolutionResult();
+
+            if (type == typeof(Uri))
             {
-                throw new UnsupportedTypeException(type);
+                result.TypeResolution = new UriResolution(type);
+            }
+            else
+            {
+                result.Exceptions.Add(new UnsupportedTypeException(type));
             }
 
-            return new UriResolution(type);
+            return result;
         }
     }
 }

--- a/src/Chr.Avro/Resolution/SymbolResolution.cs
+++ b/src/Chr.Avro/Resolution/SymbolResolution.cs
@@ -8,18 +8,15 @@ namespace Chr.Avro.Resolution
     /// </summary>
     public class SymbolResolution
     {
-        private MemberInfo member;
+        private MemberInfo member = null!;
 
-        private IdentifierResolution name;
+        private IdentifierResolution name = null!;
 
-        private object value;
+        private object value = null!;
 
         /// <summary>
         /// The resolved static field reflection info.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the reflection info is set to null.
-        /// </exception>
         public virtual MemberInfo Member
         {
             get
@@ -35,9 +32,6 @@ namespace Chr.Avro.Resolution
         /// <summary>
         /// The symbol name.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the name is set to null.
-        /// </exception>
         public virtual IdentifierResolution Name
         {
             get
@@ -53,9 +47,6 @@ namespace Chr.Avro.Resolution
         /// <summary>
         /// The raw symbol value.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the value is set to null.
-        /// </exception>
         public virtual object Value
         {
             get

--- a/src/Chr.Avro/Resolution/TypeResolution.cs
+++ b/src/Chr.Avro/Resolution/TypeResolution.cs
@@ -13,7 +13,7 @@ namespace Chr.Avro.Resolution
     /// </remarks>
     public abstract class TypeResolution
     {
-        private Type type;
+        private Type type = null!;
 
         /// <summary>
         /// Whether the resolved type can have a null value.
@@ -23,9 +23,6 @@ namespace Chr.Avro.Resolution
         /// <summary>
         /// The resolved type.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the type is set to null.
-        /// </exception>
         public virtual Type Type
         {
             get
@@ -47,9 +44,6 @@ namespace Chr.Avro.Resolution
         /// <param name="isNullable">
         /// Whether the resolved type can have a null value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the type is null.
-        /// </exception>
         public TypeResolution(Type type, bool isNullable = false)
         {
             IsNullable = isNullable;
@@ -62,12 +56,12 @@ namespace Chr.Avro.Resolution
     /// </summary>
     public class ArrayResolution : TypeResolution
     {
-        private ICollection<ConstructorResolution> constructors;
+        private ICollection<ConstructorResolution> constructors = null!;
 
-        private Type itemType;
+        private Type itemType = null!;
 
         /// <summary>
-        /// The record constructors.
+        /// The array constructors.
         /// </summary>
         public virtual ICollection<ConstructorResolution> Constructors
         {
@@ -77,16 +71,13 @@ namespace Chr.Avro.Resolution
             }
             set
             {
-                constructors = value ?? throw new ArgumentNullException(nameof(value), "Record constructor collection cannot be null.");
+                constructors = value ?? throw new ArgumentNullException(nameof(value), "Resolved constructor collection cannot be null.");
             }
         }
 
         /// <summary>
         /// The array item type.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the item type is set to null.
-        /// </exception>
         public virtual Type ItemType
         {
             get
@@ -108,15 +99,15 @@ namespace Chr.Avro.Resolution
         /// <param name="itemType">
         /// The array item type.
         /// </param>
+        /// <param name="constructors">
+        /// The array constructors.
+        /// </param>
         /// <param name="isNullable">
         /// Whether the array type can have a null value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the array type or the item type is null.
-        /// </exception>
-        public ArrayResolution(Type type, Type itemType, ICollection<ConstructorResolution> constructors, bool isNullable = false) : base(type, isNullable)
+        public ArrayResolution(Type type, Type itemType, ICollection<ConstructorResolution>? constructors = null, bool isNullable = false) : base(type, isNullable)
         {
-            Constructors = constructors ?? new ConstructorResolution[0];
+            Constructors = constructors ?? new List<ConstructorResolution>();
             ItemType = itemType;
         }
     }
@@ -135,9 +126,6 @@ namespace Chr.Avro.Resolution
         /// <param name="isNullable">
         /// Whether the boolean type can have a null value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the boolean type is null.
-        /// </exception>
         public BooleanResolution(Type type, bool isNullable = false) : base(type, isNullable) { }
     }
 
@@ -155,9 +143,6 @@ namespace Chr.Avro.Resolution
         /// <param name="isNullable">
         /// Whether the byte array type can have a null value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the byte array type is null.
-        /// </exception>
         public ByteArrayResolution(Type type, bool isNullable = false) : base(type, isNullable) { }
     }
 
@@ -241,9 +226,6 @@ namespace Chr.Avro.Resolution
         /// <param name="isNullable">
         /// Whether the decimal type can have a null value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the decimal type is null.
-        /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown when the precision is less than one or less than the scale or the scale is less
         /// than zero or greater than the precision.
@@ -299,9 +281,6 @@ namespace Chr.Avro.Resolution
         /// <param name="isNullable">
         /// Whether the duration type can have a null value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the duration type is null.
-        /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown when the precision is less than zero.
         /// </exception>
@@ -353,9 +332,6 @@ namespace Chr.Avro.Resolution
         /// <param name="isNullable">
         /// Whether the floating-point type can have a null value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the floating-point type is null.
-        /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown when the size is less than zero or not divisible by 8.
         /// </exception>
@@ -412,9 +388,6 @@ namespace Chr.Avro.Resolution
         /// <param name="size">
         /// The size of the integer type in bits.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the integer type is null.
-        /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown when the size is less than zero or not divisible by 8.
         /// </exception>
@@ -430,16 +403,13 @@ namespace Chr.Avro.Resolution
     /// </summary>
     public class MapResolution : TypeResolution
     {
-        private Type keyType;
+        private Type keyType = null!;
 
-        private Type valueType;
+        private Type valueType = null!;
 
         /// <summary>
         /// The map key type.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the key type is set to null.
-        /// </exception>
         public virtual Type KeyType
         {
             get
@@ -455,9 +425,6 @@ namespace Chr.Avro.Resolution
         /// <summary>
         /// The map value type.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the value type is set to null.
-        /// </exception>
         public virtual Type ValueType
         {
             get
@@ -485,9 +452,6 @@ namespace Chr.Avro.Resolution
         /// <param name="isNullable">
         /// Whether the map type can have a null value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the map type, the key type, or the value type is null.
-        /// </exception>
         public MapResolution(Type type, Type keyType, Type valueType, bool isNullable = false) : base(type, isNullable)
         {
             KeyType = keyType;
@@ -509,9 +473,6 @@ namespace Chr.Avro.Resolution
         /// <param name="isNullable">
         /// Whether the string type can have a null value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the string type is null.
-        /// </exception>
         public StringResolution(Type type, bool isNullable = false) : base(type, isNullable) { }
     }
 
@@ -559,9 +520,6 @@ namespace Chr.Avro.Resolution
         /// <param name="isNullable">
         /// Whether the timestamp type can have a null value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the timestamp type is null.
-        /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown when the precision is less than zero.
         /// </exception>
@@ -585,9 +543,6 @@ namespace Chr.Avro.Resolution
         /// <param name="isNullable">
         /// Whether the URI type can have a null value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the URI type is null.
-        /// </exception>
         public UriResolution(Type type, bool isNullable = false) : base(type, isNullable) { }
     }
 
@@ -624,9 +579,6 @@ namespace Chr.Avro.Resolution
         /// <param name="isNullable">
         /// Whether the UUID type can have a null value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the UUID type is null.
-        /// </exception>
         public UuidResolution(Type type, int variant, int? version = null, bool isNullable = false) : base(type, isNullable)
         {
             Variant = variant;
@@ -639,14 +591,11 @@ namespace Chr.Avro.Resolution
     /// </summary>
     public abstract class NamedTypeResolution : TypeResolution
     {
-        private IdentifierResolution name;
+        private IdentifierResolution name = null!;
 
         /// <summary>
         /// The type name.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the name is set to null.
-        /// </exception>
         public virtual IdentifierResolution Name
         {
             get
@@ -662,7 +611,7 @@ namespace Chr.Avro.Resolution
         /// <summary>
         /// The type namespace.
         /// </summary>
-        public virtual IdentifierResolution Namespace { get; set; }
+        public virtual IdentifierResolution? Namespace { get; set; }
 
         /// <summary>
         /// Creates a new named type resolution.
@@ -679,10 +628,7 @@ namespace Chr.Avro.Resolution
         /// <param name="isNullable">
         /// Whether the named type can have a null value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the named type or the name is null.
-        /// </exception>
-        public NamedTypeResolution(Type type, IdentifierResolution name, IdentifierResolution @namespace = null, bool isNullable = false) : base(type, isNullable)
+        public NamedTypeResolution(Type type, IdentifierResolution name, IdentifierResolution? @namespace = null, bool isNullable = false) : base(type, isNullable)
         {
             Name = name;
             Namespace = @namespace;
@@ -694,9 +640,9 @@ namespace Chr.Avro.Resolution
     /// </summary>
     public class EnumResolution : NamedTypeResolution
     {
-        private ICollection<SymbolResolution> symbols;
+        private ICollection<SymbolResolution> symbols = null!;
 
-        private Type underlyingType;
+        private Type underlyingType = null!;
 
         /// <summary>
         /// Whether the enum is a bit flag enum.
@@ -706,9 +652,6 @@ namespace Chr.Avro.Resolution
         /// <summary>
         /// The enum’s underlying integral type.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the type is set to null.
-        /// </exception>
         public virtual Type UnderlyingType
         {
             get
@@ -761,13 +704,10 @@ namespace Chr.Avro.Resolution
         /// <param name="isNullable">
         /// Whether the enum type can have a null value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the enum type or the name is null.
-        /// </exception>
-        public EnumResolution(Type type, Type underlyingType, IdentifierResolution name, IdentifierResolution @namespace = null, bool isFlagEnum = false, ICollection<SymbolResolution> symbols = null, bool isNullable = false) : base(type, name, @namespace, isNullable)
+        public EnumResolution(Type type, Type underlyingType, IdentifierResolution name, IdentifierResolution? @namespace = null, bool isFlagEnum = false, ICollection<SymbolResolution>? symbols = null, bool isNullable = false) : base(type, name, @namespace, isNullable)
         {
             IsFlagEnum = isFlagEnum;
-            Symbols = symbols ?? new SymbolResolution[0];
+            Symbols = symbols ?? new List<SymbolResolution>();
             UnderlyingType = underlyingType;
         }
     }
@@ -777,9 +717,9 @@ namespace Chr.Avro.Resolution
     /// </summary>
     public class RecordResolution : NamedTypeResolution
     {
-        private ICollection<ConstructorResolution> constructors;
+        private ICollection<ConstructorResolution> constructors = null!;
 
-        private ICollection<FieldResolution> fields;
+        private ICollection<FieldResolution> fields = null!;
 
         /// <summary>
         /// The record constructors.
@@ -833,13 +773,10 @@ namespace Chr.Avro.Resolution
         /// <param name="isNullable">
         /// Whether the record type can have a null value.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when the record type or the name is null.
-        /// </exception>
-        public RecordResolution(Type type, IdentifierResolution name, IdentifierResolution @namespace = null, ICollection<FieldResolution> fields = null, ICollection<ConstructorResolution> constructors = null, bool isNullable = false) : base(type, name, @namespace, isNullable)
+        public RecordResolution(Type type, IdentifierResolution name, IdentifierResolution? @namespace = null, ICollection<FieldResolution>? fields = null, ICollection<ConstructorResolution>? constructors = null, bool isNullable = false) : base(type, name, @namespace, isNullable)
         {
-            Fields = fields ?? new FieldResolution[0];
-            Constructors = constructors ?? new ConstructorResolution[0];
+            Fields = fields ?? new List<FieldResolution>();
+            Constructors = constructors ?? new List<ConstructorResolution>();
         }
     }
 }

--- a/src/Chr.Avro/UnsupportedSchemaException.cs
+++ b/src/Chr.Avro/UnsupportedSchemaException.cs
@@ -4,7 +4,7 @@ using System;
 namespace Chr.Avro
 {
     /// <summary>
-    /// The exception that is thrown when an operation does not support a schema.
+    /// An exception thrown when an operation does not support a schema.
     /// </summary>
     [Serializable]
     public class UnsupportedSchemaException : Exception
@@ -26,10 +26,7 @@ namespace Chr.Avro
         /// <param name="inner">
         /// An underlying error that may provide additional context.
         /// </param>
-        public UnsupportedSchemaException(Schema schema, string message = null, Exception inner = null) : base(
-            string.IsNullOrEmpty(message) ? $"{schema.GetType()} is not supported." : message,
-            inner
-        )
+        public UnsupportedSchemaException(Schema schema, string? message = null, Exception? inner = null) : base(message ?? $"{schema.GetType()} is not supported.", inner)
         {
             UnsupportedSchema = schema;
         }

--- a/src/Chr.Avro/UnsupportedTypeException.cs
+++ b/src/Chr.Avro/UnsupportedTypeException.cs
@@ -3,7 +3,7 @@ using System;
 namespace Chr.Avro
 {
     /// <summary>
-    /// The exception that is thrown when an operation does not support a .NET type.
+    /// An exception thrown when an operation does not support a .NET type.
     /// </summary>
     [Serializable]
     public class UnsupportedTypeException : Exception
@@ -25,10 +25,8 @@ namespace Chr.Avro
         /// <param name="inner">
         /// An underlying error that may provide additional context.
         /// </param>
-        public UnsupportedTypeException(Type type, string message = null, Exception inner = null) : base(
-            string.IsNullOrEmpty(message) ? $"{type.FullName} is not supported." : message,
-            inner
-        ) {
+        public UnsupportedTypeException(Type type, string? message = null, Exception? inner = null) : base(message ?? $"{type.FullName} is not supported.", inner)
+        {
             UnsupportedType = type;
         }
     }

--- a/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
@@ -60,7 +60,7 @@ namespace Chr.Avro.Serialization.Tests
             var serializer = SerializerBuilder.BuildSerializer<ISet<string>>(schema);
             var encoding = serializer.Serialize(value);
 
-            Assert.Throws<AggregateException>(() => DeserializerBuilder.BuildDeserializer<ISet<string>>(schema));
+            Assert.Throws<UnsupportedTypeException>(() => DeserializerBuilder.BuildDeserializer<ISet<string>>(schema));
         }
 
         [Theory]

--- a/tests/Chr.Avro.Binary.Tests/EnumSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/EnumSerializationTests.cs
@@ -34,10 +34,10 @@ namespace Chr.Avro.Serialization.Tests
         public void MissingValues()
         {
             var schema = new EnumSchema("suit", new[] { "CLUBS", "DIAMONDS", "HEARTS", "SPADES", "EAGLES" });
-            Assert.Throws<AggregateException>(() => DeserializerBuilder.BuildDeserializer<Suit>(schema));
+            Assert.Throws<UnsupportedTypeException>(() => DeserializerBuilder.BuildDeserializer<Suit>(schema));
 
             schema = new EnumSchema("suit", new[] { "CLUBS", "DIAMONDS", "HEARTS" });
-            Assert.Throws<AggregateException>(() => SerializerBuilder.BuildSerializer<Suit>(schema));
+            Assert.Throws<UnsupportedTypeException>(() => SerializerBuilder.BuildSerializer<Suit>(schema));
         }
 
         [Theory]

--- a/tests/Chr.Avro.Binary.Tests/FixedSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/FixedSerializationTests.cs
@@ -55,15 +55,6 @@ namespace Chr.Avro.Serialization.Tests
             Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value)));
         }
 
-        [Fact]
-        public void InvalidGuidLength()
-        {
-            var schema = new FixedSchema("test", 8);
-
-            Assert.Throws<AggregateException>(() => DeserializerBuilder.BuildDeserializer<Guid>(schema));
-            Assert.Throws<AggregateException>(() => SerializerBuilder.BuildSerializer<Guid>(schema));
-        }
-
         public static IEnumerable<object[]> GuidData => new List<object[]>
         {
             new object[] { Guid.Empty },

--- a/tests/Chr.Avro.Binary.Tests/UnionSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/UnionSerializationTests.cs
@@ -24,8 +24,8 @@ namespace Chr.Avro.Serialization.Tests
         {
             var schema = new UnionSchema();
 
-            Assert.Throws<AggregateException>(() => SerializerBuilder.BuildSerializer<object>(schema));
-            Assert.Throws<AggregateException>(() => DeserializerBuilder.BuildDeserializer<object>(schema));
+            Assert.Throws<UnsupportedSchemaException>(() => SerializerBuilder.BuildSerializer<object>(schema));
+            Assert.Throws<UnsupportedSchemaException>(() => DeserializerBuilder.BuildDeserializer<object>(schema));
         }
 
         [Theory]
@@ -45,7 +45,7 @@ namespace Chr.Avro.Serialization.Tests
                 Assert.Equal(encoding, serializer.Serialize(value.Value));
             }
 
-            Assert.Throws<AggregateException>(() => DeserializerBuilder.BuildDeserializer<int>(schema));
+            Assert.Throws<UnsupportedTypeException>(() => DeserializerBuilder.BuildDeserializer<int>(schema));
         }
 
         [Theory]
@@ -74,8 +74,8 @@ namespace Chr.Avro.Serialization.Tests
                 new IntSchema()
             });
 
-            Assert.Throws<AggregateException>(() => SerializerBuilder.BuildSerializer<string>(schema));
-            Assert.Throws<AggregateException>(() => DeserializerBuilder.BuildDeserializer<string>(schema));
+            Assert.Throws<UnsupportedTypeException>(() => SerializerBuilder.BuildSerializer<string>(schema));
+            Assert.Throws<UnsupportedTypeException>(() => DeserializerBuilder.BuildDeserializer<string>(schema));
         }
 
         [Theory]

--- a/tests/Chr.Avro.Tests/Abstract/SchemaBuilderTests.cs
+++ b/tests/Chr.Avro.Tests/Abstract/SchemaBuilderTests.cs
@@ -468,7 +468,7 @@ namespace Chr.Avro.Tests
         [InlineData(typeof(int[,]))]
         public void ThrowsWhenNoCaseMatches(Type type)
         {
-            Assert.Throws<AggregateException>(() => Builder.BuildSchema(type));
+            Assert.Throws<UnsupportedTypeException>(() => Builder.BuildSchema(type));
         }
     }
 }

--- a/tests/Chr.Avro.Tests/Resolution/CommonResolverTests.cs
+++ b/tests/Chr.Avro.Tests/Resolution/CommonResolverTests.cs
@@ -534,7 +534,7 @@ namespace Chr.Avro.Tests
         [InlineData(typeof(int[,]))]
         public void ThrowsWhenNoCaseMatches(Type type)
         {
-            Assert.Throws<AggregateException>(() => Resolver.ResolveType(type));
+            Assert.Throws<UnsupportedTypeException>(() => Resolver.ResolveType(type));
         }
     }
 }


### PR DESCRIPTION
- refactor all builder cases to return custom result types (as a side effect, this will make projects like serde perf improvements easier down the road)
- make builder case method names consistent (e.g. `Resolve` -> `ResolveType` to match `BuildSchema` et al.)
- refactor builders to return `UnsupportedSchemaException` or `UnsupportedTypeException` as appropriate instead of `AggregateException`
- enforce nullable reference type checking on all library projects; remove extraneous exception documentation