### PR TITLE
Fix Schema Registry serde caching logic

### DIFF
--- a/tests/Chr.Avro.Confluent.Tests/AsyncSchemaRegistryDeserializerTests.cs
+++ b/tests/Chr.Avro.Confluent.Tests/AsyncSchemaRegistryDeserializerTests.cs
@@ -1,8 +1,10 @@
+using Chr.Avro.Abstract;
+using Chr.Avro.Serialization;
 using Confluent.Kafka;
 using Moq;
-using System;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -39,6 +41,31 @@ namespace Chr.Avro.Confluent.Tests
 
             RegistryClientMock
                 .Verify(c => c.GetSchemaAsync(0), Times.Once());
+        }
+
+        [Fact]
+        public async Task DoesNotCacheSchemaRegistryFailures()
+        {
+            var deserializer = new AsyncSchemaRegistryDeserializer<object>(
+                RegistryClientMock.Object
+            );
+
+            var encoding = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+            var context = new SerializationContext(MessageComponentType.Value, "test_topic");
+
+            RegistryClientMock
+                .Setup(c => c.GetSchemaAsync(0))
+                .ThrowsAsync(new HttpRequestException());
+
+            await Assert.ThrowsAsync<HttpRequestException>(() =>
+                deserializer.DeserializeAsync(encoding, encoding.Length == 0, context)
+            );
+
+            RegistryClientMock
+                .Setup(c => c.GetSchemaAsync(0))
+                .ReturnsAsync("\"null\"");
+
+            await deserializer.DeserializeAsync(encoding, encoding.Length == 0, context);
         }
 
         [Fact]


### PR DESCRIPTION
Resolves #78. Because the Schema Registry client isn't guaranteed to cache requests (even though `CachedSchemaRegistryClient` is practically always the implementation), this change doesn't rely on that behavior.

I also punted `ConcurrentDictionary` in favor of locking on a regular dictionary. The code is a little uglier, but it also ensures that the `GetOrAdd` factory isn't run twice—if a serde was being used by multiple threads, that was a possibility; see the [`GetOrAdd` remarks](https://docs.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd?view=netframework-4.8#System_Collections_Concurrent_ConcurrentDictionary_2_GetOrAdd__1__0_System_Func__0___0__1____0_).