### PR TITLE
Support tombstone serialization

### DIFF
--- a/src/Chr.Avro.Confluent/AsyncSchemaRegistryDeserializer.cs
+++ b/src/Chr.Avro.Confluent/AsyncSchemaRegistryDeserializer.cs
@@ -8,8 +8,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
-#nullable disable
-
 namespace Chr.Avro.Confluent
 {
     /// <summary>
@@ -175,8 +173,6 @@ namespace Chr.Avro.Confluent
                 return @delegate(stream);
             }
         }
-
-        #nullable restore
 
         /// <summary>
         /// Disposes the deserializer, freeing up any resources.

--- a/src/Chr.Avro.Confluent/Chr.Avro.Confluent.csproj
+++ b/src/Chr.Avro.Confluent/Chr.Avro.Confluent.csproj
@@ -6,7 +6,6 @@
     <Description>Integration tools for the Confluent Kafka and Schema Registry clients</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Chr.Avro.Confluent/DelegateSerializer.cs
+++ b/src/Chr.Avro.Confluent/DelegateSerializer.cs
@@ -1,28 +1,20 @@
 using Confluent.Kafka;
 using System;
-using System.IO;
 
 namespace Chr.Avro.Confluent
 {
     internal class DelegateSerializer<T> : ISerializer<T>
     {
-        private readonly Action<T, Stream> _delegate;
+        private readonly Func<T, SerializationContext, byte[]> _delegate;
 
-        public DelegateSerializer(Action<T, Stream> @delegate)
+        public DelegateSerializer(Func<T, SerializationContext, byte[]> @delegate)
         {
             _delegate = @delegate ?? throw new ArgumentNullException(nameof(@delegate));
         }
 
         public byte[] Serialize(T data, SerializationContext context)
         {
-            var stream = new MemoryStream();
-
-            using (stream)
-            {
-                _delegate(data, stream);
-            }
-
-            return stream.ToArray();
+            return _delegate(data, context);
         }
     }
 }

--- a/src/Chr.Avro.Confluent/ProducerBuilderExtensions.cs
+++ b/src/Chr.Avro.Confluent/ProducerBuilderExtensions.cs
@@ -37,7 +37,7 @@ namespace Chr.Avro.Confluent
             this DependentProducerBuilder<TKey, TValue> producerBuilder,
             ISchemaRegistryClient registryClient,
             AutomaticRegistrationBehavior registerAutomatically = AutomaticRegistrationBehavior.Never,
-            Func<SerializationContext, string>? subjectNameBuilder = null
+            Func<SerializationContext, string> subjectNameBuilder = null
         ) => producerBuilder.SetKeySerializer(new AsyncSchemaRegistrySerializer<TKey>(
             registryClient,
             registerAutomatically: registerAutomatically,
@@ -67,7 +67,7 @@ namespace Chr.Avro.Confluent
             this ProducerBuilder<TKey, TValue> producerBuilder,
             ISchemaRegistryClient registryClient,
             AutomaticRegistrationBehavior registerAutomatically = AutomaticRegistrationBehavior.Never,
-            Func<SerializationContext, string>? subjectNameBuilder = null
+            Func<SerializationContext, string> subjectNameBuilder = null
         ) => producerBuilder.SetKeySerializer(new AsyncSchemaRegistrySerializer<TKey>(
             registryClient,
             registerAutomatically: registerAutomatically,
@@ -96,7 +96,7 @@ namespace Chr.Avro.Confluent
             this DependentProducerBuilder<TKey, TValue> producerBuilder,
             IEnumerable<KeyValuePair<string, string>> registryConfiguration,
             AutomaticRegistrationBehavior registerAutomatically = AutomaticRegistrationBehavior.Never,
-            Func<SerializationContext, string>? subjectNameBuilder = null
+            Func<SerializationContext, string> subjectNameBuilder = null
         ) => producerBuilder.SetKeySerializer(new AsyncSchemaRegistrySerializer<TKey>(
             registryConfiguration,
             registerAutomatically: registerAutomatically,
@@ -125,7 +125,7 @@ namespace Chr.Avro.Confluent
             this ProducerBuilder<TKey, TValue> producerBuilder,
             IEnumerable<KeyValuePair<string, string>> registryConfiguration,
             AutomaticRegistrationBehavior registerAutomatically = AutomaticRegistrationBehavior.Never,
-            Func<SerializationContext, string>? subjectNameBuilder = null
+            Func<SerializationContext, string> subjectNameBuilder = null
         ) => producerBuilder.SetKeySerializer(new AsyncSchemaRegistrySerializer<TKey>(
             registryConfiguration,
             registerAutomatically: registerAutomatically,
@@ -603,7 +603,7 @@ namespace Chr.Avro.Confluent
             this DependentProducerBuilder<TKey, TValue> producerBuilder,
             ISchemaRegistryClient registryClient,
             AutomaticRegistrationBehavior registerAutomatically = AutomaticRegistrationBehavior.Never,
-            Func<SerializationContext, string>? subjectNameBuilder = null
+            Func<SerializationContext, string> subjectNameBuilder = null
         ) => producerBuilder.SetValueSerializer(new AsyncSchemaRegistrySerializer<TValue>(
             registryClient,
             registerAutomatically: registerAutomatically,
@@ -633,7 +633,7 @@ namespace Chr.Avro.Confluent
             this ProducerBuilder<TKey, TValue> producerBuilder,
             ISchemaRegistryClient registryClient,
             AutomaticRegistrationBehavior registerAutomatically = AutomaticRegistrationBehavior.Never,
-            Func<SerializationContext, string>? subjectNameBuilder = null
+            Func<SerializationContext, string> subjectNameBuilder = null
         ) => producerBuilder.SetValueSerializer(new AsyncSchemaRegistrySerializer<TValue>(
             registryClient,
             registerAutomatically: registerAutomatically,
@@ -662,7 +662,7 @@ namespace Chr.Avro.Confluent
             this DependentProducerBuilder<TKey, TValue> producerBuilder,
             IEnumerable<KeyValuePair<string, string>> registryConfiguration,
             AutomaticRegistrationBehavior registerAutomatically = AutomaticRegistrationBehavior.Never,
-            Func<SerializationContext, string>? subjectNameBuilder = null
+            Func<SerializationContext, string> subjectNameBuilder = null
         ) => producerBuilder.SetValueSerializer(new AsyncSchemaRegistrySerializer<TValue>(
             registryConfiguration,
             registerAutomatically: registerAutomatically,
@@ -691,7 +691,7 @@ namespace Chr.Avro.Confluent
             this ProducerBuilder<TKey, TValue> producerBuilder,
             IEnumerable<KeyValuePair<string, string>> registryConfiguration,
             AutomaticRegistrationBehavior registerAutomatically = AutomaticRegistrationBehavior.Never,
-            Func<SerializationContext, string>? subjectNameBuilder = null
+            Func<SerializationContext, string> subjectNameBuilder = null
         ) => producerBuilder.SetValueSerializer(new AsyncSchemaRegistrySerializer<TValue>(
             registryConfiguration,
             registerAutomatically: registerAutomatically,

--- a/src/Chr.Avro.Confluent/SchemaRegistryDeserializerBuilder.cs
+++ b/src/Chr.Avro.Confluent/SchemaRegistryDeserializerBuilder.cs
@@ -8,8 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
-#nullable disable
-
 namespace Chr.Avro.Confluent
 {
     /// <summary>
@@ -25,7 +23,13 @@ namespace Chr.Avro.Confluent
         /// <param name="id">
         /// The ID of the schema that should be used to deserialize data.
         /// </param>
-        Task<IDeserializer<T>> Build<T>(int id);
+        /// <param name="tombstoneBehavior">
+        /// The behavior of the deserializer on tombstone records.
+        /// </param>
+        Task<IDeserializer<T>> Build<T>(
+            int id,
+            TombstoneBehavior tombstoneBehavior = TombstoneBehavior.None
+        );
 
         /// <summary>
         /// Builds a deserializer for a specific schema.
@@ -34,7 +38,13 @@ namespace Chr.Avro.Confluent
         /// The subject of the schema that should be used to deserialize data. The latest version
         /// of the subject will be resolved.
         /// </param>
-        Task<IDeserializer<T>> Build<T>(string subject);
+        /// <param name="tombstoneBehavior">
+        /// The behavior of the deserializer on tombstone records.
+        /// </param>
+        Task<IDeserializer<T>> Build<T>(
+            string subject,
+            TombstoneBehavior tombstoneBehavior = TombstoneBehavior.None
+        );
 
         /// <summary>
         /// Builds a deserializer for a specific schema.
@@ -45,7 +55,14 @@ namespace Chr.Avro.Confluent
         /// <param name="version">
         /// The version of the subject to be resolved.
         /// </param>
-        Task<IDeserializer<T>> Build<T>(string subject, int version);
+        /// <param name="tombstoneBehavior">
+        /// The behavior of the deserializer on tombstone records.
+        /// </param>
+        Task<IDeserializer<T>> Build<T>(
+            string subject,
+            int version,
+            TombstoneBehavior tombstoneBehavior = TombstoneBehavior.None
+        );
     }
 
     /// <summary>

--- a/tests/Chr.Avro.Confluent.Tests/AsyncSchemaRegistryDeserializerTests.cs
+++ b/tests/Chr.Avro.Confluent.Tests/AsyncSchemaRegistryDeserializerTests.cs
@@ -62,7 +62,7 @@ namespace Chr.Avro.Confluent.Tests
         }
 
         [Fact]
-        public async Task ReturnsNull()
+        public async Task ReturnsTombstone()
         {
             var deserializer = new AsyncSchemaRegistryDeserializer<object>(
                 RegistryClientMock.Object,

--- a/tests/Chr.Avro.Confluent.Tests/SchemaRegistrySerializerBuilderTests.cs
+++ b/tests/Chr.Avro.Confluent.Tests/SchemaRegistrySerializerBuilderTests.cs
@@ -1,7 +1,6 @@
 using Confluent.Kafka;
 using Confluent.SchemaRegistry;
 using Moq;
-using System.Net;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -9,46 +8,28 @@ namespace Chr.Avro.Confluent.Tests
 {
     public class SchemaRegistrySerializerBuilderTests
     {
-        protected const string TestSubject = "test_subject";
-
-        protected const int TestSubjectLatestId = 12;
-
-        protected const string TestSubjectLatestString = @"""string""";
-
-        protected const int TestSubjectLatestVersion = 4;
-
         protected readonly Mock<ISchemaRegistryClient> RegistryMock;
 
         public SchemaRegistrySerializerBuilderTests()
         {
             RegistryMock = new Mock<ISchemaRegistryClient>(MockBehavior.Strict);
-
-            RegistryMock.Setup(r => r.GetLatestSchemaAsync(TestSubject))
-                .ReturnsAsync(new Schema(
-                    TestSubject,
-                    TestSubjectLatestVersion,
-                    TestSubjectLatestId,
-                    TestSubjectLatestString
-                ));
-
-            RegistryMock.Setup(r => r.GetSchemaAsync(TestSubject, TestSubjectLatestVersion))
-                .ReturnsAsync(TestSubjectLatestString);
-
-            RegistryMock.Setup(r => r.GetSchemaAsync(TestSubjectLatestId))
-                .ReturnsAsync(TestSubjectLatestString);
-
-            RegistryMock.Setup(r => r.GetSchemaIdAsync(TestSubject, TestSubjectLatestString))
-                .ReturnsAsync(TestSubjectLatestId);
         }
 
         [Fact]
         public async Task BuildsSerializerWithSchemaId()
         {
+            var id = 6;
+            var json = @"[""null"",""int""]";
+
+            RegistryMock.Setup(r => r.GetSchemaAsync(id))
+                .ReturnsAsync(json)
+                .Verifiable();
+
             using (var builder = new SchemaRegistrySerializerBuilder(RegistryMock.Object))
             {
-                await builder.Build<string>(TestSubjectLatestId);
+                await builder.Build<int?>(id);
 
-                RegistryMock.Verify(r => r.GetSchemaAsync(TestSubjectLatestId), Times.Once());
+                RegistryMock.Verify();
                 RegistryMock.VerifyNoOtherCalls();
             }
         }
@@ -56,11 +37,20 @@ namespace Chr.Avro.Confluent.Tests
         [Fact]
         public async Task BuildsSerializerWithSchemaSubject()
         {
+            var id = 12;
+            var json = @"""string""";
+            var subject = "test-subject";
+            var version = 4;
+
+            RegistryMock.Setup(r => r.GetLatestSchemaAsync(subject))
+                .ReturnsAsync(new Schema(subject, version, id, json))
+                .Verifiable();
+
             using (var builder = new SchemaRegistrySerializerBuilder(RegistryMock.Object))
             {
-                await builder.Build<string>(TestSubject);
+                await builder.Build<string>(subject);
 
-                RegistryMock.Verify(r => r.GetLatestSchemaAsync(TestSubject), Times.Once());
+                RegistryMock.Verify();
                 RegistryMock.VerifyNoOtherCalls();
             }
         }
@@ -68,12 +58,24 @@ namespace Chr.Avro.Confluent.Tests
         [Fact]
         public async Task BuildsSerializerWithSchemaSubjectAndVersion()
         {
+            var id = 12;
+            var json = @"""string""";
+            var subject = "test-subject";
+            var version = 4;
+
+            RegistryMock.Setup(r => r.GetSchemaAsync(subject, version))
+                .ReturnsAsync(json)
+                .Verifiable();
+
+            RegistryMock.Setup(r => r.GetSchemaIdAsync(subject, json))
+                .ReturnsAsync(id)
+                .Verifiable();
+
             using (var builder = new SchemaRegistrySerializerBuilder(RegistryMock.Object))
             {
-                await builder.Build<string>(TestSubject, TestSubjectLatestVersion);
+                await builder.Build<string>(subject, version);
 
-                RegistryMock.Verify(r => r.GetSchemaAsync(TestSubject, TestSubjectLatestVersion), Times.Once());
-                RegistryMock.Verify(r => r.GetSchemaIdAsync(TestSubject, TestSubjectLatestString), Times.Once());
+                RegistryMock.Verify();
                 RegistryMock.VerifyNoOtherCalls();
             }
         }
@@ -83,11 +85,18 @@ namespace Chr.Avro.Confluent.Tests
         [InlineData(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x0c, 0x06, 0x73, 0x75, 0x70 }, "sup")]
         public async Task SerializesUsingConfluentWireFormat(byte[] encoding, string data)
         {
-            var context = new SerializationContext(MessageComponentType.Value, "test_topic");
+            var id = 12;
+            var json = @"""string""";
+
+            RegistryMock.Setup(r => r.GetSchemaAsync(id))
+                .ReturnsAsync(json)
+                .Verifiable();
+
+            var context = new SerializationContext(MessageComponentType.Value, "test-topic");
 
             using (var builder = new SchemaRegistrySerializerBuilder(RegistryMock.Object))
             {
-                var serializer = await builder.Build<string>(TestSubjectLatestId);
+                var serializer = await builder.Build<string>(id);
 
                 Assert.Equal(encoding, serializer.Serialize(data, context));
             }
@@ -96,8 +105,8 @@ namespace Chr.Avro.Confluent.Tests
         [Fact]
         public async Task SerializesWithAutoRegistrationAlways()
         {
-            var subject = "new_subject";
             var id = 40;
+            var subject = "new_subject";
 
             RegistryMock.Setup(r => r.RegisterSchemaAsync(subject, It.IsAny<string>()))
                 .ReturnsAsync(id)
@@ -116,7 +125,7 @@ namespace Chr.Avro.Confluent.Tests
         [Fact]
         public async Task SerializesWithAutoRegistrationNever()
         {
-            var subject = "new_subject";
+            var subject = "test-subject";
 
             RegistryMock.Setup(r => r.GetLatestSchemaAsync(subject))
                 .ReturnsAsync(new Schema(subject, 1, 38, "\"int\""))
@@ -126,9 +135,59 @@ namespace Chr.Avro.Confluent.Tests
             {
                 await Assert.ThrowsAsync<UnsupportedTypeException>(() => builder.Build<string>(subject, registerAutomatically: AutomaticRegistrationBehavior.Never));
 
-                RegistryMock.Verify(r => r.GetLatestSchemaAsync(subject), Times.Once());
-                RegistryMock.Verify(r => r.RegisterSchemaAsync(subject, It.IsAny<string>()), Times.Never());
+                RegistryMock.Verify();
                 RegistryMock.VerifyNoOtherCalls();
+            }
+        }
+
+        [Fact]
+        public async Task ThrowsOnInvalidTombstoneType()
+        {
+            var id = 4;
+            var json = @"""int""";
+
+            RegistryMock.Setup(r => r.GetSchemaAsync(id))
+                .ReturnsAsync(json)
+                .Verifiable();
+
+            using (var builder = new SchemaRegistrySerializerBuilder(RegistryMock.Object))
+            {
+                await Assert.ThrowsAsync<UnsupportedTypeException>(
+                    () => builder.Build<int>(id, TombstoneBehavior.Strict));
+            }
+        }
+
+        [Fact]
+        public async Task ThrowsOnNullTombstoneSchema()
+        {
+            var id = 1;
+            var json = @"""null""";
+
+            RegistryMock.Setup(r => r.GetSchemaAsync(id))
+                .ReturnsAsync(json)
+                .Verifiable();
+
+            using (var builder = new SchemaRegistrySerializerBuilder(RegistryMock.Object))
+            {
+                await Assert.ThrowsAsync<UnsupportedSchemaException>(
+                    () => builder.Build<int?>(id, TombstoneBehavior.Strict));
+            }
+        }
+
+        [Fact]
+        public async Task ThrowsOnNullableTombstoneSchema()
+        {
+            var id = 6;
+            var json = @"[""null"",""int""]";
+
+            RegistryMock.Setup(r => r.GetSchemaAsync(id))
+                .ReturnsAsync(json)
+                .Verifiable();
+
+            using (var builder = new SchemaRegistrySerializerBuilder(RegistryMock.Object))
+            {
+                await Assert.ThrowsAsync<UnsupportedSchemaException>(
+                    () => builder.Build<int?>(id, TombstoneBehavior.Strict));
             }
         }
     }


### PR DESCRIPTION
Follow-up to https://github.com/ch-robinson/dotnet-avro/pull/71.

This change disables nullable reference type checking across the Confluent project; it doesn’t make sense to include a bunch of workarounds until there are annotations on the Confluent libraries themselves.