### PR TITLE
Refactor binary codec

### DIFF
--- a/benchmarks/dotnet/Program.cs
+++ b/benchmarks/dotnet/Program.cs
@@ -46,6 +46,16 @@ namespace Chr.Avro.Benchmarks
                 csv.WriteRecords(Run<Apache.SpecificLargeFixedRunner>());
                 csv.WriteRecords(Run<Chr.LargeFixedRunner>());
 
+                // arrays:
+                csv.WriteRecords(Run<Apache.GenericDoubleArrayRunner>());
+                csv.WriteRecords(Run<Apache.SpecificDoubleArrayRunner>());
+                csv.WriteRecords(Run<Chr.DoubleArrayRunner>());
+
+                // maps:
+                csv.WriteRecords(Run<Apache.GenericDoubleMapRunner>());
+                csv.WriteRecords(Run<Apache.SpecificDoubleMapRunner>());
+                csv.WriteRecords(Run<Chr.DoubleMapRunner>());
+
                 // records:
                 csv.WriteRecords(Run<Apache.GenericRecordRunner>());
                 csv.WriteRecords(Run<Apache.SpecificRecordRunner>());

--- a/benchmarks/dotnet/Program.cs
+++ b/benchmarks/dotnet/Program.cs
@@ -38,6 +38,14 @@ namespace Chr.Avro.Benchmarks
                 csv.WriteRecords(Run<Apache.StringRunner>());
                 csv.WriteRecords(Run<Chr.StringRunner>());
 
+                // fixeds:
+                csv.WriteRecords(Run<Apache.GenericSmallFixedRunner>());
+                csv.WriteRecords(Run<Apache.SpecificSmallFixedRunner>());
+                csv.WriteRecords(Run<Chr.SmallFixedRunner>());
+                csv.WriteRecords(Run<Apache.GenericLargeFixedRunner>());
+                csv.WriteRecords(Run<Apache.SpecificLargeFixedRunner>());
+                csv.WriteRecords(Run<Chr.LargeFixedRunner>());
+
                 // records:
                 csv.WriteRecords(Run<Apache.GenericRecordRunner>());
                 csv.WriteRecords(Run<Apache.SpecificRecordRunner>());

--- a/benchmarks/dotnet/Suites/Array.cs
+++ b/benchmarks/dotnet/Suites/Array.cs
@@ -1,0 +1,60 @@
+namespace Chr.Avro.Benchmarks
+{
+    using global::System.Collections.Generic;
+
+    public static class DoubleArraySuite
+    {
+        public const int Iterations = 1_000_000;
+
+        public const string Name = "array[double]";
+
+        public const string Schema = "{\"type\":\"array\",\"items\":\"double\"}";
+
+        public static IEnumerable<List<double>> Values => new[]
+        {
+            new List<double> { 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 },
+            new List<double> { 44.822560, -93.464530 }
+        };
+    }
+}
+
+namespace Chr.Avro.Benchmarks.Apache
+{
+    using global::System.Collections.Generic;
+    using global::System.Linq;
+
+    public class GenericDoubleArrayRunner : GenericRunner<object[]>
+    {
+        public GenericDoubleArrayRunner() : base(
+            $"{DoubleArraySuite.Name} (generic)",
+            DoubleArraySuite.Iterations,
+            DoubleArraySuite.Schema,
+            DoubleArraySuite.Values.Select(value => value.Select(item => (object)item).ToArray())
+        ) { }
+    }
+
+    public class SpecificDoubleArrayRunner : SpecificRunner<List<double>>
+    {
+        public SpecificDoubleArrayRunner() : base(
+            $"{DoubleArraySuite.Name} (specific)",
+            DoubleArraySuite.Iterations,
+            DoubleArraySuite.Schema,
+            DoubleArraySuite.Values
+        ) { }
+    }
+}
+
+namespace Chr.Avro.Benchmarks.Chr
+{
+    using global::System.Collections.Generic;
+
+    public class DoubleArrayRunner : Runner<List<double>>
+    {
+        public DoubleArrayRunner() : base(
+            DoubleArraySuite.Name,
+            DoubleArraySuite.Iterations,
+            DoubleArraySuite.Schema,
+            DoubleArraySuite.Values
+        ) { }
+    }
+}

--- a/benchmarks/dotnet/Suites/Fixed.cs
+++ b/benchmarks/dotnet/Suites/Fixed.cs
@@ -1,0 +1,156 @@
+namespace Chr.Avro.Benchmarks
+{
+    using global::System;
+    using global::System.Collections.Generic;
+
+    public static class SmallFixedSuite
+    {
+        public const int Iterations = 10_000_000;
+
+        public const string Name = "fixed[12]";
+
+        public const string Schema = "{\"type\":\"fixed\",\"name\":\"Twelve\",\"size\":12}";
+
+        public static IEnumerable<byte[]> Values => new[]
+        {
+            new byte[12]
+        };
+    }
+
+    public static class LargeFixedSuite
+    {
+        public const int Iterations = 1_000_000;
+
+        public const string Name = "fixed[2048]";
+
+        public const string Schema = "{\"type\":\"fixed\",\"name\":\"TwentyFortyEight\",\"size\":2048}";
+
+        public static IEnumerable<byte[]> Values => new[]
+        {
+            new byte[2048]
+        };
+    }
+}
+
+namespace Chr.Avro.Benchmarks.Apache
+{
+    using global::Avro;
+    using global::Avro.Generic;
+    using global::Avro.Specific;
+    using global::System.Linq;
+
+    public class GenericSmallFixedRunner : GenericRunner<GenericFixed>
+    {
+        public GenericSmallFixedRunner() : base(
+            $"{SmallFixedSuite.Name} (generic)",
+            SmallFixedSuite.Iterations,
+            SmallFixedSuite.Schema,
+            SmallFixedSuite.Values.Select(value =>
+                new GenericFixed((FixedSchema)Schema.Parse(SmallFixedSuite.Schema), value))
+        ) { }
+    }
+
+    public class SpecificSmallFixedRunner : SpecificRunner<Twelve>
+    {
+        public SpecificSmallFixedRunner() : base(
+            $"{SmallFixedSuite.Name} (specific)",
+            SmallFixedSuite.Iterations,
+            SmallFixedSuite.Schema,
+            SmallFixedSuite.Values.Select(value => new Twelve()
+            {
+                Value = value
+            })
+        ) { }
+    }
+
+    public class GenericLargeFixedRunner : GenericRunner<GenericFixed>
+    {
+        public GenericLargeFixedRunner() : base(
+            $"{LargeFixedSuite.Name} (generic)",
+            LargeFixedSuite.Iterations,
+            LargeFixedSuite.Schema,
+            LargeFixedSuite.Values.Select(value =>
+                new GenericFixed((FixedSchema)Schema.Parse(LargeFixedSuite.Schema), value))
+        ) { }
+    }
+
+    public class SpecificLargeFixedRunner : SpecificRunner<TwentyFortyEight>
+    {
+        public SpecificLargeFixedRunner() : base(
+            $"{LargeFixedSuite.Name} (specific)",
+            LargeFixedSuite.Iterations,
+            LargeFixedSuite.Schema,
+            LargeFixedSuite.Values.Select(value => new TwentyFortyEight()
+            {
+                Value = value
+            })
+        ) { }
+    }
+
+    public partial class Twelve : SpecificFixed
+    {
+        public static Schema _SCHEMA = Schema.Parse("{\"type\":\"fixed\",\"name\":\"Twelve\",\"size\":12}");
+        private static uint fixedSize = 12;
+        public Twelve() : base(fixedSize)
+        { }
+        public override Schema Schema
+        {
+            get
+            {
+                return Twelve._SCHEMA;
+            }
+        }
+        public static uint FixedSize
+        {
+            get
+            {
+                return Twelve.fixedSize;
+            }
+        }
+    }
+
+    public partial class TwentyFortyEight : SpecificFixed
+    {
+        public static Schema _SCHEMA = Schema.Parse("{\"type\":\"fixed\",\"name\":\"TwentyFortyEight\",\"size\":2048}");
+        private static uint fixedSize = 2048;
+        public TwentyFortyEight() : base(fixedSize)
+        { }
+        public override Schema Schema
+        {
+            get
+            {
+                return TwentyFortyEight._SCHEMA;
+            }
+        }
+        public static uint FixedSize
+        {
+            get
+            {
+                return TwentyFortyEight.fixedSize;
+            }
+        }
+    }
+}
+
+namespace Chr.Avro.Benchmarks.Chr
+{
+    public class SmallFixedRunner : Runner<byte[]>
+    {
+        public SmallFixedRunner() : base(
+            SmallFixedSuite.Name,
+            SmallFixedSuite.Iterations,
+            SmallFixedSuite.Schema,
+            SmallFixedSuite.Values
+        ) { }
+    }
+
+    public class LargeFixedRunner : Runner<byte[]>
+    {
+        public LargeFixedRunner() : base(
+            LargeFixedSuite.Name,
+            LargeFixedSuite.Iterations,
+            LargeFixedSuite.Schema,
+            LargeFixedSuite.Values
+        ) { }
+    }
+}

--- a/benchmarks/dotnet/Suites/Map.cs
+++ b/benchmarks/dotnet/Suites/Map.cs
@@ -1,0 +1,65 @@
+namespace Chr.Avro.Benchmarks
+{
+    using global::System;
+    using global::System.Collections.Generic;
+
+    public static class DoubleMapSuite
+    {
+        public const int Iterations = 1_000_000;
+
+        public const string Name = "map[double]";
+
+        public const string Schema = "{\"type\":\"map\",\"values\":\"double\"}";
+
+        public static IEnumerable<Dictionary<string, double>> Values => new[]
+        {
+            new Dictionary<string, double>
+            {
+                { "e", Math.E },
+                { "pi", Math.PI },
+                { "tau", Math.PI * 2 }
+            }
+        };
+    }
+}
+
+namespace Chr.Avro.Benchmarks.Apache
+{
+    using global::System.Collections.Generic;
+    using global::System.Linq;
+
+    public class GenericDoubleMapRunner : GenericRunner<Dictionary<string, object>>
+    {
+        public GenericDoubleMapRunner() : base(
+            $"{DoubleMapSuite.Name} (generic)",
+            DoubleMapSuite.Iterations,
+            DoubleMapSuite.Schema,
+            DoubleMapSuite.Values.Select(value => value.ToDictionary(pair => pair.Key, pair => (object)pair.Value))
+        ) { }
+    }
+
+    public class SpecificDoubleMapRunner : SpecificRunner<Dictionary<string, double>>
+    {
+        public SpecificDoubleMapRunner() : base(
+            $"{DoubleMapSuite.Name} (specific)",
+            DoubleMapSuite.Iterations,
+            DoubleMapSuite.Schema,
+            DoubleMapSuite.Values
+        ) { }
+    }
+}
+
+namespace Chr.Avro.Benchmarks.Chr
+{
+    using global::System.Collections.Generic;
+
+    public class DoubleMapRunner : Runner<Dictionary<string, double>>
+    {
+        public DoubleMapRunner() : base(
+            DoubleMapSuite.Name,
+            DoubleMapSuite.Iterations,
+            DoubleMapSuite.Schema,
+            DoubleMapSuite.Values
+        ) { }
+    }
+}

--- a/benchmarks/dotnet/Suites/Record.cs
+++ b/benchmarks/dotnet/Suites/Record.cs
@@ -59,7 +59,8 @@ namespace Chr.Avro.Benchmarks.Apache
             $"{RecordSuite.Name} (generic)",
             RecordSuite.Iterations,
             RecordSuite.Schema,
-            RecordSuite.Values.Select(value => {
+            RecordSuite.Values.Select(value =>
+            {
                 var person = (RecordSchema)Schema.Parse(RecordSuite.Schema);
                 var color = (EnumSchema)person["favoriteColor"].Schema;
 

--- a/src/Chr.Avro.Binary/BinaryDeserializerBuilder.cs
+++ b/src/Chr.Avro.Binary/BinaryDeserializerBuilder.cs
@@ -406,7 +406,7 @@ namespace Chr.Avro.Serialization
                             .GetMethod(nameof(IBinaryDeserializerBuilder.BuildDelegate))
                             .MakeGenericMethod(item);
 
-                        expression = Codec.ReadList(stream,
+                        expression = Codec.ReadArray(stream,
                             Expression.Invoke(
                                 Expression.Constant(
                                     build.Invoke(DeserializerBuilder, new object[] { arraySchema.Item, cache }),
@@ -1375,7 +1375,7 @@ namespace Chr.Avro.Serialization
                         var buildKey = build.MakeGenericMethod(key);
                         var buildItem = build.MakeGenericMethod(item);
 
-                        expression = Codec.ReadDictionary(stream,
+                        expression = Codec.ReadMap(stream,
                             Expression.Invoke(
                                 Expression.Constant(
                                     buildKey.Invoke(DeserializerBuilder, new object[] { new StringSchema(), cache }),

--- a/tests/Chr.Avro.Binary.Tests/BinaryCodecTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/BinaryCodecTests.cs
@@ -119,13 +119,18 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(BlockEncodings))]
-        public void WritesBlocks(byte[] items, byte[] encoding)
+        public void WritesArrays(byte[] items, byte[] encoding)
         {
             var stream = new MemoryStream();
 
+            var output = Expression.Parameter(typeof(Stream));
+            var item = Expression.Variable(typeof(byte));
+            var writeItem = Expression.Call(output, typeof(Stream).GetMethod(nameof(Stream.WriteByte)), item);
+            var write = (Action<Stream>)Expression.Lambda(Codec.WriteArray(Expression.Constant(items), item, writeItem, output), new[] { output }).Compile();
+
             using (stream)
             {
-                Codec.WriteBlocks(items, (b, s) => s.WriteByte(b), stream);
+                write(stream);
             }
 
             Assert.Equal(encoding, stream.ToArray());
@@ -137,9 +142,12 @@ namespace Chr.Avro.Serialization.Tests
         {
             var stream = new MemoryStream();
 
+            var output = Expression.Parameter(typeof(Stream));
+            var write = (Action<Stream>)Expression.Lambda(Codec.WriteBoolean(Expression.Constant(value), output), new[] { output }).Compile();
+
             using (stream)
             {
-                Codec.WriteBoolean(value, stream);
+                write(stream);
             }
 
             Assert.Equal(encoding, stream.ToArray());
@@ -151,9 +159,12 @@ namespace Chr.Avro.Serialization.Tests
         {
             var stream = new MemoryStream();
 
+            var output = Expression.Parameter(typeof(Stream));
+            var write = (Action<Stream>)Expression.Lambda(Codec.WriteFloat(Expression.Constant(value), output), new[] { output }).Compile();
+
             using (stream)
             {
-                Codec.WriteDouble(value, stream);
+                write(stream);
             }
 
             Assert.Equal(encoding, stream.ToArray());
@@ -165,9 +176,12 @@ namespace Chr.Avro.Serialization.Tests
         {
             var stream = new MemoryStream();
 
+            var output = Expression.Parameter(typeof(Stream));
+            var write = (Action<Stream>)Expression.Lambda(Codec.WriteInteger(Expression.Constant(value), output), new[] { output }).Compile();
+
             using (stream)
             {
-                Codec.WriteInteger(value, stream);
+                write(stream);
             }
 
             Assert.Equal(encoding, stream.ToArray());
@@ -179,9 +193,12 @@ namespace Chr.Avro.Serialization.Tests
         {
             var stream = new MemoryStream();
 
+            var output = Expression.Parameter(typeof(Stream));
+            var write = (Action<Stream>)Expression.Lambda(Codec.WriteFloat(Expression.Constant(value), output), new[] { output }).Compile();
+
             using (stream)
             {
-                Codec.WriteSingle(value, stream);
+                write(stream);
             }
 
             Assert.Equal(encoding, stream.ToArray());


### PR DESCRIPTION
Work described in #55.

- rewrite `IBinaryCodec` methods to return expression trees
- fix some serde builder cases to avoid duplicate computation

Benchmark results:

| Benchmark | Component | Apache (ms) | Before (ms) | After (ms) | Δ (%) |
| - | - | -:| -:| -:| -:|
| array[double] | deserialization | 410 | 319 | 281 | -12 |
| array[double] | serialization | 513 | 415 | 328 | -21 |
| boolean | deserialization | 212 | 70 | 46 | -35 |
| boolean | serialization | 347 | 120 | 76 | -36 |
| double | deserialization | 407 | 271 | 231 | -15 |
| double | serialization | 753 | 387 | 357 | -8 |
| fixed[12] | deserialization | 863 | 218 | 178 | -18 |
| fixed[12] | serialization | 249 | 194 | 172 | -11 |
| fixed[2048] | deserialization | 610 | 528 | 497 | -6 |
| fixed[2048] | serialization | 782 | 759 | 769 | 1 |
| float | deserialization | 389 | 230 | 195 | -15 |
| float | serialization | 525 | 295 | 266 | -10 |
| int | deserialization | 356 | 143 | 131 | -8 |
| int | serialization | 488 | 251 | 213 | -15 |
| long | deserialization | 497 | 199 | 201 | 1 |
| long | serialization | 623 | 413 | 363 | -12 |
| long | deserialization | 497 | 199 | 201 | 1 |
| long | serialization | 623 | 413 | 363 | -12 |
| map[double] | deserialization | 587 | 888 | 444 | -50 |
| map[double] | serialization | 606 | 629 | 387 | -38 |
| record | deserialization | 327 | 156 | 146 | -6 |
| record | serialization | 276 | 491 | 697 | 42 |
| string | deserialization | 720 | 651 | 593 | -9 |
| string | serialization | 1161 | 1288 | 797 | -38 |