### PR TITLE
Properly search loaded assemblies in CLI create/test verbs

### DIFF
--- a/src/Chr.Avro.Cli/ClrTypeOptions.cs
+++ b/src/Chr.Avro.Cli/ClrTypeOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace Chr.Avro.Cli
@@ -16,39 +17,62 @@ namespace Chr.Avro.Cli
     {
         public static Type ResolveType(this IClrTypeOptions options)
         {
-            foreach (var assembly in options.AssemblyNames)
-            {
-                try
+            var assemblies = options.AssemblyNames
+                .Select(name =>
                 {
-                    Assembly.Load(assembly);
-                    continue;
-                }
-                catch (FileNotFoundException)
-                {
-                    // nbd
-                }
-                catch (FileLoadException)
-                {
-                    // also nbd
-                }
+                    try
+                    {
+                        return Assembly.Load(name);
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        // nbd
+                    }
+                    catch (FileLoadException)
+                    {
+                        // also nbd
+                    }
 
-                try
-                {
-                    Assembly.LoadFrom(Path.GetFullPath(assembly));
-                }
-                catch (FileNotFoundException)
-                {
-                    throw new ProgramException(message: $"{assembly} could not be found. Make sure that you’ve provided either a recognizable name (e.g. System.Runtime) or a valid assembly path.");
-                }
-                catch (BadImageFormatException)
-                {
-                    throw new ProgramException(message: $"{assembly} is not valid. Check that the path you’re providing points to a valid assembly file.");
-                }
-            }
+                    try
+                    {
+                        return Assembly.LoadFrom(Path.GetFullPath(name));
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        throw new ProgramException(message: $"{name} could not be found. Make sure that you’ve provided either a recognizable name (e.g. System.Runtime) or a valid assembly path.");
+                    }
+                    catch (BadImageFormatException)
+                    {
+                        throw new ProgramException(message: $"{name} is not valid. Check that the path you’re providing points to a valid assembly file.");
+                    }
+                })
+                .ToDictionary(type => type.GetName());
 
             try
             {
-                return Type.GetType(options.TypeName, ignoreCase: true, throwOnError: true);
+                return Type.GetType(
+                    options.TypeName,
+                    assemblyResolver: name => assemblies.GetValueOrDefault(name),
+                    typeResolver: (assembly, name, ignoreCase) =>
+                    {
+                        if (assembly == null)
+                        {
+                            foreach (var candidate in assemblies.Values)
+                            {
+                                if (candidate.GetType(name, ignoreCase: ignoreCase, throwOnError: false) is Type result)
+                                {
+                                    return result;
+                                }
+                            }
+
+                            return null;
+                        }
+
+                        return assembly.GetType(name, ignoreCase: ignoreCase, throwOnError: false);
+                    },
+                    ignoreCase: true,
+                    throwOnError: true
+                );
             }
             catch (TypeLoadException)
             {


### PR DESCRIPTION
This fix ensures that all assemblies are searched when passed to the CLI via the `--assembly` flag.