### PR TITLE
Prevent out-of-range enum values from being serialized

### DIFF
--- a/src/Chr.Avro.Binary/BinarySerializerBuilder.cs
+++ b/src/Chr.Avro.Binary/BinarySerializerBuilder.cs
@@ -1001,7 +1001,12 @@ namespace Chr.Avro.Serialization
                         return Expression.SwitchCase(Codec.WriteInteger(Expression.Constant((long)index), context.Stream), Expression.Constant(symbol.Value));
                     });
 
-                    result.Expression = Expression.Switch(value, cases.ToArray());
+                    var exceptionConstructor = typeof(ArgumentOutOfRangeException)
+                        .GetConstructor(new[] { typeof(string) });
+
+                    var exception = Expression.New(exceptionConstructor, Expression.Constant("Enum value out of range."));
+
+                    result.Expression = Expression.Switch(value, Expression.Throw(exception), cases.ToArray());
                 }
                 else
                 {

--- a/tests/Chr.Avro.Binary.Tests/EnumSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/EnumSerializationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Chr.Avro.Abstract;
 using Xunit;
 
@@ -37,6 +38,10 @@ namespace Chr.Avro.Serialization.Tests
 
             schema = new EnumSchema("suit", new[] { "CLUBS", "DIAMONDS", "HEARTS" });
             Assert.Throws<UnsupportedTypeException>(() => SerializerBuilder.BuildSerializer<Suit>(schema));
+
+            schema = new EnumSchema("suit", new[] { "CLUBS", "DIAMONDS", "HEARTS", "SPADES" });
+            var serializer = SerializerBuilder.BuildSerializer<Suit>(schema);
+            Assert.Throws<ArgumentOutOfRangeException>(() => serializer.Serialize((Suit)(-1)));
         }
 
         [Theory]


### PR DESCRIPTION
Resolves #82 with a default case on generated enum serializers.