### PR TITLE
Allow named schema aliases that match the qualified name

### DIFF
--- a/src/Chr.Avro.Json/JsonSchemaReader.cs
+++ b/src/Chr.Avro.Json/JsonSchemaReader.cs
@@ -538,6 +538,11 @@ namespace Chr.Avro.Representation
 
                     foreach (var alias in schema.Aliases)
                     {
+                        if (alias == schema.FullName)
+                        {
+                            continue;
+                        }
+
                         if (!cache.TryAdd(alias, schema))
                         {
                             throw new InvalidDataException($"Invalid fixed alias; a definition for {alias} was already read.");
@@ -696,6 +701,11 @@ namespace Chr.Avro.Representation
 
                 foreach (var alias in schema.Aliases)
                 {
+                    if (alias == schema.FullName)
+                    {
+                        continue;
+                    }
+
                     if (!cache.TryAdd(alias, schema))
                     {
                         throw new InvalidDataException($"Invalid duration alias; a definition for {alias} was already read.");
@@ -750,6 +760,11 @@ namespace Chr.Avro.Representation
 
                 foreach (var alias in schema.Aliases)
                 {
+                    if (alias == schema.FullName)
+                    {
+                        continue;
+                    }
+
                     if (!cache.TryAdd(alias, schema))
                     {
                         throw new InvalidDataException($"Invalid enum alias; a definition for {alias} was already read.");
@@ -850,6 +865,11 @@ namespace Chr.Avro.Representation
 
                 foreach (var alias in schema.Aliases)
                 {
+                    if (alias == schema.FullName)
+                    {
+                        continue;
+                    }
+
                     if (!cache.TryAdd(alias, schema))
                     {
                         throw new InvalidDataException($"Invalid fixed alias; a definition for {alias} was already read.");
@@ -1154,6 +1174,11 @@ namespace Chr.Avro.Representation
 
                 foreach (var alias in schema.Aliases)
                 {
+                    if (alias == schema.FullName)
+                    {
+                        continue;
+                    }
+
                     if (!cache.TryAdd(alias, schema))
                     {
                         throw new InvalidDataException($"Invalid record alias; a definition for {alias} was already read.");

--- a/tests/Chr.Avro.Json.Tests/JsonRepresentationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/JsonRepresentationTests.cs
@@ -73,6 +73,7 @@ namespace Chr.Avro.Representation.Tests
         public static IEnumerable<object[]> FixedSchemaRepresentations => new List<object[]>
         {
             new object[] { "{\"name\":\"Empty\",\"type\":\"fixed\",\"size\":0}" },
+            new object[] { "{\"name\":\"Empty\",\"aliases\":[\"Empty\"],\"type\":\"fixed\",\"size\":0}" },
             new object[] { "{\"name\":\"sizes.Kibibyte\",\"type\":\"fixed\",\"size\":0}" },
         };
 
@@ -98,6 +99,7 @@ namespace Chr.Avro.Representation.Tests
         public static IEnumerable<object[]> RecordSchemaRepresentations => new List<object[]>
         {
             new object[] { "{\"name\":\"Empty\",\"type\":\"record\",\"fields\":[]}" },
+            new object[] { "{\"name\":\"Empty\",\"aliases\":[\"Empty\"],\"type\":\"record\",\"fields\":[]}" },
             new object[] { "{\"name\":\"cards.Card\",\"type\":\"record\",\"fields\":[{\"name\":\"suit\",\"type\":{\"name\":\"cards.Suit\",\"type\":\"enum\",\"symbols\":[\"CLUBS\",\"DIAMONDS\",\"HEARTS\",\"SPADES\"]}},{\"name\":\"number\",\"type\":\"int\"}]}" },
             new object[] { "{\"name\":\"lists.Node\",\"type\":\"record\",\"fields\":[{\"name\":\"value\",\"type\":\"int\"},{\"name\":\"next\",\"type\":\"lists.Node\"}]}" },
         };


### PR DESCRIPTION
Currently, the JSON schema reader throws if it finds an alias that matches a name it’s already seen. This causes the reader to reject schemas that have an alias that matches the qualified name (redundant, but technically valid).

Since aliases are backed by a set, this check doesn’t need to account for duplicate aliases.