### PR TITLE
Return the default value if the Deserializer is passed isNull

### DIFF
--- a/src/Chr.Avro.Confluent/AsyncSchemaRegistryDeserializer.cs
+++ b/src/Chr.Avro.Confluent/AsyncSchemaRegistryDeserializer.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
+#nullable disable
+
 namespace Chr.Avro.Confluent
 {
     /// <summary>
@@ -67,8 +69,8 @@ namespace Chr.Avro.Confluent
         /// </exception>
         public AsyncSchemaRegistryDeserializer(
             IEnumerable<KeyValuePair<string, string>> registryConfiguration,
-            IBinaryDeserializerBuilder? deserializerBuilder = null,
-            IJsonSchemaReader? schemaReader = null,
+            IBinaryDeserializerBuilder deserializerBuilder = null,
+            IJsonSchemaReader schemaReader = null,
             TombstoneBehavior tombstoneBehavior = TombstoneBehavior.None
         ) {
             if (registryConfiguration == null)
@@ -78,7 +80,7 @@ namespace Chr.Avro.Confluent
 
             if (tombstoneBehavior != TombstoneBehavior.None && default(T) != null)
             {
-                throw new ArgumentException($"{typeof(T)} cannot represent tombstone values.", nameof(tombstoneBehavior));
+                throw new UnsupportedTypeException(typeof(T), $"{typeof(T)} cannot represent tombstone values.");
             }
 
             DeserializerBuilder = deserializerBuilder ?? new BinaryDeserializerBuilder();
@@ -112,8 +114,8 @@ namespace Chr.Avro.Confluent
         /// </exception>
         public AsyncSchemaRegistryDeserializer(
             ISchemaRegistryClient registryClient,
-            IBinaryDeserializerBuilder? deserializerBuilder = null,
-            IJsonSchemaReader? schemaReader = null,
+            IBinaryDeserializerBuilder deserializerBuilder = null,
+            IJsonSchemaReader schemaReader = null,
             TombstoneBehavior tombstoneBehavior = TombstoneBehavior.None
         ) {
             if (registryClient == null)
@@ -123,7 +125,7 @@ namespace Chr.Avro.Confluent
 
             if (tombstoneBehavior != TombstoneBehavior.None && default(T) != null)
             {
-                throw new ArgumentException($"{typeof(T)} cannot represent tombstone values.", nameof(tombstoneBehavior));
+                throw new UnsupportedTypeException(typeof(T), $"{typeof(T)} cannot represent tombstone values.");
             }
 
             DeserializerBuilder = deserializerBuilder ?? new BinaryDeserializerBuilder();
@@ -134,8 +136,6 @@ namespace Chr.Avro.Confluent
             _cache = new ConcurrentDictionary<int, Task<Func<Stream, T>>>();
             _disposeRegistryClient = false;
         }
-
-        #nullable disable annotations
 
         /// <summary>
         /// Deserialize a message. (See <see cref="IAsyncDeserializer{T}.DeserializeAsync(ReadOnlyMemory{byte}, bool, SerializationContext)" />.)
@@ -176,7 +176,7 @@ namespace Chr.Avro.Confluent
             }
         }
 
-        #nullable restore annotations
+        #nullable restore
 
         /// <summary>
         /// Disposes the deserializer, freeing up any resources.

--- a/src/Chr.Avro.Confluent/AsyncSchemaRegistryDeserializer.cs
+++ b/src/Chr.Avro.Confluent/AsyncSchemaRegistryDeserializer.cs
@@ -35,6 +35,11 @@ namespace Chr.Avro.Confluent
         /// </summary>
         public IJsonSchemaReader SchemaReader { get; }
 
+        /// <summary>
+        /// The behavior of the deserializer on tombstone records.
+        /// </summary>
+        public TombstoneBehavior TombstoneBehavior { get; }
+
         private readonly ConcurrentDictionary<int, Task<Func<Stream, T>>> _cache;
 
         private readonly bool _disposeRegistryClient;
@@ -54,22 +59,32 @@ namespace Chr.Avro.Confluent
         /// The JSON schema reader to use to convert schemas received from the registry into abstract
         /// representations. If none is provided, the default schema reader will be used.
         /// </param>
+        /// <param name="tombstoneBehavior">
+        /// The behavior of the deserializer on tombstone records.
+        /// </param>
         /// <exception cref="ArgumentNullException">
         /// Thrown when the registry configuration is null.
         /// </exception>
         public AsyncSchemaRegistryDeserializer(
             IEnumerable<KeyValuePair<string, string>> registryConfiguration,
             IBinaryDeserializerBuilder? deserializerBuilder = null,
-            IJsonSchemaReader? schemaReader = null
+            IJsonSchemaReader? schemaReader = null,
+            TombstoneBehavior tombstoneBehavior = TombstoneBehavior.None
         ) {
             if (registryConfiguration == null)
             {
                 throw new ArgumentNullException(nameof(registryConfiguration));
             }
 
+            if (tombstoneBehavior != TombstoneBehavior.None && default(T) != null)
+            {
+                throw new ArgumentException($"{typeof(T)} cannot represent tombstone values.", nameof(tombstoneBehavior));
+            }
+
             DeserializerBuilder = deserializerBuilder ?? new BinaryDeserializerBuilder();
             RegistryClient = new CachedSchemaRegistryClient(registryConfiguration);
             SchemaReader = schemaReader ?? new JsonSchemaReader();
+            TombstoneBehavior = tombstoneBehavior;
 
             _cache = new ConcurrentDictionary<int, Task<Func<Stream, T>>>();
             _disposeRegistryClient = true;
@@ -89,36 +104,52 @@ namespace Chr.Avro.Confluent
         /// The JSON schema reader used to convert schemas received from the registry into abstract
         /// representations. If none is provided, the default schema reader will be used.
         /// </param>
+        /// <param name="tombstoneBehavior">
+        /// The behavior of the deserializer on tombstone records.
+        /// </param>
         /// <exception cref="ArgumentNullException">
         /// Thrown when the registry client is null.
         /// </exception>
         public AsyncSchemaRegistryDeserializer(
             ISchemaRegistryClient registryClient,
             IBinaryDeserializerBuilder? deserializerBuilder = null,
-            IJsonSchemaReader? schemaReader = null
+            IJsonSchemaReader? schemaReader = null,
+            TombstoneBehavior tombstoneBehavior = TombstoneBehavior.None
         ) {
             if (registryClient == null)
             {
                 throw new ArgumentNullException(nameof(registryClient));
             }
 
+            if (tombstoneBehavior != TombstoneBehavior.None && default(T) != null)
+            {
+                throw new ArgumentException($"{typeof(T)} cannot represent tombstone values.", nameof(tombstoneBehavior));
+            }
+
             DeserializerBuilder = deserializerBuilder ?? new BinaryDeserializerBuilder();
             RegistryClient = registryClient;
             SchemaReader = schemaReader ?? new JsonSchemaReader();
+            TombstoneBehavior = tombstoneBehavior;
 
             _cache = new ConcurrentDictionary<int, Task<Func<Stream, T>>>();
             _disposeRegistryClient = false;
         }
+
+        #nullable disable annotations
 
         /// <summary>
         /// Deserialize a message. (See <see cref="IAsyncDeserializer{T}.DeserializeAsync(ReadOnlyMemory{byte}, bool, SerializationContext)" />.)
         /// </summary>
         public virtual async Task<T> DeserializeAsync(ReadOnlyMemory<byte> data, bool isNull, SerializationContext context)
         {
-            if (isNull)
+            if (isNull && TombstoneBehavior != TombstoneBehavior.None)
             {
-                return default(T);
+                if (context.Component == MessageComponentType.Value || TombstoneBehavior != TombstoneBehavior.Strict)
+                {
+                    return default;
+                }
             }
+
             using (var stream = new MemoryStream(data.ToArray(), false))
             {
                 var bytes = new byte[4];
@@ -144,6 +175,8 @@ namespace Chr.Avro.Confluent
                 return @delegate(stream);
             }
         }
+
+        #nullable restore annotations
 
         /// <summary>
         /// Disposes the deserializer, freeing up any resources.

--- a/src/Chr.Avro.Confluent/AsyncSchemaRegistryDeserializer.cs
+++ b/src/Chr.Avro.Confluent/AsyncSchemaRegistryDeserializer.cs
@@ -115,6 +115,10 @@ namespace Chr.Avro.Confluent
         /// </summary>
         public virtual async Task<T> DeserializeAsync(ReadOnlyMemory<byte> data, bool isNull, SerializationContext context)
         {
+            if (isNull)
+            {
+                return default(T);
+            }
             using (var stream = new MemoryStream(data.ToArray(), false))
             {
                 var bytes = new byte[4];

--- a/src/Chr.Avro.Confluent/DelegateDeserializer.cs
+++ b/src/Chr.Avro.Confluent/DelegateDeserializer.cs
@@ -1,24 +1,20 @@
 using Confluent.Kafka;
 using System;
-using System.IO;
 
 namespace Chr.Avro.Confluent
 {
     internal class DelegateDeserializer<T> : IDeserializer<T>
     {
-        private readonly Func<Stream, T> _delegate;
+        private readonly Func<byte[], bool, SerializationContext, T> _delegate;
 
-        public DelegateDeserializer(Func<Stream, T> @delegate)
+        public DelegateDeserializer(Func<byte[], bool, SerializationContext, T> @delegate)
         {
             _delegate = @delegate ?? throw new ArgumentNullException(nameof(@delegate));
         }
 
         public T Deserialize(ReadOnlySpan<byte> data, bool isNull, SerializationContext context)
         {
-            using (var stream = new MemoryStream(data.ToArray(), false))
-            {
-                return _delegate(stream);
-            }
+            return _delegate(data.ToArray(), isNull, context);
         }
     }
 }

--- a/src/Chr.Avro.Confluent/TombstoneBehavior.cs
+++ b/src/Chr.Avro.Confluent/TombstoneBehavior.cs
@@ -1,0 +1,21 @@
+namespace Chr.Avro.Confluent
+{
+    /// <summary>
+    /// Options for serializing and deserializing null record components.
+    /// </summary>
+    public enum TombstoneBehavior
+    {
+        /// <summary>
+        /// Do not support tombstones. Require that record keys and values conform to the Confluent
+        /// wire format.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Support tombstones with strict correctness requirements. Require that record keys
+        /// conform to the Confluent wire format and that any type mapped to a record value is
+        /// either a reference type or nullable value type.
+        /// </summary>
+        Strict
+    }
+}

--- a/tests/Chr.Avro.Confluent.Tests/AsyncSchemaRegistryDeserializerTests.cs
+++ b/tests/Chr.Avro.Confluent.Tests/AsyncSchemaRegistryDeserializerTests.cs
@@ -94,7 +94,7 @@ namespace Chr.Avro.Confluent.Tests
         [Fact]
         public void ThrowsOnInvalidTombstoneType()
         {
-            Assert.Throws<ArgumentException>(() => new AsyncSchemaRegistryDeserializer<int>(
+            Assert.Throws<UnsupportedTypeException>(() => new AsyncSchemaRegistryDeserializer<int>(
                 RegistryClientMock.Object,
                 tombstoneBehavior: TombstoneBehavior.Strict
             ));

--- a/tests/Chr.Avro.Confluent.Tests/AsyncSchemaRegistryDeserializerTests.cs
+++ b/tests/Chr.Avro.Confluent.Tests/AsyncSchemaRegistryDeserializerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Chr.Avro.Abstract;
 using Chr.Avro.Representation;
 using Chr.Avro.Serialization;
@@ -60,6 +61,22 @@ namespace Chr.Avro.Confluent.Tests
 
             Assert.Equal(data,
                 await deserializer.DeserializeAsync(encoding, false, context)
+            );
+        }
+
+        [Fact]
+        public async Task ReturnsDefaultObjectWhenValueIsNull()
+        {
+            var deserializer = new AsyncSchemaRegistryDeserializer<Object>(
+                RegistryClientMock.Object
+            );
+
+            Object data = null;
+            var encoding = new byte[] { };
+            var context = new SerializationContext(MessageComponentType.Value, "test_topic");
+
+            Assert.Equal(data,
+                await deserializer.DeserializeAsync(encoding, true, context)
             );
         }
 


### PR DESCRIPTION
Hi!

Looking around, I haven't seen anything on the consumer side of https://github.com/ch-robinson/dotnet-avro/issues/32, which in turn relates to https://github.com/confluentinc/confluent-kafka-dotnet/issues/905

I've been using this library to consume messages from Kafka, but found that when attempting to consume a tombstone message it throws: `InvalidDataException: "Data does not conform to the Confluent wire format."`

I figured that at least for objects, returning null in this case would make more sense, especially since we know whether or not the value is null in the calling code.