### PR TITLE
Improve CLI type loading

### DIFF
--- a/src/Chr.Avro.Cli/Chr.Avro.Cli.csproj
+++ b/src/Chr.Avro.Cli/Chr.Avro.Cli.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <ToolCommandName>dotnet-avro</ToolCommandName>
   </PropertyGroup>
 

--- a/src/Chr.Avro.Cli/ClrTypeOptions.cs
+++ b/src/Chr.Avro.Cli/ClrTypeOptions.cs
@@ -46,7 +46,8 @@ namespace Chr.Avro.Cli
                         throw new ProgramException(message: $"{name} is not valid. Check that the path you’re providing points to a valid assembly file.");
                     }
                 })
-                .ToDictionary(type => type.GetName());
+                .Append(typeof(object).Assembly) // ensure System.Runtime is included by default
+                .ToDictionary(assembly => assembly.GetName());
 
             try
             {


### PR DESCRIPTION
- target `net5.0` (3.1 can’t read 5.0 assemblies)
- include System.Runtime by default