### PR TITLE
Flesh out collection mapping

### DIFF
--- a/docs/src/pages/internals/mapping.js
+++ b/docs/src/pages/internals/mapping.js
@@ -25,10 +25,10 @@ export default () =>
         <p>The type is a one-dimensional or jagged array. Multi-dimensional arrays are currently not supported because they can’t be deserialized reliably.</p>
       </li>
       <li>
-        <p>The type is assignable from <DotnetReference id='T:System.Collections.Generic.List`1' />. Other <DotnetReference id='T:System.Collections.Generic.IEnumerable`1' />s can also be serialized to <Highlight inline language='avro'>"array"</Highlight>, but they can’t be deserialized.</p>
+        <p>The type is a generic collection type from <DotnetReference id='N:System.Collections.Generic' /> or <DotnetReference id='N:System.Collections.Immutable' />.</p>
       </li>
       <li>
-        <p>The type has a constructor with an <DotnetReference id='T:System.Collections.Generic.IEnumerable`1' /> parameter.</p>
+        <p>The type implements <DotnetReference id='T:System.Collections.Generic.IEnumerable`1' /> (for serialization) and has a constructor with a single <DotnetReference id='T:System.Collections.Generic.IEnumerable`1' /> parameter (for deserialization).</p>
       </li>
     </ol>
     <p>Some examples:</p>
@@ -64,43 +64,37 @@ export default () =>
           <td><DotnetReference id='T:System.Collections.Generic.IEnumerable{System.Int32}' /></td>
           <td align='center'><span role="img" aria-label="serializable">✅</span></td>
           <td align='center'><span role="img" aria-label="deserializable">✅</span></td>
-          <td><DotnetReference id='T:System.Collections.Generic.IEnumerable{System.Int32}' /> is assignable from <DotnetReference id='T:System.Collections.Generic.List{System.Int32}' />.</td>
-        </tr>
-        <tr valign='top'>
-          <td><DotnetReference id='T:System.Collections.Generic.ICollection{System.Int32}' /></td>
-          <td align='center'><span role="img" aria-label="serializable">✅</span></td>
-          <td align='center'><span role="img" aria-label="deserializable">✅</span></td>
-          <td><DotnetReference id='T:System.Collections.Generic.ICollection{System.Int32}' /> is assignable from <DotnetReference id='T:System.Collections.Generic.List{System.Int32}' />.</td>
+          <td><DotnetReference id='T:System.Collections.Generic.IEnumerable{System.Int32}' /> is a generic collection type.</td>
         </tr>
         <tr valign='top'>
           <td><DotnetReference id='T:System.Collections.Generic.ISet{System.Int32}' /></td>
           <td align='center'><span role="img" aria-label="serializable">✅</span></td>
-          <td align='center'><span role="img" aria-label="not deserializable">🚫</span></td>
-          <td><DotnetReference id='T:System.Collections.Generic.ISet{System.Int32}' /> implements <DotnetReference id='T:System.Collections.Generic.IEnumerable{System.Int32}' /> but is not assignable from <DotnetReference id='T:System.Collections.Generic.List{System.Int32}' />.</td>
+          <td align='center'><span role="img" aria-label="deserializable">✅</span></td>
+          <td><DotnetReference id='T:System.Collections.Generic.ISet{System.Int32}' /> is a generic collection type.</td>
         </tr>
         <tr valign='top'>
           <td><DotnetReference id='T:System.Collections.Generic.List{System.Int32}' /></td>
           <td align='center'><span role="img" aria-label="serializable">✅</span></td>
           <td align='center'><span role="img" aria-label="deserializable">✅</span></td>
-          <td><DotnetReference id='T:System.Collections.Generic.List{System.Int32}' /> is assignable from <DotnetReference id='T:System.Collections.Generic.List{System.Int32}' />.</td>
+          <td><DotnetReference id='T:System.Collections.Generic.List{System.Int32}' /> is a generic collection type.</td>
         </tr>
         <tr valign='top'>
           <td><DotnetReference id='T:System.Collections.Generic.List{System.Int32[]}' /></td>
           <td align='center'><span role="img" aria-label="serializable">✅</span></td>
           <td align='center'><span role="img" aria-label="deserializable">✅</span></td>
-          <td><DotnetReference id='T:System.Collections.Generic.List{System.Int32[]}' /> is assignable from <DotnetReference id='T:System.Collections.Generic.List{System.Int32[]}' /> and <DotnetReference id='T:System.Int32[]' /> is an array type.</td>
+          <td><DotnetReference id='T:System.Collections.Generic.List{System.Int32[]}' /> is a generic collection type and <DotnetReference id='T:System.Int32[]' /> is an array type.</td>
+        </tr>
+        <tr valign='top'>
+          <td><DotnetReference id='T:System.Collections.Immutable.ImmutableQueue{System.Int32}' /></td>
+          <td align='center'><span role="img" aria-label="serializable">✅</span></td>
+          <td align='center'><span role="img" aria-label="deserializable">✅</span></td>
+          <td><DotnetReference id='T:System.Collections.Immutable.ImmutableQueue{System.Int32}' /> is a generic collection type.</td>
         </tr>
         <tr valign='top'>
           <td><DotnetReference id='T:System.Array' /></td>
           <td align='center'><span role="img" aria-label="not serializable">🚫</span></td>
           <td align='center'><span role="img" aria-label="not deserializable">🚫</span></td>
-          <td><DotnetReference id='T:System.Array' /> isn’t generic, so Chr.Avro can’t determine its item type.</td>
-        </tr>
-        <tr valign='top'>
-          <td><DotnetReference id='T:System.Collections.Generic.HashSet{System.Int32}' /></td>
-          <td align='center'><span role='img' aria-label="serializable">✅</span></td>
-          <td align='center'><span role='img' aria-label="deserializable">✅</span></td>
-          <td><DotnetReference id='T:System.Collections.Generic.HashSet{System.Int32}' /> has a constructor with an <DotnetReference id='T:System.Collections.Generic.IEnumerable{System.Int32}' /> parameter.</td>
+          <td><DotnetReference id='T:System.Array' /> isn’t a generic type, so Chr.Avro can’t determine how to handle its items.</td>
         </tr>
       </tbody>
     </table>
@@ -173,7 +167,15 @@ deserializer.Deserialize(serializer.Serialize(epoch)); // 0L`}</Highlight>
     <p>Because enum types are able to be implicitly converted to and from integral types, Chr.Avro can map any integral type to <Highlight inline language='avro'>"enum"</Highlight> as well.</p>
 
     <h2 id='maps'>Maps</h2>
-    <p>Avro’s <Highlight inline language='avro'>"map"</Highlight> type represents a map of keys (assumed to be strings) to values. Chr.Avro can serialize a .NET type to <Highlight inline language='avro'>"map"</Highlight> if it implements <DotnetReference id='T:System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair`2}' />. However, Chr.Avro can only deserialize a type from <Highlight inline language='avro'>"map"</Highlight> if it’s assignable from <DotnetReference id='T:System.Collections.Generic.Dictionary`2' />.</p>
+    <p>Avro’s <Highlight inline language='avro'>"map"</Highlight> type represents a map of keys (assumed to be strings) to values. Chr.Avro can map a .NET type to <Highlight inline language='avro'>"map"</Highlight> if any of the following is true:</p>
+    <ol>
+      <li>
+        <p>The type is a generic dictionary type from <DotnetReference id='N:System.Collections.Generic' /> or <DotnetReference id='N:System.Collections.Immutable' />.</p>
+      </li>
+      <li>
+        <p>The type implements <DotnetReference id='T:System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair`2}' /> (for serialization) and has a constructor with a single <DotnetReference id='T:System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair`2}' /> parameter (for deserialization).</p>
+      </li>
+    </ol>
     <p>Additionally, because Avro map keys are assumed to be strings, serializers and deserializers are built for key types by mapping to <Highlight inline language='avro'>"string"</Highlight> implicitly.</p>
     <p>Some examples of this behavior:</p>
     <table>
@@ -190,49 +192,49 @@ deserializer.Deserialize(serializer.Serialize(epoch)); // 0L`}</Highlight>
           <td><DotnetReference id='T:System.Collections.Generic.IDictionary{System.String,System.Int32}' /></td>
           <td align='center'><span role="img" aria-label="serializable">✅</span></td>
           <td align='center'><span role="img" aria-label="deserializable">✅</span></td>
-          <td><DotnetReference id='T:System.Collections.Generic.IDictionary{System.String,System.Int32}' /> is assignable from <DotnetReference id='T:System.Collections.Generic.Dictionary{System.String,System.Int32}' />.</td>
+          <td><DotnetReference id='T:System.Collections.Generic.IDictionary{System.String,System.Int32}' /> is a generic dictionary type.</td>
         </tr>
         <tr valign='top'>
           <td><DotnetReference id='T:System.Collections.Generic.Dictionary{System.String,System.Int32}' /></td>
           <td align='center'><span role="img" aria-label="serializable">✅</span></td>
           <td align='center'><span role="img" aria-label="deserializable">✅</span></td>
-          <td><DotnetReference id='T:System.Collections.Generic.Dictionary{System.String,System.Int32}' /> is assignable from <DotnetReference id='T:System.Collections.Generic.Dictionary{System.String,System.Int32}' />.</td>
+          <td><DotnetReference id='T:System.Collections.Generic.Dictionary{System.String,System.Int32}' /> is a generic dictionary type.</td>
         </tr>
         <tr valign='top'>
           <td><DotnetReference id='T:System.Collections.Generic.IDictionary{System.Guid,System.Int32}' /></td>
           <td align='center'><span role="img" aria-label="serializable">✅</span></td>
           <td align='center'><span role="img" aria-label="deserializable">✅</span></td>
-          <td><DotnetReference id='T:System.Collections.Generic.IDictionary{System.Guid,System.Int32}' /> is assignable from <DotnetReference id='T:System.Collections.Generic.Dictionary{System.Guid,System.Int32}' />, and <DotnetReference id='T:System.Guid' /> can be mapped to <Highlight inline language='avro'>"string"</Highlight>.</td>
+          <td><DotnetReference id='T:System.Collections.Generic.IDictionary{System.Guid,System.Int32}' /> is a generic dictionary type, and <DotnetReference id='T:System.Guid' /> can be mapped to <Highlight inline language='avro'>"string"</Highlight>.</td>
         </tr>
         <tr valign='top'>
           <td><DotnetReference id='T:System.Collections.Generic.IDictionary{System.Byte[],System.Int32}' /></td>
           <td align='center'><span role="img" aria-label="not serializable">🚫</span></td>
           <td align='center'><span role="img" aria-label="not deserializable">🚫</span></td>
-          <td><DotnetReference id='T:System.Collections.Generic.IDictionary{System.Byte[],System.Int32}' /> is assignable from <DotnetReference id='T:System.Collections.Generic.Dictionary{System.Byte[],System.Int32}' />, but <DotnetReference id='T:System.Byte[]' /> cannot be mapped to <Highlight inline language='avro'>"string"</Highlight>.</td>
+          <td><DotnetReference id='T:System.Collections.Generic.IDictionary{System.Byte[],System.Int32}' /> is a generic dictionary type, but <DotnetReference id='T:System.Byte[]' /> cannot be mapped to <Highlight inline language='avro'>"string"</Highlight>.</td>
         </tr>
         <tr valign='top'>
           <td><DotnetReference id='T:System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.Int32}}' /></td>
           <td align='center'><span role="img" aria-label="serializable">✅</span></td>
           <td align='center'><span role="img" aria-label="deserializable">✅</span></td>
-          <td><DotnetReference id='T:System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.Int32}}' /> is assignable from <DotnetReference id='T:System.Collections.Generic.Dictionary{System.String,System.Int32}' />.</td>
+          <td><DotnetReference id='T:System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.Int32}}' /> is recognized as a generic dictionary type.</td>
         </tr>
         <tr valign='top'>
           <td><DotnetReference id='T:System.Collections.Generic.ICollection{System.Collections.Generic.KeyValuePair{System.String,System.Int32}}' /></td>
           <td align='center'><span role="img" aria-label="serializable">✅</span></td>
           <td align='center'><span role="img" aria-label="deserializable">✅</span></td>
-          <td><DotnetReference id='T:System.Collections.Generic.ICollection{System.Collections.Generic.KeyValuePair{System.String,System.Int32}}' /> is assignable from <DotnetReference id='T:System.Collections.Generic.Dictionary{System.String,System.Int32}' />.</td>
+          <td><DotnetReference id='T:System.Collections.Generic.ICollection{System.Collections.Generic.KeyValuePair{System.String,System.Int32}}' /> is recognized as a generic dictionary type.</td>
         </tr>
         <tr valign='top'>
-          <td><DotnetReference id='T:System.Collections.Generic.IList{System.Collections.Generic.KeyValuePair{System.String,System.Int32}}' /></td>
+          <td><DotnetReference id='T:System.Collections.Immutable.ImmutableSortedDictionary{System.String,System.Int32}' /></td>
           <td align='center'><span role="img" aria-label="serializable">✅</span></td>
-          <td align='center'><span role="img" aria-label="not deserializable">🚫</span></td>
-          <td><DotnetReference id='T:System.Collections.Generic.IList{System.Collections.Generic.KeyValuePair{System.String,System.Int32}}' /> implements <DotnetReference id='T:System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.Int32}}' /> but is not assignable from <DotnetReference id='T:System.Collections.Generic.Dictionary{System.String,System.Int32}' />.</td>
+          <td align='center'><span role="img" aria-label="deserializable">✅</span></td>
+          <td><DotnetReference id='T:System.Collections.Immutable.ImmutableSortedDictionary{System.String,System.Int32}' /> is a generic dictionary type.</td>
         </tr>
         <tr valign='top'>
           <td><DotnetReference id='T:System.Collections.Generic.IEnumerable{System.ValueTuple{System.String,System.Int32}}' /></td>
           <td align='center'><span role="img" aria-label="not serializable">🚫</span></td>
           <td align='center'><span role="img" aria-label="not deserializable">🚫</span></td>
-          <td><DotnetReference id='T:System.Collections.Generic.IEnumerable{System.ValueTuple{System.String,System.Int32}}' /> does not implement <DotnetReference id='T:System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.Int32}}' /> and is not assignable from <DotnetReference id='T:System.Collections.Generic.Dictionary{System.String,System.Int32}' />.</td>
+          <td><DotnetReference id='T:System.Collections.Generic.IEnumerable{System.ValueTuple{System.String,System.Int32}}' /> is not recognized as a generic dictionary type.</td>
         </tr>
       </tbody>
     </table>

--- a/docs/src/pages/internals/mapping.js
+++ b/docs/src/pages/internals/mapping.js
@@ -25,7 +25,7 @@ export default () =>
         <p>The type is a one-dimensional or jagged array. Multi-dimensional arrays are currently not supported because they can’t be deserialized reliably.</p>
       </li>
       <li>
-        <p>The type is a generic collection type from <DotnetReference id='N:System.Collections.Generic' /> or <DotnetReference id='N:System.Collections.Immutable' />.</p>
+        <p>The type is an <DotnetReference id='T:System.ArraySegment`1' /> type or a generic collection type from <DotnetReference id='N:System.Collections.Generic' /> or <DotnetReference id='N:System.Collections.Immutable' />.</p>
       </li>
       <li>
         <p>The type implements <DotnetReference id='T:System.Collections.Generic.IEnumerable`1' /> (for serialization) and has a constructor with a single <DotnetReference id='T:System.Collections.Generic.IEnumerable`1' /> parameter (for deserialization).</p>

--- a/src/Chr.Avro.Binary/BinaryDeserializerBuilder.cs
+++ b/src/Chr.Avro.Binary/BinaryDeserializerBuilder.cs
@@ -481,7 +481,7 @@ namespace Chr.Avro.Serialization
         /// </summary>
         protected virtual Expression CreateIntermediateCollection(ArrayResolution resolution)
         {
-            if (resolution.Type.IsArray || resolution.Type.IsAssignableFrom(typeof(ImmutableArray<>).MakeGenericType(resolution.ItemType)))
+            if (resolution.Type.IsArray || resolution.Type.IsAssignableFrom(typeof(ArraySegment<>).MakeGenericType(resolution.ItemType)) || resolution.Type.IsAssignableFrom(typeof(ImmutableArray<>).MakeGenericType(resolution.ItemType)))
             {
                 var createBuilder = typeof(ImmutableArray)
                     .GetMethod(nameof(ImmutableArray.CreateBuilder), Type.EmptyTypes)
@@ -545,7 +545,7 @@ namespace Chr.Avro.Serialization
         /// </summary>
         protected override Expression GenerateConversion(Expression value, Type target)
         {
-            if (target.IsArray && !value.Type.IsArray)
+            if (!value.Type.IsArray && (target.IsArray || target.IsAssignableFrom(typeof(ArraySegment<>).MakeGenericType(target.GenericTypeArguments))))
             {
                 var toArray = value.Type
                     .GetMethod("ToArray", Type.EmptyTypes);

--- a/src/Chr.Avro.Binary/BinarySerializerBuilder.cs
+++ b/src/Chr.Avro.Binary/BinarySerializerBuilder.cs
@@ -975,7 +975,6 @@ namespace Chr.Avro.Serialization
             {
                 if (resolution is EnumResolution enumResolution)
                 {
-                    var source = resolution.Type;
                     var symbols = enumSchema.Symbols.ToList();
 
                     // find a match for each enum in the type:
@@ -985,12 +984,12 @@ namespace Chr.Avro.Serialization
 
                         if (index < 0)
                         {
-                            throw new UnsupportedTypeException(source, $"{source.Name} has a symbol ({symbol.Name}) that cannot be serialized.");
+                            throw new UnsupportedTypeException(resolution.Type, $"{resolution.Type.Name} has a symbol ({symbol.Name}) that cannot be serialized.");
                         }
 
                         if (symbols.FindLastIndex(s => symbol.Name.IsMatch(s)) != index)
                         {
-                            throw new UnsupportedTypeException(source, $"{source.Name} has an ambiguous symbol ({symbol.Name}).");
+                            throw new UnsupportedTypeException(resolution.Type, $"{resolution.Type.Name} has an ambiguous symbol ({symbol.Name}).");
                         }
 
                         return Expression.SwitchCase(Codec.WriteInteger(Expression.Constant((long)index), context.Stream), Expression.Constant(symbol.Value));

--- a/src/Chr.Avro/Resolution/DataContractResolver.cs
+++ b/src/Chr.Avro/Resolution/DataContractResolver.cs
@@ -69,7 +69,7 @@ namespace Chr.Avro.Resolution
                     : new DataContractEnumResolverCase() as ITypeResolverCase,
 
                 // dictionaries:
-                resolver => new DictionaryResolverCase(),
+                resolver => new DictionaryResolverCase(memberVisibility),
 
                 // enumerables:
                 resolver => new EnumerableResolverCase(memberVisibility),

--- a/src/Chr.Avro/Resolution/TypeResolution.cs
+++ b/src/Chr.Avro/Resolution/TypeResolution.cs
@@ -403,9 +403,26 @@ namespace Chr.Avro.Resolution
     /// </summary>
     public class MapResolution : TypeResolution
     {
+        private ICollection<ConstructorResolution> constructors = null!;
+
         private Type keyType = null!;
 
         private Type valueType = null!;
+
+        /// <summary>
+        /// The map constructors.
+        /// </summary>
+        public virtual ICollection<ConstructorResolution> Constructors
+        {
+            get
+            {
+                return constructors ?? throw new InvalidOperationException();
+            }
+            set
+            {
+                constructors = value ?? throw new ArgumentNullException(nameof(value), "Resolved constructor collection cannot be null.");
+            }
+        }
 
         /// <summary>
         /// The map key type.
@@ -449,11 +466,15 @@ namespace Chr.Avro.Resolution
         /// <param name="valueType">
         /// The map value type.
         /// </param>
+        /// <param name="constructors">
+        /// The map constructors.
+        /// </param>
         /// <param name="isNullable">
         /// Whether the map type can have a null value.
         /// </param>
-        public MapResolution(Type type, Type keyType, Type valueType, bool isNullable = false) : base(type, isNullable)
+        public MapResolution(Type type, Type keyType, Type valueType, ICollection<ConstructorResolution>? constructors = null, bool isNullable = false) : base(type, isNullable)
         {
+            Constructors = constructors ?? new List<ConstructorResolution>();
             KeyType = keyType;
             ValueType = valueType;
         }

--- a/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
@@ -1,4 +1,5 @@
 using Chr.Avro.Abstract;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -26,6 +27,17 @@ namespace Chr.Avro.Serialization.Tests
 
             var deserializer = DeserializerBuilder.BuildDeserializer<int[]>(schema);
             var serializer = SerializerBuilder.BuildSerializer<int[]>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value)));
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrayData))]
+        public void ArraySegmentValues(int[] value)
+        {
+            var schema = new ArraySchema(new IntSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<ArraySegment<int>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<ArraySegment<int>>(schema);
             Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value)));
         }
 

--- a/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
@@ -1,5 +1,6 @@
 using Chr.Avro.Abstract;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Xunit;
 
@@ -29,6 +30,17 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
+        [MemberData(nameof(SetData))]
+        public void HashSetValues(HashSet<string> value)
+        {
+            var schema = new ArraySchema(new StringSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<HashSet<string>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<HashSet<string>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value)));
+        }
+
+        [Theory]
         [MemberData(nameof(ArrayData))]
         public void ICollectionValues(int[] value)
         {
@@ -51,15 +63,157 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [MemberData(nameof(ISetData))]
+        [MemberData(nameof(ArrayData))]
+        public void IImmutableListValues(int[] value)
+        {
+            var schema = new ArraySchema(new IntSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<IImmutableList<int>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<IImmutableList<int>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value.ToImmutableList())));
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrayData))]
+        public void IImmutableQueueValues(int[] value)
+        {
+            var schema = new ArraySchema(new IntSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<IImmutableQueue<int>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<IImmutableQueue<int>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(ImmutableQueue.CreateRange(value))));
+        }
+
+        [Theory]
+        [MemberData(nameof(SetData))]
+        public void IImmutableSetValues(ISet<string> value)
+        {
+            var schema = new ArraySchema(new StringSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<IImmutableSet<string>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<IImmutableSet<string>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value.ToImmutableHashSet())).OrderBy(v => v));
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrayData))]
+        public void IImmutableStackValues(int[] value)
+        {
+            var schema = new ArraySchema(new IntSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<IImmutableStack<int>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<IImmutableStack<int>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(ImmutableStack.CreateRange(value))));
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrayData))]
+        public void IListValues(int[] value)
+        {
+            var schema = new ArraySchema(new IntSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<IList<int>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<IList<int>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value)));
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrayData))]
+        public void IReadOnlyCollectionValues(int[] value)
+        {
+            var schema = new ArraySchema(new IntSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<IReadOnlyCollection<int>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<IReadOnlyCollection<int>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value)));
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrayData))]
+        public void IReadOnlyListValues(int[] value)
+        {
+            var schema = new ArraySchema(new IntSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<IReadOnlyList<int>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<IReadOnlyList<int>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value)));
+        }
+
+        [Theory]
+        [MemberData(nameof(SetData))]
         public void ISetValues(ISet<string> value)
         {
-            var schema = new ArraySchema(new NullSchema());
+            var schema = new ArraySchema(new StringSchema());
 
+            var deserializer = DeserializerBuilder.BuildDeserializer<ISet<string>>(schema);
             var serializer = SerializerBuilder.BuildSerializer<ISet<string>>(schema);
-            var encoding = serializer.Serialize(value);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value)).OrderBy(v => v));
+        }
 
-            Assert.Throws<UnsupportedTypeException>(() => DeserializerBuilder.BuildDeserializer<ISet<string>>(schema));
+        [Theory]
+        [MemberData(nameof(ArrayData))]
+        public void ImmutableArrayValues(int[] value)
+        {
+            var schema = new ArraySchema(new IntSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<ImmutableArray<int>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<ImmutableArray<int>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value.ToImmutableArray())));
+        }
+
+        [Theory]
+        [MemberData(nameof(SetData))]
+        public void ImmutableHashSetValues(ISet<string> value)
+        {
+            var schema = new ArraySchema(new StringSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<ImmutableHashSet<string>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<ImmutableHashSet<string>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value.ToImmutableHashSet())).OrderBy(v => v));
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrayData))]
+        public void ImmutableListValues(int[] value)
+        {
+            var schema = new ArraySchema(new IntSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<ImmutableList<int>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<ImmutableList<int>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value.ToImmutableList())));
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrayData))]
+        public void ImmutableQueueValues(int[] value)
+        {
+            var schema = new ArraySchema(new IntSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<ImmutableQueue<int>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<ImmutableQueue<int>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(ImmutableQueue.CreateRange(value))));
+        }
+
+        [Theory]
+        [MemberData(nameof(SetData))]
+        public void ImmutableSortedSetValues(HashSet<string> value)
+        {
+            var schema = new ArraySchema(new StringSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<ImmutableSortedSet<string>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<ImmutableSortedSet<string>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value.ToImmutableSortedSet())));
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrayData))]
+        public void ImmutableStackValues(int[] value)
+        {
+            var schema = new ArraySchema(new IntSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<ImmutableStack<int>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<ImmutableStack<int>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(ImmutableStack.CreateRange(value))));
         }
 
         [Theory]
@@ -75,6 +229,17 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
+        public void LinkedListValues(int[] value)
+        {
+            var schema = new ArraySchema(new IntSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<LinkedList<int>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<LinkedList<int>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(new LinkedList<int>(value))));
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrayData))]
         public void ListValues(int[] value)
         {
             var schema = new ArraySchema(new IntSchema());
@@ -85,14 +250,36 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [MemberData(nameof(ISetData))]
-        public void HashSetValues(HashSet<string> value)
+        [MemberData(nameof(ArrayData))]
+        public void QueueValues(int[] value)
+        {
+            var schema = new ArraySchema(new IntSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<Queue<int>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<Queue<int>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(new Queue<int>(value))));
+        }
+
+        [Theory]
+        [MemberData(nameof(SetData))]
+        public void SortedSetValues(HashSet<string> value)
         {
             var schema = new ArraySchema(new StringSchema());
-            var deserializer = DeserializerBuilder.BuildDeserializer<HashSet<string>>(schema);
-            var serializer = SerializerBuilder.BuildSerializer<HashSet<string>>(schema);
 
-            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value)));
+            var deserializer = DeserializerBuilder.BuildDeserializer<SortedSet<string>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<SortedSet<string>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(new SortedSet<string>(value))));
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrayData))]
+        public void StackValues(int[] value)
+        {
+            var schema = new ArraySchema(new IntSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<Stack<int>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<Stack<int>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(new Stack<int>(value))));
         }
 
         public static IEnumerable<object[]> ArrayData => new List<object[]>
@@ -102,7 +289,7 @@ namespace Chr.Avro.Serialization.Tests
             new object[] { new int[] { -10, 10, -5, 5, 0} },
         };
 
-        public static IEnumerable<object[]> ISetData => new List<object[]>
+        public static IEnumerable<object[]> SetData => new List<object[]>
         {
             new object[] { new HashSet<string>() },
             new object[] { new HashSet<string>() { "a", "as", "aspen" } },

--- a/tests/Chr.Avro.Binary.Tests/MapSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/MapSerializationTests.cs
@@ -53,6 +53,28 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(StringKeyData))]
+        public void IImmutableDictionaryValues(Dictionary<string, double> value)
+        {
+            var schema = new MapSchema(new DoubleSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<IImmutableDictionary<string, double>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<IImmutableDictionary<string, double>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value.ToImmutableDictionary())));
+        }
+
+        [Theory]
+        [MemberData(nameof(StringKeyData))]
+        public void IReadOnlyDictionaryValues(Dictionary<string, double> value)
+        {
+            var schema = new MapSchema(new DoubleSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<IReadOnlyDictionary<string, double>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<IReadOnlyDictionary<string, double>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value)));
+        }
+
+        [Theory]
+        [MemberData(nameof(StringKeyData))]
         public void ImmutableDictionaryValues(Dictionary<string, double> value)
         {
             var schema = new MapSchema(new DoubleSchema());
@@ -60,6 +82,39 @@ namespace Chr.Avro.Serialization.Tests
             var deserializer = DeserializerBuilder.BuildDeserializer<ImmutableDictionary<string, double>>(schema);
             var serializer = SerializerBuilder.BuildSerializer<ImmutableDictionary<string, double>>(schema);
             Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value.ToImmutableDictionary())));
+        }
+
+        [Theory]
+        [MemberData(nameof(StringKeyData))]
+        public void ImmutableSortedDictionaryValues(Dictionary<string, double> value)
+        {
+            var schema = new MapSchema(new DoubleSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<ImmutableSortedDictionary<string, double>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<ImmutableSortedDictionary<string, double>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(value.ToImmutableSortedDictionary())));
+        }
+
+        [Theory]
+        [MemberData(nameof(StringKeyData))]
+        public void SortedDictionaryValues(Dictionary<string, double> value)
+        {
+            var schema = new MapSchema(new DoubleSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<SortedDictionary<string, double>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<SortedDictionary<string, double>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(new SortedDictionary<string, double>(value))));
+        }
+
+        [Theory]
+        [MemberData(nameof(StringKeyData))]
+        public void SortedListValues(Dictionary<string, double> value)
+        {
+            var schema = new MapSchema(new DoubleSchema());
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<SortedList<string, double>>(schema);
+            var serializer = SerializerBuilder.BuildSerializer<SortedList<string, double>>(schema);
+            Assert.Equal(value, deserializer.Deserialize(serializer.Serialize(new SortedList<string, double>(value))));
         }
 
         public static IEnumerable<object[]> DateTimeKeyData => new List<object[]>


### PR DESCRIPTION
From #5/#60:

- refactor codec to allow the deserializer builder to specify a collection instance
- add `FindDictionaryConstructor` to the map case to match `FindEnumerableConstructor` on the array case
- add `CreateIntermediateCollection`/`CreateIntermediateDictionary` on array/map cases
- add `System.ArraySegment<T>` and `System.Collections.Immutable` cases to `GenerateConversion` overrides
- ensure test cases cover all supported collection types