### PR TITLE
Target Confluent.SchemaRegistry 1.5.0

### DIFF
--- a/src/Chr.Avro.Confluent/Chr.Avro.Confluent.csproj
+++ b/src/Chr.Avro.Confluent/Chr.Avro.Confluent.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="[1.2.0,2)" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="[1.2.0,2)" />
+    <PackageReference Include="Confluent.Kafka" Version="[1.5.0,1.6)" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="[1.5.0,1.6)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Chr.Avro/UnsupportedSchemaException.cs
+++ b/src/Chr.Avro/UnsupportedSchemaException.cs
@@ -12,7 +12,7 @@ namespace Chr.Avro
         /// <summary>
         /// The schema that caused the exception to be thrown.
         /// </summary>
-        public Schema UnsupportedSchema { get; }
+        public Schema? UnsupportedSchema { get; }
 
         /// <summary>
         /// Creates an exception describing the error.
@@ -26,7 +26,7 @@ namespace Chr.Avro
         /// <param name="inner">
         /// An underlying error that may provide additional context.
         /// </param>
-        public UnsupportedSchemaException(Schema schema, string? message = null, Exception? inner = null) : base(message ?? $"{schema.GetType()} is not supported.", inner)
+        public UnsupportedSchemaException(Schema? schema, string? message = null, Exception? inner = null) : base(message ?? $"{schema?.GetType()?.Name ?? "The schema"} is not supported.", inner)
         {
             UnsupportedSchema = schema;
         }

--- a/src/Chr.Avro/UnsupportedTypeException.cs
+++ b/src/Chr.Avro/UnsupportedTypeException.cs
@@ -11,7 +11,7 @@ namespace Chr.Avro
         /// <summary>
         /// The type that caused the exception to be thrown.
         /// </summary>
-        public Type UnsupportedType { get; }
+        public Type? UnsupportedType { get; }
 
         /// <summary>
         /// Creates an exception describing the error.
@@ -25,7 +25,7 @@ namespace Chr.Avro
         /// <param name="inner">
         /// An underlying error that may provide additional context.
         /// </param>
-        public UnsupportedTypeException(Type type, string? message = null, Exception? inner = null) : base(message ?? $"{type.FullName} is not supported.", inner)
+        public UnsupportedTypeException(Type? type, string? message = null, Exception? inner = null) : base(message ?? $"{type?.FullName ?? "The .NET type"} is not supported.", inner)
         {
             UnsupportedType = type;
         }

--- a/tests/Chr.Avro.Confluent.Tests/AsyncSchemaRegistryDeserializerTests.cs
+++ b/tests/Chr.Avro.Confluent.Tests/AsyncSchemaRegistryDeserializerTests.cs
@@ -1,6 +1,5 @@
-using Chr.Avro.Abstract;
-using Chr.Avro.Serialization;
 using Confluent.Kafka;
+using Confluent.SchemaRegistry;
 using Moq;
 using System.IO;
 using System.Linq;
@@ -32,15 +31,15 @@ namespace Chr.Avro.Confluent.Tests
             var context = new SerializationContext(MessageComponentType.Value, "test_topic");
 
             RegistryClientMock
-                .Setup(c => c.GetSchemaAsync(0))
-                .ReturnsAsync("\"null\"");
+                .Setup(c => c.GetSchemaAsync(0, null))
+                .ReturnsAsync(new Schema("\"null\"", SchemaType.Avro));
 
             await Task.WhenAll(Enumerable.Range(0, 5).Select(i =>
                 deserializer.DeserializeAsync(encoding, encoding.Length == 0, context)
             ));
 
             RegistryClientMock
-                .Verify(c => c.GetSchemaAsync(0), Times.Once());
+                .Verify(c => c.GetSchemaAsync(0, null), Times.Once());
         }
 
         [Fact]
@@ -54,7 +53,7 @@ namespace Chr.Avro.Confluent.Tests
             var context = new SerializationContext(MessageComponentType.Value, "test_topic");
 
             RegistryClientMock
-                .Setup(c => c.GetSchemaAsync(0))
+                .Setup(c => c.GetSchemaAsync(0, null))
                 .ThrowsAsync(new HttpRequestException());
 
             await Assert.ThrowsAsync<HttpRequestException>(() =>
@@ -62,8 +61,8 @@ namespace Chr.Avro.Confluent.Tests
             );
 
             RegistryClientMock
-                .Setup(c => c.GetSchemaAsync(0))
-                .ReturnsAsync("\"null\"");
+                .Setup(c => c.GetSchemaAsync(0, null))
+                .ReturnsAsync(new Schema("\"null\"", SchemaType.Avro));
 
             await deserializer.DeserializeAsync(encoding, encoding.Length == 0, context);
         }
@@ -80,8 +79,8 @@ namespace Chr.Avro.Confluent.Tests
             var context = new SerializationContext(MessageComponentType.Value, "test_topic");
 
             RegistryClientMock
-                .Setup(c => c.GetSchemaAsync(4))
-                .ReturnsAsync("\"int\"");
+                .Setup(c => c.GetSchemaAsync(4, null))
+                .ReturnsAsync(new Schema("\"int\"", SchemaType.Avro));
 
             Assert.Equal(data,
                 await deserializer.DeserializeAsync(encoding, encoding.Length == 0, context)

--- a/tests/Chr.Avro.Confluent.Tests/AsyncSchemaRegistrySerializerTests.cs
+++ b/tests/Chr.Avro.Confluent.Tests/AsyncSchemaRegistrySerializerTests.cs
@@ -31,7 +31,7 @@ namespace Chr.Avro.Confluent.Tests
 
             RegistryClientMock
                 .Setup(c => c.GetLatestSchemaAsync(subject))
-                .ReturnsAsync(new Schema(subject, 1, 12, "\"null\""));
+                .ReturnsAsync(new RegisteredSchema(subject, 1, 12, "\"null\"", SchemaType.Avro, null));
 
             await Task.WhenAll(Enumerable.Range(0, 5).Select(i =>
                 serializer.SerializeAsync(null, context)
@@ -62,7 +62,7 @@ namespace Chr.Avro.Confluent.Tests
 
             RegistryClientMock
                 .Setup(c => c.GetLatestSchemaAsync(subject))
-                .ReturnsAsync(new Schema(subject, 1, 12, "\"null\""));
+                .ReturnsAsync(new RegisteredSchema(subject, 1, 12, "\"null\"", SchemaType.Avro, null));
 
             await serializer.SerializeAsync(null, context);
         }
@@ -82,7 +82,7 @@ namespace Chr.Avro.Confluent.Tests
 
             RegistryClientMock
                 .Setup(c => c.GetLatestSchemaAsync(subject))
-                .ReturnsAsync(new Schema(subject, 1, 4, "\"int\""));
+                .ReturnsAsync(new RegisteredSchema(subject, 1, 4, "\"int\"", SchemaType.Avro, null));
 
             Assert.Equal(encoding,
                 await serializer.SerializeAsync(data, context)
@@ -103,7 +103,7 @@ namespace Chr.Avro.Confluent.Tests
 
             RegistryClientMock
                 .Setup(c => c.GetLatestSchemaAsync(subject))
-                .ReturnsAsync(new Schema(subject, 1, 4, "\"int\""));
+                .ReturnsAsync(new RegisteredSchema(subject, 1, 4, "\"int\"", SchemaType.Avro, null));
 
             Assert.Null(await serializer.SerializeAsync(data, context));
         }
@@ -123,7 +123,7 @@ namespace Chr.Avro.Confluent.Tests
             var subject = $"{context.Topic}-value";
 
             RegistryClientMock
-                .Setup(c => c.RegisterSchemaAsync(subject, It.IsAny<string>()))
+                .Setup(c => c.RegisterSchemaAsync(subject, It.Is<Schema>(s => s.SchemaType == SchemaType.Avro)))
                 .ReturnsAsync(9);
 
             Assert.Equal(encoding, await serializer.SerializeAsync(data, context));
@@ -144,7 +144,7 @@ namespace Chr.Avro.Confluent.Tests
 
             RegistryClientMock
                 .Setup(c => c.GetLatestSchemaAsync(subject))
-                .ReturnsAsync(new Schema(subject, 1, 9, "\"string\""));
+                .ReturnsAsync(new RegisteredSchema(subject, 1, 9, "\"string\"", SchemaType.Avro, null));
 
             await Assert.ThrowsAsync<UnsupportedTypeException>(() => serializer.SerializeAsync(data, context));
         }
@@ -163,7 +163,7 @@ namespace Chr.Avro.Confluent.Tests
 
             RegistryClientMock
                 .Setup(c => c.GetLatestSchemaAsync(subject))
-                .ReturnsAsync(new Schema(subject, 1, 4, "\"int\""));
+                .ReturnsAsync(new RegisteredSchema(subject, 1, 4, "\"int\"", SchemaType.Avro, null));
 
             await Assert.ThrowsAsync<InvalidOperationException>(() =>
                 serializer.SerializeAsync(data, context)
@@ -197,7 +197,7 @@ namespace Chr.Avro.Confluent.Tests
 
             RegistryClientMock
                 .Setup(c => c.GetLatestSchemaAsync(subject))
-                .ReturnsAsync(new Schema(subject, 2, 8, "\"int\""));
+                .ReturnsAsync(new RegisteredSchema(subject, 2, 8, "\"int\"", SchemaType.Avro, null));
 
             Assert.Equal(encoding,
                 await serializer.SerializeAsync(data, context)

--- a/tests/Chr.Avro.Confluent.Tests/SchemaRegistryDeserializerBuilderTests.cs
+++ b/tests/Chr.Avro.Confluent.Tests/SchemaRegistryDeserializerBuilderTests.cs
@@ -22,8 +22,8 @@ namespace Chr.Avro.Confluent.Tests
             var id = 6;
             var json = @"[""null"",""int""]";
 
-            RegistryMock.Setup(r => r.GetSchemaAsync(id))
-                .ReturnsAsync(json)
+            RegistryMock.Setup(r => r.GetSchemaAsync(id, null))
+                .ReturnsAsync(new Schema(json, SchemaType.Avro))
                 .Verifiable();
 
             using (var builder = new SchemaRegistryDeserializerBuilder(RegistryMock.Object))
@@ -44,7 +44,7 @@ namespace Chr.Avro.Confluent.Tests
             var version = 4;
 
             RegistryMock.Setup(r => r.GetLatestSchemaAsync(subject))
-                .ReturnsAsync(new Schema(subject, version, id, json))
+                .ReturnsAsync(new RegisteredSchema(subject, version, id, json, SchemaType.Avro, null))
                 .Verifiable();
 
             using (var builder = new SchemaRegistryDeserializerBuilder(RegistryMock.Object))
@@ -64,11 +64,11 @@ namespace Chr.Avro.Confluent.Tests
             var subject = "test-subject";
             var version = 4;
 
-            RegistryMock.Setup(r => r.GetSchemaAsync(subject, version))
-                .ReturnsAsync(json)
+            RegistryMock.Setup(r => r.GetRegisteredSchemaAsync(subject, version))
+                .ReturnsAsync(new RegisteredSchema(subject, version, id, json, SchemaType.Avro, null))
                 .Verifiable();
 
-            RegistryMock.Setup(r => r.GetSchemaIdAsync(subject, json))
+            RegistryMock.Setup(r => r.GetSchemaIdAsync(subject, It.Is<Schema>(s => s.SchemaString == json)))
                 .ReturnsAsync(id)
                 .Verifiable();
 
@@ -89,8 +89,8 @@ namespace Chr.Avro.Confluent.Tests
             var id = 12;
             var json = @"""string""";
 
-            RegistryMock.Setup(r => r.GetSchemaAsync(id))
-                .ReturnsAsync(json)
+            RegistryMock.Setup(r => r.GetSchemaAsync(id, null))
+                .ReturnsAsync(new Schema(json, SchemaType.Avro))
                 .Verifiable();
 
             var context = new SerializationContext(MessageComponentType.Value, "test-topic");
@@ -109,8 +109,8 @@ namespace Chr.Avro.Confluent.Tests
             var id = 4;
             var json = @"""int""";
 
-            RegistryMock.Setup(r => r.GetSchemaAsync(id))
-                .ReturnsAsync(json)
+            RegistryMock.Setup(r => r.GetSchemaAsync(id, null))
+                .ReturnsAsync(new Schema(json, SchemaType.Avro))
                 .Verifiable();
 
             using (var builder = new SchemaRegistryDeserializerBuilder(RegistryMock.Object))
@@ -126,8 +126,8 @@ namespace Chr.Avro.Confluent.Tests
             var id = 1;
             var json = @"""null""";
 
-            RegistryMock.Setup(r => r.GetSchemaAsync(id))
-                .ReturnsAsync(json)
+            RegistryMock.Setup(r => r.GetSchemaAsync(id, null))
+                .ReturnsAsync(new Schema(json, SchemaType.Avro))
                 .Verifiable();
 
             using (var builder = new SchemaRegistryDeserializerBuilder(RegistryMock.Object))
@@ -143,8 +143,8 @@ namespace Chr.Avro.Confluent.Tests
             var id = 6;
             var json = @"[""null"",""int""]";
 
-            RegistryMock.Setup(r => r.GetSchemaAsync(id))
-                .ReturnsAsync(json)
+            RegistryMock.Setup(r => r.GetSchemaAsync(id, null))
+                .ReturnsAsync(new Schema(json, SchemaType.Avro))
                 .Verifiable();
 
             using (var builder = new SchemaRegistryDeserializerBuilder(RegistryMock.Object))
@@ -161,8 +161,8 @@ namespace Chr.Avro.Confluent.Tests
             var id = 12;
             var json = @"""string""";
 
-            RegistryMock.Setup(r => r.GetSchemaAsync(id))
-                .ReturnsAsync(json)
+            RegistryMock.Setup(r => r.GetSchemaAsync(id, null))
+                .ReturnsAsync(new Schema(json, SchemaType.Avro))
                 .Verifiable();
 
             var context = new SerializationContext(MessageComponentType.Value, "test-topic");
@@ -184,8 +184,8 @@ namespace Chr.Avro.Confluent.Tests
             var id = 12;
             var json = @"""string""";
 
-            RegistryMock.Setup(r => r.GetSchemaAsync(id))
-                .ReturnsAsync(json)
+            RegistryMock.Setup(r => r.GetSchemaAsync(id, null))
+                .ReturnsAsync(new Schema(json, SchemaType.Avro))
                 .Verifiable();
 
             var context = new SerializationContext(MessageComponentType.Value, "test-topic");

--- a/tests/Chr.Avro.Confluent.Tests/SchemaRegistrySerializerBuilderTests.cs
+++ b/tests/Chr.Avro.Confluent.Tests/SchemaRegistrySerializerBuilderTests.cs
@@ -21,8 +21,8 @@ namespace Chr.Avro.Confluent.Tests
             var id = 6;
             var json = @"[""null"",""int""]";
 
-            RegistryMock.Setup(r => r.GetSchemaAsync(id))
-                .ReturnsAsync(json)
+            RegistryMock.Setup(r => r.GetSchemaAsync(id, null))
+                .ReturnsAsync(new Schema(json, SchemaType.Avro))
                 .Verifiable();
 
             using (var builder = new SchemaRegistrySerializerBuilder(RegistryMock.Object))
@@ -43,7 +43,7 @@ namespace Chr.Avro.Confluent.Tests
             var version = 4;
 
             RegistryMock.Setup(r => r.GetLatestSchemaAsync(subject))
-                .ReturnsAsync(new Schema(subject, version, id, json))
+                .ReturnsAsync(new RegisteredSchema(subject, version, id, json, SchemaType.Avro, null))
                 .Verifiable();
 
             using (var builder = new SchemaRegistrySerializerBuilder(RegistryMock.Object))
@@ -63,11 +63,11 @@ namespace Chr.Avro.Confluent.Tests
             var subject = "test-subject";
             var version = 4;
 
-            RegistryMock.Setup(r => r.GetSchemaAsync(subject, version))
-                .ReturnsAsync(json)
+            RegistryMock.Setup(r => r.GetRegisteredSchemaAsync(subject, version))
+                .ReturnsAsync(new RegisteredSchema(subject, version, id, json, SchemaType.Avro, null))
                 .Verifiable();
 
-            RegistryMock.Setup(r => r.GetSchemaIdAsync(subject, json))
+            RegistryMock.Setup(r => r.GetSchemaIdAsync(subject, It.Is<Schema>(s => s.SchemaString == json)))
                 .ReturnsAsync(id)
                 .Verifiable();
 
@@ -88,8 +88,8 @@ namespace Chr.Avro.Confluent.Tests
             var id = 12;
             var json = @"""string""";
 
-            RegistryMock.Setup(r => r.GetSchemaAsync(id))
-                .ReturnsAsync(json)
+            RegistryMock.Setup(r => r.GetSchemaAsync(id, null))
+                .ReturnsAsync(new Schema(json, SchemaType.Avro))
                 .Verifiable();
 
             var context = new SerializationContext(MessageComponentType.Value, "test-topic");
@@ -108,7 +108,7 @@ namespace Chr.Avro.Confluent.Tests
             var id = 40;
             var subject = "new_subject";
 
-            RegistryMock.Setup(r => r.RegisterSchemaAsync(subject, It.IsAny<string>()))
+            RegistryMock.Setup(r => r.RegisterSchemaAsync(subject, It.Is<Schema>(s => s.SchemaType == SchemaType.Avro)))
                 .ReturnsAsync(id)
                 .Verifiable();
 
@@ -117,7 +117,7 @@ namespace Chr.Avro.Confluent.Tests
                 await builder.Build<string>(subject, registerAutomatically: AutomaticRegistrationBehavior.Always);
 
                 RegistryMock.Verify(r => r.GetLatestSchemaAsync(subject), Times.Never());
-                RegistryMock.Verify(r => r.RegisterSchemaAsync(subject, It.IsAny<string>()), Times.Once());
+                RegistryMock.Verify(r => r.RegisterSchemaAsync(subject, It.IsAny<Schema>()), Times.Once());
                 RegistryMock.VerifyNoOtherCalls();
             }
         }
@@ -128,7 +128,7 @@ namespace Chr.Avro.Confluent.Tests
             var subject = "test-subject";
 
             RegistryMock.Setup(r => r.GetLatestSchemaAsync(subject))
-                .ReturnsAsync(new Schema(subject, 1, 38, "\"int\""))
+                .ReturnsAsync(new RegisteredSchema(subject, 1, 38, "\"int\"", SchemaType.Avro, null))
                 .Verifiable();
 
             using (var builder = new SchemaRegistrySerializerBuilder(RegistryMock.Object))
@@ -146,8 +146,8 @@ namespace Chr.Avro.Confluent.Tests
             var id = 4;
             var json = @"""int""";
 
-            RegistryMock.Setup(r => r.GetSchemaAsync(id))
-                .ReturnsAsync(json)
+            RegistryMock.Setup(r => r.GetSchemaAsync(id, null))
+                .ReturnsAsync(new Schema(json, SchemaType.Avro))
                 .Verifiable();
 
             using (var builder = new SchemaRegistrySerializerBuilder(RegistryMock.Object))
@@ -163,8 +163,8 @@ namespace Chr.Avro.Confluent.Tests
             var id = 1;
             var json = @"""null""";
 
-            RegistryMock.Setup(r => r.GetSchemaAsync(id))
-                .ReturnsAsync(json)
+            RegistryMock.Setup(r => r.GetSchemaAsync(id, null))
+                .ReturnsAsync(new Schema(json, SchemaType.Avro))
                 .Verifiable();
 
             using (var builder = new SchemaRegistrySerializerBuilder(RegistryMock.Object))
@@ -180,8 +180,8 @@ namespace Chr.Avro.Confluent.Tests
             var id = 6;
             var json = @"[""null"",""int""]";
 
-            RegistryMock.Setup(r => r.GetSchemaAsync(id))
-                .ReturnsAsync(json)
+            RegistryMock.Setup(r => r.GetSchemaAsync(id, null))
+                .ReturnsAsync(new Schema(json, SchemaType.Avro))
                 .Verifiable();
 
             using (var builder = new SchemaRegistrySerializerBuilder(RegistryMock.Object))


### PR DESCRIPTION
- tighten range to 1.5.x to reduce possibility that we're burned by breaking changes in the future
- ensure schemas pulled from the Registry are Avro
- fix deprecations