### PR TITLE
Support mapping enum schemas to `string`

### DIFF
--- a/docs/src/pages/internals/mapping.js
+++ b/docs/src/pages/internals/mapping.js
@@ -162,7 +162,8 @@ deserializer.Deserialize(serializer.Serialize(epoch)); // 0L`}</Highlight>
         <p>When the deserializer builder can’t find a matching enumerator, <DotnetReference id='T:System.AggregateException' /> is thrown.</p>
       </li>
     </ul>
-    <p>By default, Chr.Avro also honors data contract attributes if a <DotnetReference id='T:System.Runtime.Serialization.DataContractAttribute' /> is present on the enumeration. In that case, if <DotnetReference id='P:System.Runtime.Serialization.EnumMemberAttribute.Value' /> is set on an enumerator, the custom value must match the symbol exactly. If it’s not set, the enumerator name will be compared inexactly as described above.</p>
+    <p>By default, Chr.Avro honors data contract attributes if a <DotnetReference id='T:System.Runtime.Serialization.DataContractAttribute' /> is present on the enumeration. In that case, if <DotnetReference id='P:System.Runtime.Serialization.EnumMemberAttribute.Value' /> is set on an enumerator, the custom value must match the symbol exactly. If it’s not set, the enumerator name will be compared inexactly as described above.</p>
+    <p><Highlight inline language='avro'>"enum"</Highlight> values may also be mapped to <DotnetReference id='T:System.String' />. When serializing, <DotnetReference id='T:System.String' /> values must match each symbol exactly.</p>
     <p>To change or extend this behavior, implement <DotnetReference id='T:Chr.Avro.Resolution.ITypeResolver' /> or extend one of the existing resolvers (<DotnetReference id='T:Chr.Avro.Resolution.ReflectionResolver' /> and <DotnetReference id='T:Chr.Avro.Resolution.DataContractResolver' />).</p>
     <p>Because enum types are able to be implicitly converted to and from integral types, Chr.Avro can map any integral type to <Highlight inline language='avro'>"enum"</Highlight> as well.</p>
 

--- a/src/Chr.Avro.Binary/Serialization/BinaryEnumDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryEnumDeserializerBuilderCase.cs
@@ -8,7 +8,7 @@ namespace Chr.Avro.Serialization
 
     /// <summary>
     /// Implements a <see cref="BinaryDeserializerBuilder" /> case that matches <see cref="EnumSchema" />
-    /// and attempts to map it to enum types.
+    /// and attempts to map it to any provided type.
     /// </summary>
     public class BinaryEnumDeserializerBuilderCase : EnumDeserializerBuilderCase, IBinaryDeserializerBuilderCase
     {
@@ -16,78 +16,80 @@ namespace Chr.Avro.Serialization
         /// Builds a <see cref="BinaryDeserializer{T}" /> for an <see cref="EnumSchema" />.
         /// </summary>
         /// <returns>
-        /// A successful <see cref="BinaryDeserializerBuilderCaseResult" /> if <paramref name="type" />
-        /// is an enum and <paramref name="schema" /> is an <see cref="EnumSchema" />; an
-        /// unsuccessful <see cref="BinaryDeserializerBuilderCaseResult" /> otherwise.
+        /// A successful <see cref="BinaryDeserializerBuilderCaseResult" /> if <paramref name="schema" />
+        /// is an <see cref="EnumSchema" />; an unsuccessful <see cref="BinaryDeserializerBuilderCaseResult" />
+        /// otherwise.
         /// </returns>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when <paramref name="type" /> does not have a matching member for each symbol in
-        /// <paramref name="schema" />.
+        /// Thrown when <paramref name="type" /> is an enum type without a matching member for each
+        /// symbol in <paramref name="schema" /> or when <see cref="string" /> cannot be converted
+        /// to <paramref name="type" />.
         /// </exception>
         /// <inheritdoc />
         public virtual BinaryDeserializerBuilderCaseResult BuildExpression(Type type, Schema schema, BinaryDeserializerBuilderContext context)
         {
             if (schema is EnumSchema enumSchema)
             {
+                var readInteger = typeof(BinaryReader)
+                    .GetMethod(nameof(BinaryReader.ReadInteger), Type.EmptyTypes);
+
+                Expression expression = Expression.ConvertChecked(
+                    Expression.Call(context.Reader, readInteger),
+                    typeof(int));
+
                 var underlying = Nullable.GetUnderlyingType(type) ?? type;
 
-                if (underlying.IsEnum)
-                {
-                    var readInteger = typeof(BinaryReader)
-                        .GetMethod(nameof(BinaryReader.ReadInteger), Type.EmptyTypes);
+                // enum fields will always be public static, so no need to expose binding flags:
+                var fields = underlying.GetFields(BindingFlags.Public | BindingFlags.Static);
 
-                    Expression expression = Expression.ConvertChecked(
-                        Expression.Call(context.Reader, readInteger),
-                        typeof(int));
-
-                    // enum fields will always be public static, so no need to expose binding flags:
-                    var fields = underlying.GetFields(BindingFlags.Public | BindingFlags.Static);
-
-                    // find a match for each enum in the schema:
-                    var cases = enumSchema.Symbols.Select((symbol, index) =>
-                    {
-                        var match = fields.SingleOrDefault(field => IsMatch(symbol, field.Name));
-
-                        if (match == null)
+                var cases = underlying.IsEnum
+                    ? enumSchema.Symbols
+                        .Select((symbol, index) =>
                         {
-                            throw new UnsupportedTypeException(type, $"{type} has no value that matches {symbol}.");
-                        }
+                            var match = fields.SingleOrDefault(s => IsMatch(symbol, s.Name));
 
-                        return Expression.SwitchCase(
-                            BuildConversion(Expression.Constant(Enum.Parse(underlying, match.Name)), type),
-                            Expression.Constant(index));
-                    });
+                            if (match == null)
+                            {
+                                throw new UnsupportedTypeException(type, $"{type} has no value that matches {symbol}.");
+                            }
 
-                    var position = typeof(BinaryReader)
-                        .GetProperty(nameof(BinaryReader.Index))
-                        .GetGetMethod();
+                            return Expression.SwitchCase(
+                                BuildConversion(Expression.Constant(Enum.Parse(underlying, match.Name)), type),
+                                Expression.Constant(index));
+                        })
+                    : enumSchema.Symbols
+                        .Select((symbol, index) =>
+                        {
+                            return Expression.SwitchCase(
+                                BuildConversion(Expression.Constant(symbol), type),
+                                Expression.Constant(index));
+                        });
 
-                    var exceptionConstructor = typeof(InvalidEncodingException)
-                        .GetConstructor(new[] { typeof(long), typeof(string), typeof(Exception) });
+                var position = typeof(BinaryReader)
+                    .GetProperty(nameof(BinaryReader.Index))
+                    .GetGetMethod();
 
-                    try
-                    {
-                        // generate a switch on the index:
-                        return BinaryDeserializerBuilderCaseResult.FromExpression(
-                            Expression.Switch(
-                                expression,
-                                Expression.Throw(
-                                    Expression.New(
-                                        exceptionConstructor,
-                                        Expression.Property(context.Reader, position),
-                                        Expression.Constant($"Invalid enum index; expected a value in [0-{enumSchema.Symbols.Count}). This may indicate invalid encoding earlier in the stream."),
-                                        Expression.Constant(null, typeof(Exception))),
-                                    type),
-                                cases.ToArray()));
-                    }
-                    catch (InvalidOperationException exception)
-                    {
-                        throw new UnsupportedTypeException(type, $"Failed to map {enumSchema} to {type}.", exception);
-                    }
-                }
-                else
+                var exceptionConstructor = typeof(InvalidEncodingException)
+                    .GetConstructor(new[] { typeof(long), typeof(string), typeof(Exception) });
+
+                try
                 {
-                    return BinaryDeserializerBuilderCaseResult.FromException(new UnsupportedTypeException(type, $"{nameof(BinaryEnumDeserializerBuilderCase)} can only be applied to enum types."));
+                    // generate a switch on the index:
+                    return BinaryDeserializerBuilderCaseResult.FromExpression(
+                        Expression.Switch(
+                            expression,
+                            Expression.Throw(
+                                Expression.New(
+                                    exceptionConstructor,
+                                    Expression.Property(context.Reader, position),
+                                    Expression.Constant($"Invalid enum index; expected a value in [0-{enumSchema.Symbols.Count}). This may indicate invalid encoding earlier in the stream."),
+                                    Expression.Constant(null, typeof(Exception))),
+                                type),
+                            cases.ToArray()));
+                }
+                catch (InvalidOperationException exception)
+                {
+                    throw new UnsupportedTypeException(type, $"Failed to map {enumSchema} to {type}.", exception);
                 }
             }
             else

--- a/tests/Chr.Avro.Binary.Tests/EnumSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/EnumSerializationTests.cs
@@ -48,7 +48,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Fact]
-        public void MissingValues()
+        public void MissingEnumValues()
         {
             var schema = new EnumSchema("ordinal", new[] { "NONE", "FIRST", "SECOND", "THIRD", "FOURTH", "FIFTH" });
             Assert.Throws<UnsupportedTypeException>(() => deserializerBuilder.BuildDelegate<ImplicitEnum>(schema));
@@ -65,6 +65,18 @@ namespace Chr.Avro.Serialization.Tests
             }
         }
 
+        [Fact]
+        public void MissingStringValues()
+        {
+            var schema = new EnumSchema("ordinal", new[] { "NONE", "FIRST" });
+            var serialize = serializerBuilder.BuildDelegate<string>(schema);
+
+            using (stream)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => serialize("SECOND", new BinaryWriter(stream)));
+            }
+        }
+
         [Theory]
         [InlineData(ImplicitEnum.None)]
         [InlineData(ImplicitEnum.First)]
@@ -77,6 +89,29 @@ namespace Chr.Avro.Serialization.Tests
 
             var deserialize = deserializerBuilder.BuildDelegate<ImplicitEnum?>(schema);
             var serialize = serializerBuilder.BuildDelegate<ImplicitEnum>(schema);
+
+            using (stream)
+            {
+                serialize(value, new BinaryWriter(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+
+            Assert.Equal(value, deserialize(ref reader));
+        }
+
+        [Theory]
+        [InlineData("NONE")]
+        [InlineData("FIRST")]
+        [InlineData("SECOND")]
+        [InlineData("THIRD")]
+        [InlineData("FOURTH")]
+        public void StringValues(string value)
+        {
+            var schema = new EnumSchema("ordinal", new[] { "NONE", "FIRST", "SECOND", "THIRD", "FOURTH" });
+
+            var deserialize = deserializerBuilder.BuildDelegate<string>(schema);
+            var serialize = serializerBuilder.BuildDelegate<string>(schema);
 
             using (stream)
             {


### PR DESCRIPTION
This change allows the .NET `string` type to be mapped to `"enum"` schemas. When serializing, a `string` value must match a symbol in the schema exactly or the serializer will throw `ArgumentOutOfRangeException`.

This is also a prerequisite for some other work, namely default value support, since `"enum"` is currently the only schema without a good surrogate .NET type.