### PR TITLE
Support deserialization of immutable dictionaries from avro maps

### DIFF
--- a/src/Chr.Avro.Binary/BinaryDeserializerBuilder.cs
+++ b/src/Chr.Avro.Binary/BinaryDeserializerBuilder.cs
@@ -1426,6 +1426,7 @@ namespace Chr.Avro.Serialization
             {
                 result.Exceptions.Add(new UnsupportedSchemaException(schema));
             }
+
             return result;
         }
     }

--- a/src/Chr.Avro.Binary/Chr.Avro.Binary.csproj
+++ b/src/Chr.Avro.Binary/Chr.Avro.Binary.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Chr.Avro.Binary.Tests/MapSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/MapSerializationTests.cs
@@ -1,6 +1,7 @@
 using Chr.Avro.Abstract;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Xunit;
 
 namespace Chr.Avro.Serialization.Tests
@@ -48,6 +49,17 @@ namespace Chr.Avro.Serialization.Tests
             var deserializer = DeserializerBuilder.BuildDeserializer<IEnumerable<KeyValuePair<string, double>>>(schema);
             var serializer = SerializerBuilder.BuildSerializer<IEnumerable<KeyValuePair<string, double>>>(schema);
             Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value)));
+        }
+
+        [Theory]
+        [MemberData(nameof(StringKeyData))]
+        public void ImmutableDictionaryValues(Dictionary<string, double> value)
+        {
+            var schema = new MapSchema(new DoubleSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<ImmutableDictionary<string, double>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<ImmutableDictionary<string, double>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value.ToImmutableDictionary())));
         }
 
         public static IEnumerable<object[]> DateTimeKeyData => new List<object[]>


### PR DESCRIPTION
Adds special handling for immutable dictionaries, which cannot be directly assigned to from dictionaries.