### PR TITLE
Reference generated serde expression trees by schema-type pair

### DIFF
--- a/src/Chr.Avro.Binary/BinaryDeserializerBuilder.cs
+++ b/src/Chr.Avro.Binary/BinaryDeserializerBuilder.cs
@@ -106,9 +106,9 @@ namespace Chr.Avro.Serialization
         ConcurrentDictionary<ParameterExpression, Expression> Assignments { get; }
 
         /// <summary>
-        /// A map of types to top-level variables.
+        /// A map of schema-type pairs to top-level variables.
         /// </summary>
-        ConcurrentDictionary<Type, ParameterExpression> References { get; }
+        ConcurrentDictionary<(Schema, Type), ParameterExpression> References { get; }
 
         /// <summary>
         /// The input <see cref="System.IO.Stream" />.
@@ -369,7 +369,7 @@ namespace Chr.Avro.Serialization
         /// <summary>
         /// A map of types to top-level variables.
         /// </summary>
-        public ConcurrentDictionary<Type, ParameterExpression> References { get; }
+        public ConcurrentDictionary<(Schema, Type), ParameterExpression> References { get; }
 
         /// <summary>
         /// The input <see cref="System.IO.Stream" />.
@@ -386,7 +386,7 @@ namespace Chr.Avro.Serialization
         public BinaryDeserializerBuilderContext(ParameterExpression? stream = null)
         {
             Assignments = new ConcurrentDictionary<ParameterExpression, Expression>();
-            References = new ConcurrentDictionary<Type, ParameterExpression>();
+            References = new ConcurrentDictionary<(Schema, Type), ParameterExpression>();
             Stream = stream ?? Expression.Parameter(typeof(Stream));
         }
     }
@@ -1524,7 +1524,7 @@ namespace Chr.Avro.Serialization
                 if (resolution is RecordResolution recordResolution)
                 {
                     var parameter = Expression.Parameter(typeof(Func<>).MakeGenericType(resolution.Type));
-                    var reference = context.References.GetOrAdd(resolution.Type, parameter);
+                    var reference = context.References.GetOrAdd((recordSchema, resolution.Type), parameter);
                     result.Expression = Expression.Invoke(reference);
 
                     if (parameter == reference)

--- a/src/Chr.Avro.Binary/BinarySerializerBuilder.cs
+++ b/src/Chr.Avro.Binary/BinarySerializerBuilder.cs
@@ -108,9 +108,9 @@ namespace Chr.Avro.Serialization
         ConcurrentDictionary<ParameterExpression, Expression> Assignments { get; }
 
         /// <summary>
-        /// A map of types to top-level variables.
+        /// A map of schema-type pairs to top-level variables.
         /// </summary>
-        ConcurrentDictionary<Type, ParameterExpression> References { get; }
+        ConcurrentDictionary<(Schema, Type), ParameterExpression> References { get; }
 
         /// <summary>
         /// The output <see cref="System.IO.Stream" />.
@@ -369,7 +369,7 @@ namespace Chr.Avro.Serialization
         /// <summary>
         /// A map of types to top-level variables.
         /// </summary>
-        public ConcurrentDictionary<Type, ParameterExpression> References { get; }
+        public ConcurrentDictionary<(Schema, Type), ParameterExpression> References { get; }
 
         /// <summary>
         /// The output <see cref="System.IO.Stream" />.
@@ -386,7 +386,7 @@ namespace Chr.Avro.Serialization
         public BinarySerializerBuilderContext(ParameterExpression? stream = null)
         {
             Assignments = new ConcurrentDictionary<ParameterExpression, Expression>();
-            References = new ConcurrentDictionary<Type, ParameterExpression>();
+            References = new ConcurrentDictionary<(Schema, Type), ParameterExpression>();
             Stream = stream ?? Expression.Parameter(typeof(Stream));
         }
     }
@@ -1406,7 +1406,7 @@ namespace Chr.Avro.Serialization
                 if (resolution is RecordResolution recordResolution)
                 {
                     var parameter = Expression.Parameter(typeof(Action<>).MakeGenericType(resolution.Type));
-                    var reference = context.References.GetOrAdd(resolution.Type, parameter);
+                    var reference = context.References.GetOrAdd((recordSchema, resolution.Type), parameter);
                     result.Expression = Expression.Invoke(reference, value);
 
                     if (parameter == reference)

--- a/tests/Chr.Avro.Binary.Tests/UnionSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/UnionSerializationTests.cs
@@ -112,6 +112,45 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Fact]
+        public void PartiallySelectedTypes()
+        {
+            var schema = new UnionSchema(new[]
+            {
+                new RecordSchema(nameof(OrderCancelledEvent), new[]
+                {
+                    new RecordField("timestamp", new StringSchema())
+                }),
+                new RecordSchema(nameof(OrderCreatedEvent), new[]
+                {
+                    new RecordField("timestamp", new StringSchema()),
+                    new RecordField("total", new BytesSchema()
+                    {
+                        LogicalType = new DecimalLogicalType(5, 2)
+                    })
+                })
+            });
+
+            var codec = new BinaryCodec();
+            var resolver = new ReflectionResolver();
+
+            var deserializer = DeserializerBuilder.BuildDeserializer<OrderCreatedEvent>(schema);
+
+            var serializer = new BinarySerializerBuilder(BinarySerializerBuilder.CreateBinarySerializerCaseBuilders(codec)
+                .Prepend(builder => new OrderSerializerBuilderCase(resolver, codec, builder)))
+                .BuildSerializer<OrderEvent>(schema);
+
+            var value = new OrderCreatedEvent
+            {
+                Timestamp = DateTime.UtcNow,
+                Total = 40M
+            };
+
+            var result = deserializer.Deserialize(serializer.Serialize(value));
+            Assert.Equal(value.Timestamp, result.Timestamp);
+            Assert.Equal(value.Total, result.Total);
+        }
+
+        [Fact]
         public void SelectedTypes()
         {
             var schema = new RecordSchema(nameof(EventContainer), new[]
@@ -266,7 +305,7 @@ namespace Chr.Avro.Serialization.Tests
 
             protected override TypeResolution SelectType(TypeResolution resolution, Schema schema)
             {
-                if (!(resolution is RecordResolution recordResolution) || recordResolution.Type != typeof(IEvent))
+                if (!(resolution is RecordResolution recordResolution) || !recordResolution.Type.IsAssignableFrom(typeof(OrderEvent)))
                 {
                     throw new UnsupportedTypeException(resolution.Type);
                 }


### PR DESCRIPTION
When building serdes, references to previously generated expression trees are keyed by type. This causes incorrect behavior when mapping the same type to multiple schemas (for example, when mapping a union of multiple record schemas to a single class).

This is technically a public API change, so we’ll need to do a minor release and bump the assembly version.