### PR TITLE
Fix missing import in example docs

### DIFF
--- a/docs/src/pages/guides/extending.js
+++ b/docs/src/pages/guides/extending.js
@@ -121,7 +121,8 @@ public class OrderLineItem
 }`}</Highlight>
       <p>Out of the box, {projectName} won’t be able to figure out this mapping. When building a serializer, it will try to map <code>IEvent</code> to each schema in the union and fail because there are multiple matches. When building a deserializer, it will fail because <code>IEvent</code> is not a concrete type.</p>
       <p>To support this type of advanced mapping, applications can provide custom cases for the serializer and deserializer builders. The cases will match the union schema and the <code>IEvent</code> interface and choose the appropriate concrete class:</p>
-      <Highlight language='csharp'>{`using Chr.Avro.Abstract;
+      <Highlight language='csharp'>{`using Chr.Avro;
+using Chr.Avro.Abstract;
 using Chr.Avro.Resolution;
 using Chr.Avro.Serialization;
 


### PR DESCRIPTION
The exceptions used in this example come from Chr.Avro, not the other sub packages