### PR TITLE
Refactor serde builders

### DIFF
--- a/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
@@ -1,5 +1,4 @@
 using Chr.Avro.Abstract;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;

--- a/tests/Chr.Avro.Binary.Tests/EnumSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/EnumSerializationTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Chr.Avro.Abstract;
 using Xunit;
 

--- a/tests/Chr.Avro.Binary.Tests/RecordConstructorDeserializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/RecordConstructorDeserializationTests.cs
@@ -1,5 +1,4 @@
 using Chr.Avro.Abstract;
-using Chr.Avro.Resolution;
 using Chr.Avro.Serialization;
 using System.Collections.Generic;
 using Xunit;


### PR DESCRIPTION
API changes:

*   New `Expression` methods on `IBinaryDeserializerBuilder` and `IBinarySerializerBuilder`:

    ```csharp
    Expression BuildExpression(Type type, Schema schema, IBinaryDeserializerBuilderContext context);
    ```

    ```csharp
    Expression BuildExpression(Expression value, Schema schema, IBinarySerializerBuilderContext context);
    ```

*   No more optional `cache` parameter on the `BuildDelegate` methods (what was previously the “cache” is now `Assignments` and `References` parameters on the context objects).

*   `BuildDelegate` replaced by `BuildExpression` on serde builder cases.

*    `RecordConstructorDeserializerBuilderCase` folded into `RecordDeserializerBuilderCase`.

This eliminates the worst of the reflection code, both the scary closure tricks in the record serde builders and the `.Invoke`s needed to generate child serdes.

Performance-wise, the benchmarks run a bit faster overall. After this change, we’ll also be able to optimize record handling by only generating recursive code if a class/struct is self-referencing.