### PR TITLE
Implement dynamic serdes

### DIFF
--- a/src/Chr.Avro.Binary/Serialization/BinaryArrayDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryArrayDeserializerBuilderCase.cs
@@ -45,9 +45,14 @@ namespace Chr.Avro.Serialization
         {
             if (schema is ArraySchema arraySchema)
             {
-                if (GetEnumerableType(type) is Type itemType)
+                var enumerableType = GetEnumerableType(type);
+
+                if (enumerableType is not null || type == typeof(object))
                 {
-                    var instantiateCollection = BuildIntermediateCollection(type);
+                    // support dynamic mapping:
+                    var itemType = enumerableType ?? typeof(object);
+
+                    var instantiateCollection = BuildIntermediateCollection(type, itemType);
 
                     var readInteger = typeof(BinaryReader)
                         .GetMethod(nameof(BinaryReader.ReadInteger), Type.EmptyTypes);

--- a/src/Chr.Avro.Binary/Serialization/BinaryDeserializerBuilder.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryDeserializerBuilder.cs
@@ -10,7 +10,7 @@ namespace Chr.Avro.Serialization
     /// <summary>
     /// Builds binary Avro deserializers for .NET <see cref="Type" />s.
     /// </summary>
-    public class BinaryDeserializerBuilder : IBinaryDeserializerBuilder
+    public class BinaryDeserializerBuilder : ExpressionBuilder, IBinaryDeserializerBuilder
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BinaryDeserializerBuilder" /> class
@@ -103,14 +103,14 @@ namespace Chr.Avro.Serialization
         /// <inheritdoc />
         public virtual BinaryDeserializer<T> BuildDelegate<T>(Schema schema, BinaryDeserializerBuilderContext? context = default)
         {
-            return BuildExpression<T>(schema, context).Compile();
+            return BuildDelegateExpression<T>(schema, context).Compile();
         }
 
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no case can map <typeparamref name="T" /> to <paramref name="schema" />.
         /// </exception>
         /// <inheritdoc />
-        public virtual Expression<BinaryDeserializer<T>> BuildExpression<T>(Schema schema, BinaryDeserializerBuilderContext? context = default)
+        public virtual Expression<BinaryDeserializer<T>> BuildDelegateExpression<T>(Schema schema, BinaryDeserializerBuilderContext? context = default)
         {
             context ??= new BinaryDeserializerBuilderContext();
 

--- a/src/Chr.Avro.Binary/Serialization/BinaryDeserializerBuilderContext.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryDeserializerBuilderContext.cs
@@ -46,6 +46,6 @@ namespace Chr.Avro.Serialization
         /// This is necessary for potentially recursive deserializers, such as ones built for
         /// <see cref="RecordSchema" />s.
         /// </summary>
-        public virtual IDictionary<(Schema, Type), ParameterExpression> References { get; }
+        public virtual IDictionary<(Schema Schema, Type Type), ParameterExpression> References { get; }
     }
 }

--- a/src/Chr.Avro.Binary/Serialization/BinaryEnumSerializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryEnumSerializerBuilderCase.cs
@@ -64,16 +64,20 @@ namespace Chr.Avro.Serialization
                         {
                             return Expression.SwitchCase(
                                 Expression.Call(context.Writer, writeInteger, Expression.Constant((long)index)),
-                                Expression.Constant(symbol, type));
+                                Expression.Constant(symbol));
                         });
 
                 var exceptionConstructor = typeof(ArgumentOutOfRangeException)
                     .GetConstructor(new[] { typeof(string) });
 
                 var exception = Expression.New(exceptionConstructor, Expression.Constant("Enum value out of range."));
+                var intermediate = Expression.Variable(type.IsEnum ? type : typeof(string));
 
                 return BinarySerializerBuilderCaseResult.FromExpression(
-                    Expression.Switch(value, Expression.Throw(exception), cases.ToArray()));
+                    Expression.Block(
+                        new[] { intermediate },
+                        Expression.Assign(intermediate, BuildConversion(value, intermediate.Type)),
+                        Expression.Switch(intermediate, Expression.Throw(exception), cases.ToArray())));
             }
             else
             {

--- a/src/Chr.Avro.Binary/Serialization/BinaryMapDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryMapDeserializerBuilderCase.cs
@@ -44,9 +44,15 @@ namespace Chr.Avro.Serialization
         {
             if (schema is MapSchema mapSchema)
             {
-                if (GetDictionaryTypes(type) is (Type keyType, Type valueType))
+                var dictionaryTypes = GetDictionaryTypes(type);
+
+                if (dictionaryTypes is not null || type == typeof(object))
                 {
-                    var instantiateDictionary = BuildIntermediateDictionary(type);
+                    // support dynamic mapping:
+                    var keyType = dictionaryTypes?.Key ?? typeof(string);
+                    var valueType = dictionaryTypes?.Value ?? typeof(object);
+
+                    var instantiateDictionary = BuildIntermediateDictionary(type, keyType, valueType);
 
                     var readInteger = typeof(BinaryReader)
                         .GetMethod(nameof(BinaryReader.ReadInteger), Type.EmptyTypes);

--- a/src/Chr.Avro.Binary/Serialization/BinaryRecordSerializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryRecordSerializerBuilderCase.cs
@@ -1,10 +1,14 @@
 namespace Chr.Avro.Serialization
 {
     using System;
+    using System.Dynamic;
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
     using Chr.Avro.Abstract;
+    using Microsoft.CSharp.RuntimeBinder;
+
+    using Binder = Microsoft.CSharp.RuntimeBinder.Binder;
 
     /// <summary>
     /// Implements a <see cref="BinarySerializerBuilder" /> case that matches <see cref="RecordSchema" />
@@ -79,12 +83,29 @@ namespace Chr.Avro.Serialization
                             {
                                 var match = members.SingleOrDefault(member => IsMatch(field, member.Name));
 
+                                Expression inner;
+
                                 if (match == null)
                                 {
-                                    throw new UnsupportedTypeException(type, $"{type} does not have a field or property that matches the {field.Name} field on {recordSchema.Name}.");
+                                    // if the type could be dynamic, attempt to use a dynamic getter:
+                                    if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type) || type == typeof(object))
+                                    {
+                                        var flags = CSharpBinderFlags.None;
+                                        var infos = new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) };
+                                        var binder = Binder.GetMember(flags, field.Name, type, infos);
+                                        inner = Expression.Dynamic(binder, typeof(object), value);
+                                    }
+                                    else
+                                    {
+                                        throw new UnsupportedTypeException(type, $"{type} does not have a field or property that matches the {field.Name} field on {recordSchema.Name}.");
+                                    }
+                                }
+                                else
+                                {
+                                    inner = Expression.PropertyOrField(argument, match.Name);
                                 }
 
-                                return SerializerBuilder.BuildExpression(Expression.PropertyOrField(argument, match.Name), field.Type, context);
+                                return SerializerBuilder.BuildExpression(inner, field.Type, context);
                             })
                             .ToList();
 

--- a/src/Chr.Avro.Binary/Serialization/BinarySerializerBuilder.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinarySerializerBuilder.cs
@@ -10,7 +10,7 @@ namespace Chr.Avro.Serialization
     /// <summary>
     /// Builds binary Avro serializers for .NET <see cref="Type" />s.
     /// </summary>
-    public class BinarySerializerBuilder : IBinarySerializerBuilder
+    public class BinarySerializerBuilder : ExpressionBuilder, IBinarySerializerBuilder
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BinarySerializerBuilder" /> class
@@ -103,14 +103,14 @@ namespace Chr.Avro.Serialization
         /// <inheritdoc />
         public virtual BinarySerializer<T> BuildDelegate<T>(Schema schema, BinarySerializerBuilderContext? context = default)
         {
-            return BuildExpression<T>(schema, context).Compile();
+            return BuildDelegateExpression<T>(schema, context).Compile();
         }
 
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no case can map <typeparamref name="T" /> to <paramref name="schema" />.
         /// </exception>
         /// <inheritdoc />
-        public virtual Expression<BinarySerializer<T>> BuildExpression<T>(Schema schema, BinarySerializerBuilderContext? context = default)
+        public virtual Expression<BinarySerializer<T>> BuildDelegateExpression<T>(Schema schema, BinarySerializerBuilderContext? context = default)
         {
             context ??= new BinarySerializerBuilderContext();
             var value = Expression.Parameter(typeof(T));

--- a/src/Chr.Avro.Binary/Serialization/BinarySerializerBuilderContext.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinarySerializerBuilderContext.cs
@@ -40,7 +40,7 @@ namespace Chr.Avro.Serialization
         /// is necessary for potentially recursive serializers, such as ones built for
         /// <see cref="RecordSchema" />s.
         /// </summary>
-        public virtual IDictionary<(Schema, Type), ParameterExpression> References { get; }
+        public virtual IDictionary<(Schema Schema, Type Type), ParameterExpression> References { get; }
 
         /// <summary>
         /// Gets the expression that represents the <see cref="BinaryWriter" /> argument of

--- a/src/Chr.Avro.Binary/Serialization/IBinaryDeserializerBuilder.cs
+++ b/src/Chr.Avro.Binary/Serialization/IBinaryDeserializerBuilder.cs
@@ -10,10 +10,11 @@ namespace Chr.Avro.Serialization
     public interface IBinaryDeserializerBuilder : IDeserializerBuilder<BinaryDeserializerBuilderContext>
     {
         /// <summary>
-        /// Builds a delegate that reads a binary-encoded Avro value.
+        /// Builds a delegate that reads a binary-encoded Avro value of a specific
+        /// <see cref="Type" />.
         /// </summary>
         /// <typeparam name="T">
-        /// The <see cref="Type" /> of object to be deserialized.
+        /// The <see cref="Type" /> to be deserialized.
         /// </typeparam>
         /// <param name="schema">
         /// A <see cref="Schema" /> to map to <typeparamref name="T" />.
@@ -30,7 +31,8 @@ namespace Chr.Avro.Serialization
         BinaryDeserializer<T> BuildDelegate<T>(Schema schema, BinaryDeserializerBuilderContext? context = default);
 
         /// <summary>
-        /// Builds an <see cref="Expression" /> that represents a <see cref="BinaryDeserializer{T}" />.
+        /// Builds an <see cref="Expression" /> that represents a <see cref="BinaryDeserializer{T}" />
+        /// for a specific <see cref="Type" />.
         /// </summary>
         /// <typeparam name="T">
         /// The <see cref="Type" /> of object to be deserialized.
@@ -48,6 +50,6 @@ namespace Chr.Avro.Serialization
         /// An expression representing a <see cref="BinaryDeserializer{T}" /> based on
         /// <paramref name="schema" />.
         /// </returns>
-        Expression<BinaryDeserializer<T>> BuildExpression<T>(Schema schema, BinaryDeserializerBuilderContext? context = default);
+        Expression<BinaryDeserializer<T>> BuildDelegateExpression<T>(Schema schema, BinaryDeserializerBuilderContext? context = default);
     }
 }

--- a/src/Chr.Avro.Binary/Serialization/IBinarySerializerBuilder.cs
+++ b/src/Chr.Avro.Binary/Serialization/IBinarySerializerBuilder.cs
@@ -13,7 +13,7 @@ namespace Chr.Avro.Serialization
         /// Builds a delegate that writes a binary-encoded Avro value.
         /// </summary>
         /// <typeparam name="T">
-        /// The <see cref="Type" /> of object to be serialized.
+        /// The <see cref="Type" /> to be serialized.
         /// </typeparam>
         /// <param name="schema">
         /// A <see cref="Schema" /> to map to <typeparamref name="T" />.
@@ -33,7 +33,7 @@ namespace Chr.Avro.Serialization
         /// Builds an <see cref="Expression" /> that represents a <see cref="BinarySerializer{T}" />.
         /// </summary>
         /// <typeparam name="T">
-        /// The <see cref="Type" /> of object to be serialized.
+        /// The <see cref="Type" /> to be serialized.
         /// </typeparam>
         /// <param name="schema">
         /// A <see cref="Schema" /> to map to <typeparamref name="T" />.
@@ -48,6 +48,6 @@ namespace Chr.Avro.Serialization
         /// An expression representing a <see cref="BinarySerializer{T}" /> based on
         /// <paramref name="schema" />.
         /// </returns>
-        Expression<BinarySerializer<T>> BuildExpression<T>(Schema schema, BinarySerializerBuilderContext? context = default);
+        Expression<BinarySerializer<T>> BuildDelegateExpression<T>(Schema schema, BinarySerializerBuilderContext? context = default);
     }
 }

--- a/src/Chr.Avro.Confluent/Confluent/AsyncSchemaRegistryDeserializer.cs
+++ b/src/Chr.Avro.Confluent/Confluent/AsyncSchemaRegistryDeserializer.cs
@@ -243,7 +243,7 @@ namespace Chr.Avro.Confluent
         {
             // the reader, as a ref struct, can't be declared within an async or lambda function, so
             // build it into the delegate:
-            var inner = DeserializerBuilder.BuildExpression<T>(schema);
+            var inner = DeserializerBuilder.BuildDelegateExpression<T>(schema);
             var memory = Expression.Parameter(typeof(ReadOnlyMemory<byte>));
 
             var getSpan = memory.Type

--- a/src/Chr.Avro.Confluent/Confluent/AsyncSchemaRegistrySerializer.cs
+++ b/src/Chr.Avro.Confluent/Confluent/AsyncSchemaRegistrySerializer.cs
@@ -316,7 +316,7 @@ namespace Chr.Avro.Confluent
                 Array.Reverse(header, 1, 4);
             }
 
-            var inner = SerializerBuilder.BuildExpression<T>(schema);
+            var inner = SerializerBuilder.BuildDelegateExpression<T>(schema);
 
             var streamConstructor = typeof(MemoryStream)
                 .GetConstructor(Type.EmptyTypes);

--- a/src/Chr.Avro.Json/Serialization/IJsonDeserializerBuilder.cs
+++ b/src/Chr.Avro.Json/Serialization/IJsonDeserializerBuilder.cs
@@ -30,7 +30,8 @@ namespace Chr.Avro.Serialization
         JsonDeserializer<T> BuildDelegate<T>(Schema schema, JsonDeserializerBuilderContext? context = default);
 
         /// <summary>
-        /// Builds an <see cref="Expression" /> that represents a <see cref="JsonDeserializer{T}" />.
+        /// Builds an <see cref="Expression" /> that represents a <see cref="JsonDeserializer{T}" />
+        /// for a specific <see cref="Type" />.
         /// </summary>
         /// <typeparam name="T">
         /// The <see cref="Type" /> of object to be deserialized.
@@ -48,6 +49,6 @@ namespace Chr.Avro.Serialization
         /// An expression representing a <see cref="JsonDeserializer{T}" /> based on
         /// <paramref name="schema" />.
         /// </returns>
-        Expression<JsonDeserializer<T>> BuildExpression<T>(Schema schema, JsonDeserializerBuilderContext? context = default);
+        Expression<JsonDeserializer<T>> BuildDelegateExpression<T>(Schema schema, JsonDeserializerBuilderContext? context = default);
     }
 }

--- a/src/Chr.Avro.Json/Serialization/IJsonSerializerBuilder.cs
+++ b/src/Chr.Avro.Json/Serialization/IJsonSerializerBuilder.cs
@@ -48,6 +48,6 @@ namespace Chr.Avro.Serialization
         /// An expression representing a <see cref="JsonSerializer{T}" /> based on
         /// <paramref name="schema" />.
         /// </returns>
-        Expression<JsonSerializer<T>> BuildExpression<T>(Schema schema, JsonSerializerBuilderContext? context = default);
+        Expression<JsonSerializer<T>> BuildDelegateExpression<T>(Schema schema, JsonSerializerBuilderContext? context = default);
     }
 }

--- a/src/Chr.Avro.Json/Serialization/JsonArrayDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonArrayDeserializerBuilderCase.cs
@@ -46,9 +46,14 @@ namespace Chr.Avro.Serialization
         {
             if (schema is ArraySchema arraySchema)
             {
-                if (GetEnumerableType(type) is Type itemType)
+                var enumerableType = GetEnumerableType(type);
+
+                if (enumerableType is not null || type == typeof(object))
                 {
-                    var instantiateCollection = BuildIntermediateCollection(type);
+                    // support dynamic mapping:
+                    var itemType = enumerableType ?? typeof(object);
+
+                    var instantiateCollection = BuildIntermediateCollection(type, itemType);
 
                     var readItem = DeserializerBuilder
                         .BuildExpression(itemType, arraySchema.Item, context);

--- a/src/Chr.Avro.Json/Serialization/JsonDeserializerBuilder.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonDeserializerBuilder.cs
@@ -11,7 +11,7 @@ namespace Chr.Avro.Serialization
     /// <summary>
     /// Builds JSON Avro deserializers for .NET <see cref="Type" />s.
     /// </summary>
-    public class JsonDeserializerBuilder : IJsonDeserializerBuilder
+    public class JsonDeserializerBuilder : ExpressionBuilder, IJsonDeserializerBuilder
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonDeserializerBuilder" /> class
@@ -104,14 +104,14 @@ namespace Chr.Avro.Serialization
         /// <inheritdoc />
         public virtual JsonDeserializer<T> BuildDelegate<T>(Schema schema, JsonDeserializerBuilderContext? context = default)
         {
-            return BuildExpression<T>(schema, context).Compile();
+            return BuildDelegateExpression<T>(schema, context).Compile();
         }
 
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no case can map <typeparamref name="T" /> to <paramref name="schema" />.
         /// </exception>
         /// <inheritdoc />
-        public Expression<JsonDeserializer<T>> BuildExpression<T>(Schema schema, JsonDeserializerBuilderContext? context = default)
+        public virtual Expression<JsonDeserializer<T>> BuildDelegateExpression<T>(Schema schema, JsonDeserializerBuilderContext? context = default)
         {
             context ??= new JsonDeserializerBuilderContext();
 
@@ -126,11 +126,7 @@ namespace Chr.Avro.Serialization
                     context.Assignments.Keys,
                     context.Assignments
                         .Select(assignment => (Expression)Expression.Assign(assignment.Key, assignment.Value))
-                        .Concat(new[]
-                        {
-                            Expression.Call(context.Reader, read),
-                            root,
-                        })),
+                        .Concat(new[] { Expression.Call(context.Reader, read), root })),
                 new[] { context.Reader });
         }
 

--- a/src/Chr.Avro.Json/Serialization/JsonDeserializerBuilderContext.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonDeserializerBuilderContext.cs
@@ -47,6 +47,6 @@ namespace Chr.Avro.Serialization
         /// This is necessary for potentially recursive deserializers, such as ones built for
         /// <see cref="RecordSchema" />s.
         /// </summary>
-        public virtual IDictionary<(Schema, Type), ParameterExpression> References { get; }
+        public virtual IDictionary<(Schema Schema, Type Type), ParameterExpression> References { get; }
     }
 }

--- a/src/Chr.Avro.Json/Serialization/JsonMapDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonMapDeserializerBuilderCase.cs
@@ -45,9 +45,15 @@ namespace Chr.Avro.Serialization
         {
             if (schema is MapSchema mapSchema)
             {
-                if (GetDictionaryTypes(type) is (Type keyType, Type valueType))
+                var dictionaryTypes = GetDictionaryTypes(type);
+
+                if (dictionaryTypes is not null || type == typeof(object))
                 {
-                    var instantiateDictionary = BuildIntermediateDictionary(type);
+                    // support dynamic mapping:
+                    var keyType = dictionaryTypes?.Key ?? typeof(string);
+                    var valueType = dictionaryTypes?.Value ?? typeof(object);
+
+                    var instantiateDictionary = BuildIntermediateDictionary(type, keyType, valueType);
 
                     var readKey = DeserializerBuilder
                         .BuildExpression(keyType, new StringSchema(), context);

--- a/src/Chr.Avro.Json/Serialization/JsonRecordDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonRecordDeserializerBuilderCase.cs
@@ -1,11 +1,15 @@
 namespace Chr.Avro.Serialization
 {
     using System;
+    using System.Dynamic;
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
     using System.Text.Json;
     using Chr.Avro.Abstract;
+    using Microsoft.CSharp.RuntimeBinder;
+
+    using Binder = Microsoft.CSharp.RuntimeBinder.Binder;
 
     /// <summary>
     /// Implements a <see cref="JsonDeserializerBuilder" /> case that matches <see cref="RecordSchema" />
@@ -158,7 +162,12 @@ namespace Chr.Avro.Serialization
                         else
                         {
                             var members = underlying.GetMembers(MemberVisibility);
-                            var value = Expression.Parameter(underlying);
+
+                            // support dynamic deserialization:
+                            var value = Expression.Parameter(
+                                underlying.IsAssignableFrom(typeof(ExpandoObject))
+                                    ? typeof(ExpandoObject)
+                                    : underlying);
 
                             expression = Expression.Block(
                                 new[] { value },
@@ -192,27 +201,43 @@ namespace Chr.Avro.Serialization
                                                 .Select(field =>
                                                 {
                                                     var match = members.SingleOrDefault(member => IsMatch(field, member.Name));
-                                                    var schema = match == null ? CreateSurrogateSchema(field.Type) : field.Type;
-                                                    var type = match == null ? GetSurrogateType(schema) : match switch
-                                                    {
-                                                        FieldInfo fieldMatch => fieldMatch.FieldType,
-                                                        PropertyInfo propertyMatch => propertyMatch.PropertyType,
-                                                        MemberInfo unknown => throw new InvalidOperationException($"Unsupported {typeof(MemberInfo)} {unknown.GetType()}.")
-                                                    };
 
-                                                    // always read to advance the stream:
-                                                    Expression expression = Expression.Block(
-                                                        Expression.Call(context.Reader, read),
-                                                        DeserializerBuilder.BuildExpression(type, schema, context));
+                                                    Expression expression;
 
-                                                    if (match != null)
+                                                    if (match == null)
                                                     {
-                                                        // and assign if a field matches:
-                                                        expression = Expression.Assign(Expression.PropertyOrField(value, match.Name), expression);
+                                                        // always deserialize fields to advance the reader:
+                                                        expression = DeserializerBuilder.BuildExpression(typeof(object), field.Type, context);
+
+                                                        // fall back to a dynamic setter if the value supports it:
+                                                        if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(value.Type))
+                                                        {
+                                                            var flags = CSharpBinderFlags.None;
+                                                            var infos = new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) };
+                                                            var binder = Binder.SetMember(flags, field.Name, value.Type, infos);
+                                                            expression = Expression.Dynamic(binder, typeof(void), value, expression);
+                                                        }
+                                                    }
+                                                    else
+                                                    {
+                                                        expression = Expression.Assign(
+                                                            Expression.PropertyOrField(value, match.Name),
+                                                            DeserializerBuilder.BuildExpression(
+                                                                match switch
+                                                                {
+                                                                    FieldInfo fieldMatch => fieldMatch.FieldType,
+                                                                    PropertyInfo propertyMatch => propertyMatch.PropertyType,
+                                                                    MemberInfo unknown => throw new InvalidOperationException($"Record fields can only be mapped to fields and properties.")
+                                                                },
+                                                                field.Type,
+                                                                context));
                                                     }
 
                                                     return Expression.SwitchCase(
-                                                        Expression.Block(expression, Expression.Empty()),
+                                                        Expression.Block(
+                                                            Expression.Call(context.Reader, read),
+                                                            expression,
+                                                            Expression.Empty()),
                                                         Expression.Constant(field.Name));
                                                 })
                                                 .ToArray())),
@@ -241,27 +266,6 @@ namespace Chr.Avro.Serialization
             {
                 return JsonDeserializerBuilderCaseResult.FromException(new UnsupportedSchemaException(schema, $"{nameof(JsonRecordDeserializerBuilderCase)} can only be applied to {nameof(RecordSchema)}s."));
             }
-        }
-
-        /// <summary>
-        /// Creates a schema that can be used to deserialize missing record fields.
-        /// </summary>
-        /// <param name="schema">
-        /// The schema to alter.
-        /// </param>
-        /// <returns>
-        /// A schema that can be mapped to a surrogate type.
-        /// </returns>
-        protected virtual Schema CreateSurrogateSchema(Schema schema)
-        {
-            return schema switch
-            {
-                ArraySchema array => new ArraySchema(CreateSurrogateSchema(array.Item)),
-                EnumSchema _ => new StringSchema(),
-                MapSchema map => new MapSchema(CreateSurrogateSchema(map.Value)),
-                UnionSchema union => new UnionSchema(union.Schemas.Select(CreateSurrogateSchema).ToList()),
-                _ => schema
-            };
         }
     }
 }

--- a/src/Chr.Avro.Json/Serialization/JsonSerializerBuilder.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonSerializerBuilder.cs
@@ -11,7 +11,7 @@ namespace Chr.Avro.Serialization
     /// <summary>
     /// Builds JSON Avro serializers for .NET <see cref="Type" />s.
     /// </summary>
-    public class JsonSerializerBuilder : IJsonSerializerBuilder
+    public class JsonSerializerBuilder : ExpressionBuilder, IJsonSerializerBuilder
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonSerializerBuilder" /> class
@@ -104,14 +104,14 @@ namespace Chr.Avro.Serialization
         /// <inheritdoc />
         public virtual JsonSerializer<T> BuildDelegate<T>(Schema schema, JsonSerializerBuilderContext? context = default)
         {
-            return BuildExpression<T>(schema).Compile();
+            return BuildDelegateExpression<T>(schema).Compile();
         }
 
         /// <exception cref="UnsupportedTypeException">
         /// Thrown when no case can map <typeparamref name="T" /> to <paramref name="schema" />.
         /// </exception>
         /// <inheritdoc />
-        public virtual Expression<JsonSerializer<T>> BuildExpression<T>(Schema schema, JsonSerializerBuilderContext? context = default)
+        public virtual Expression<JsonSerializer<T>> BuildDelegateExpression<T>(Schema schema, JsonSerializerBuilderContext? context = default)
         {
             context ??= new JsonSerializerBuilderContext();
             var value = Expression.Parameter(typeof(T));

--- a/src/Chr.Avro.Json/Serialization/JsonSerializerBuilderContext.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonSerializerBuilderContext.cs
@@ -41,7 +41,7 @@ namespace Chr.Avro.Serialization
         /// is necessary for potentially recursive serializers, such as ones built for
         /// <see cref="RecordSchema" />s.
         /// </summary>
-        public virtual IDictionary<(Schema, Type), ParameterExpression> References { get; }
+        public virtual IDictionary<(Schema Schema, Type Type), ParameterExpression> References { get; }
 
         /// <summary>
         /// Gets the expression that represents the <see cref="Utf8JsonWriter" /> argument of

--- a/src/Chr.Avro/Chr.Avro.csproj
+++ b/src/Chr.Avro/Chr.Avro.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Chr.Avro/Serialization/ArraySerializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/ArraySerializerBuilderCase.cs
@@ -2,14 +2,85 @@ namespace Chr.Avro.Serialization
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
     using Chr.Avro.Abstract;
     using Chr.Avro.Infrastructure;
+    using Microsoft.CSharp.RuntimeBinder;
 
     /// <summary>
     /// Provides a base implementation for serializer builder cases that match <see cref="ArraySchema" />.
     /// </summary>
     public abstract class ArraySerializerBuilderCase : SerializerBuilderCase
     {
+        /// <inheritdoc />
+        protected override Expression BuildDynamicConversion(Expression value, Type target)
+        {
+            if (target.GetEnumerableType() is Type itemType)
+            {
+                var collectionType = typeof(ICollection<>).MakeGenericType(itemType);
+                var enumerableType = typeof(IEnumerable<>).MakeGenericType(itemType);
+
+                var toList = typeof(Enumerable)
+                    .GetMethod(nameof(Enumerable.ToList))
+                    .MakeGenericMethod(itemType);
+
+                return Expression.Convert(
+                    Expression.Call(
+                        null,
+                        toList,
+                        Expression.Convert(
+                            Expression.Dynamic(
+                                Binder.InvokeMember(
+                                    CSharpBinderFlags.None,
+                                    nameof(Cast),
+                                    null,
+                                    typeof(ArraySerializerBuilderCase),
+                                    new[]
+                                    {
+                                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, null),
+                                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                                    }),
+                                typeof(object),
+                                Expression.Constant(typeof(ArraySerializerBuilderCase)),
+                                value),
+                            enumerableType)),
+                    collectionType);
+            }
+            else
+            {
+                return base.BuildDynamicConversion(value, target);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override Expression BuildStaticConversion(Expression value, Type target)
+        {
+            if (target.GetEnumerableType() is Type itemType)
+            {
+                var collectionType = typeof(ICollection<>).MakeGenericType(itemType);
+                var enumerableType = typeof(IEnumerable<>).MakeGenericType(itemType);
+
+                if (!collectionType.IsAssignableFrom(value.Type))
+                {
+                    var toList = typeof(Enumerable)
+                        .GetMethod(nameof(Enumerable.ToList))
+                        .MakeGenericMethod(itemType);
+
+                    value = Expression.Call(
+                        null,
+                        toList,
+                        base.BuildStaticConversion(value, enumerableType));
+                }
+
+                return base.BuildStaticConversion(value, collectionType);
+            }
+            else
+            {
+                return base.BuildStaticConversion(value, target);
+            }
+        }
+
         /// <summary>
         /// Gets the item <see cref="Type" /> of an enumerable <see cref="Type" />.
         /// </summary>
@@ -23,6 +94,23 @@ namespace Chr.Avro.Serialization
         protected virtual Type? GetEnumerableType(Type type)
         {
             return type.GetEnumerableType();
+        }
+
+        /// <summary>
+        /// Creates an enumerable that ensures items from the source enumerable are boxed.
+        /// </summary>
+        /// <param name="enumerable">
+        /// An enumerable of any type.
+        /// </param>
+        /// <returns>
+        /// An enumerable whose items are guaranteed to be boxed.
+        /// </returns>
+        private static IEnumerable<object?> Cast<T>(IEnumerable<T> enumerable)
+        {
+            foreach (object? item in enumerable)
+            {
+                yield return item;
+            }
         }
     }
 }

--- a/src/Chr.Avro/Serialization/BytesDeserializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/BytesDeserializerBuilderCase.cs
@@ -15,7 +15,7 @@ namespace Chr.Avro.Serialization
         /// used.
         /// </remarks>
         /// <inheritdoc />
-        protected override Expression BuildConversion(Expression value, Type target)
+        protected override Expression BuildStaticConversion(Expression value, Type target)
         {
             if (target == typeof(Guid) || target == typeof(Guid?))
             {
@@ -25,7 +25,7 @@ namespace Chr.Avro.Serialization
                 value = Expression.New(guidConstructor, value);
             }
 
-            return base.BuildConversion(value, target);
+            return base.BuildStaticConversion(value, target);
         }
     }
 }

--- a/src/Chr.Avro/Serialization/BytesSerializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/BytesSerializerBuilderCase.cs
@@ -15,7 +15,7 @@ namespace Chr.Avro.Serialization
         /// used.
         /// </remarks>
         /// <inheritdoc />
-        protected override Expression BuildConversion(Expression value, Type intermediate)
+        protected override Expression BuildStaticConversion(Expression value, Type intermediate)
         {
             if (value.Type == typeof(Guid))
             {
@@ -25,7 +25,7 @@ namespace Chr.Avro.Serialization
                 value = Expression.Call(value, convertGuid);
             }
 
-            return base.BuildConversion(value, intermediate);
+            return base.BuildStaticConversion(value, intermediate);
         }
     }
 }

--- a/src/Chr.Avro/Serialization/DeserializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/DeserializerBuilderCase.cs
@@ -1,44 +1,9 @@
 namespace Chr.Avro.Serialization
 {
-    using System;
-    using System.Linq.Expressions;
-
     /// <summary>
     /// Provides a base deserializer builder case implementation.
     /// </summary>
-    public abstract class DeserializerBuilderCase
+    public abstract class DeserializerBuilderCase : ExpressionBuilder
     {
-        /// <summary>
-        /// Builds an <see cref="Expression" /> representing a conversion from an intermediate
-        /// <see cref="Type" /> to a target <see cref="Type" />.
-        /// </summary>
-        /// <remarks>
-        /// See the remarks for <see cref="Expression.ConvertChecked(Expression, Type)" />.
-        /// </remarks>
-        /// <param name="value">
-        /// An <see cref="Expression" /> representing an intermediately typed value (a value used
-        /// by a generated deserializer internally prior to converting and returning).
-        /// </param>
-        /// <param name="target">
-        /// A <see cref="Type" /> to convert <paramref name="value" /> to (the return type of the
-        /// generated deserializer).
-        /// </param>
-        /// <returns>
-        /// An <see cref="Expression" /> representing the conversion of <paramref name="value" />
-        /// to <paramref name="target" />. If <paramref name="value" /> already has type
-        /// <paramref name="target" />, <paramref name="value" /> is returned as-is.
-        /// </returns>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown when no conversion to <paramref name="target" /> can be built.
-        /// </exception>
-        protected virtual Expression BuildConversion(Expression value, Type target)
-        {
-            if (value.Type == target)
-            {
-                return value;
-            }
-
-            return Expression.ConvertChecked(value, target);
-        }
     }
 }

--- a/src/Chr.Avro/Serialization/EnumSerializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/EnumSerializerBuilderCase.cs
@@ -1,6 +1,7 @@
 namespace Chr.Avro.Serialization
 {
     using System;
+    using System.Linq.Expressions;
     using System.Text.RegularExpressions;
     using Chr.Avro.Abstract;
 
@@ -10,6 +11,41 @@ namespace Chr.Avro.Serialization
     public abstract class EnumSerializerBuilderCase : SerializerBuilderCase
     {
         private static readonly Regex FuzzyCharacters = new (@"[^A-Za-z0-9]");
+
+        /// <remarks>
+        /// This override includes additional conditions to handle conversions to types that can be
+        /// idiomatically represented as strings. If none match, the base implementation is used.
+        /// </remarks>
+        /// <inheritdoc />
+        protected override Expression BuildDynamicConversion(Expression value, Type target)
+        {
+            if (target == typeof(string))
+            {
+                var getType = typeof(object)
+                    .GetMethod(nameof(object.GetType));
+
+                var isEnum = typeof(Type)
+                    .GetProperty(nameof(Type.IsEnum));
+
+                var toString = typeof(object)
+                    .GetMethod(nameof(object.ToString), Type.EmptyTypes);
+
+                var intermediate = Expression.Variable(value.Type);
+                var result = Expression.Label(target);
+
+                return Expression.Block(
+                    new[] { intermediate },
+                    Expression.Assign(intermediate, value),
+                    Expression.IfThen(
+                        Expression.Property(Expression.Call(intermediate, getType), isEnum),
+                        Expression.Return(result, Expression.Call(intermediate, toString))),
+                    Expression.Label(result, base.BuildDynamicConversion(intermediate, target)));
+            }
+            else
+            {
+                return base.BuildDynamicConversion(value, target);
+            }
+        }
 
         /// <summary>
         /// Determines whether an enum symbol matches another name.

--- a/src/Chr.Avro/Serialization/ExpressionBuilder.cs
+++ b/src/Chr.Avro/Serialization/ExpressionBuilder.cs
@@ -1,0 +1,105 @@
+namespace Chr.Avro.Serialization
+{
+    using System;
+    using System.Linq.Expressions;
+    using Microsoft.CSharp.RuntimeBinder;
+
+    /// <summary>
+    /// Provides a shared base for classes that build <see cref="Expression" />s.
+    /// </summary>
+    public abstract class ExpressionBuilder
+    {
+        /// <summary>
+        /// Builds an <see cref="Expression" /> representing a conversion to a target
+        /// <see cref="Type" />.
+        /// </summary>
+        /// <remarks>
+        /// Inheriting classes should override <see cref="BuildDynamicConversion" /> and
+        /// <see cref="BuildStaticConversion" /> to provide additional conversions.
+        /// </remarks>
+        /// <param name="value">
+        /// An <see cref="Expression" /> representing an intermediately typed value (a value used
+        /// by a generated serializer or deserializer internally prior to converting and returning).
+        /// </param>
+        /// <param name="target">
+        /// A <see cref="Type" /> to convert <paramref name="value" /> to (the return type of the
+        /// generated serializer or deserializer).
+        /// </param>
+        /// <returns>
+        /// An <see cref="Expression" /> representing the conversion of <paramref name="value" />
+        /// to <paramref name="target" />. If <paramref name="value" /> already has type
+        /// <paramref name="target" />, <paramref name="value" /> is returned as-is.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when no conversion to <paramref name="target" /> can be built.
+        /// </exception>
+        protected Expression BuildConversion(Expression value, Type target)
+        {
+            // bail early if the type already matches:
+            if (value.Type == target)
+            {
+                return value;
+            }
+
+            // if the type is unknown, generate a dynamic conversion:
+            else if (value.Type == typeof(object))
+            {
+                return BuildDynamicConversion(value, target);
+            }
+
+            // in all other cases, generate a static conversion:
+            else
+            {
+                return BuildStaticConversion(value, target);
+            }
+        }
+
+        /// <summary>
+        /// Builds an <see cref="Expression" /> representing a dynamic conversion to a target
+        /// <see cref="Type" />.
+        /// </summary>
+        /// <param name="value">
+        /// An <see cref="Expression" /> representing an intermediately typed value (a value used
+        /// by a generated serializer or deserializer internally prior to converting and returning).
+        /// </param>
+        /// <param name="target">
+        /// A <see cref="Type" /> to convert <paramref name="value" /> to (the return type of the
+        /// generated serializer or deserializer).
+        /// </param>
+        /// <returns>
+        /// An <see cref="Expression" /> representing the static conversion of <paramref name="value" />
+        /// to <paramref name="target" />.
+        /// </returns>
+        protected virtual Expression BuildDynamicConversion(Expression value, Type target)
+        {
+            return Expression.Dynamic(
+                Binder.Convert(
+                    CSharpBinderFlags.CheckedContext | CSharpBinderFlags.ConvertExplicit,
+                    target,
+                    value.Type),
+                target,
+                value);
+        }
+
+        /// <summary>
+        /// Builds an <see cref="Expression" /> representing a static conversion to a target
+        /// <see cref="Type" />.
+        /// </summary>
+        /// <param name="value">
+        /// An <see cref="Expression" /> representing an intermediately typed value (a value used
+        /// by a generated serializer or deserializer internally prior to converting and returning).
+        /// </param>
+        /// <param name="target">
+        /// A <see cref="Type" /> to convert <paramref name="value" /> to (the return type of the
+        /// generated serializer or deserializer).
+        /// </param>
+        /// <returns>
+        /// An <see cref="Expression" /> representing the static conversion of <paramref name="value" />
+        /// to <paramref name="target" />.
+        /// </returns>
+        protected virtual Expression BuildStaticConversion(Expression value, Type target)
+        {
+            return Expression.ConvertChecked(value, target);
+        }
+    }
+}

--- a/src/Chr.Avro/Serialization/FixedDeserializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/FixedDeserializerBuilderCase.cs
@@ -15,7 +15,7 @@ namespace Chr.Avro.Serialization
         /// used.
         /// </remarks>
         /// <inheritdoc />
-        protected override Expression BuildConversion(Expression value, Type target)
+        protected override Expression BuildStaticConversion(Expression value, Type target)
         {
             if (target == typeof(Guid) || target == typeof(Guid?))
             {
@@ -25,7 +25,7 @@ namespace Chr.Avro.Serialization
                 value = Expression.New(guidConstructor, value);
             }
 
-            return base.BuildConversion(value, target);
+            return base.BuildStaticConversion(value, target);
         }
     }
 }

--- a/src/Chr.Avro/Serialization/FixedSerializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/FixedSerializerBuilderCase.cs
@@ -15,7 +15,7 @@ namespace Chr.Avro.Serialization
         /// used.
         /// </remarks>
         /// <inheritdoc />
-        protected override Expression BuildConversion(Expression value, Type intermediate)
+        protected override Expression BuildStaticConversion(Expression value, Type intermediate)
         {
             if (value.Type == typeof(Guid))
             {
@@ -25,7 +25,7 @@ namespace Chr.Avro.Serialization
                 value = Expression.Call(value, convertGuid);
             }
 
-            return base.BuildConversion(value, intermediate);
+            return base.BuildStaticConversion(value, intermediate);
         }
     }
 }

--- a/src/Chr.Avro/Serialization/MapSerializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/MapSerializerBuilderCase.cs
@@ -2,14 +2,87 @@ namespace Chr.Avro.Serialization
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
     using Chr.Avro.Abstract;
     using Chr.Avro.Infrastructure;
+    using Microsoft.CSharp.RuntimeBinder;
 
     /// <summary>
     /// Provides a base implementation for serializer builder cases that match <see cref="MapSchema" />.
     /// </summary>
     public abstract class MapSerializerBuilderCase : SerializerBuilderCase
     {
+        /// <inheritdoc />
+        protected override Expression BuildDynamicConversion(Expression value, Type target)
+        {
+            if (target.GetDictionaryTypes() is (Type keyType, Type valueType))
+            {
+                var pairType = typeof(KeyValuePair<,>).MakeGenericType(keyType, valueType);
+                var collectionType = typeof(ICollection<>).MakeGenericType(pairType);
+                var enumerableType = typeof(IEnumerable<>).MakeGenericType(pairType);
+
+                var toList = typeof(Enumerable)
+                    .GetMethod(nameof(Enumerable.ToList))
+                    .MakeGenericMethod(pairType);
+
+                return Expression.Convert(
+                    Expression.Call(
+                        null,
+                        toList,
+                        Expression.Convert(
+                            Expression.Dynamic(
+                                Binder.InvokeMember(
+                                    CSharpBinderFlags.None,
+                                    nameof(Cast),
+                                    null,
+                                    typeof(MapSerializerBuilderCase),
+                                    new[]
+                                    {
+                                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.IsStaticType, null),
+                                        CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                                    }),
+                                typeof(object),
+                                Expression.Constant(typeof(MapSerializerBuilderCase)),
+                                value),
+                            enumerableType)),
+                    collectionType);
+            }
+            else
+            {
+                return base.BuildDynamicConversion(value, target);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override Expression BuildStaticConversion(Expression value, Type target)
+        {
+            if (target.GetDictionaryTypes() is (Type keyType, Type valueType))
+            {
+                var pairType = typeof(KeyValuePair<,>).MakeGenericType(keyType, valueType);
+                var collectionType = typeof(ICollection<>).MakeGenericType(pairType);
+                var enumerableType = typeof(IEnumerable<>).MakeGenericType(pairType);
+
+                if (!collectionType.IsAssignableFrom(value.Type))
+                {
+                    var toList = typeof(Enumerable)
+                        .GetMethod(nameof(Enumerable.ToList))
+                        .MakeGenericMethod(pairType);
+
+                    value = Expression.Call(
+                        null,
+                        toList,
+                        base.BuildStaticConversion(value, enumerableType));
+                }
+
+                return base.BuildStaticConversion(value, collectionType);
+            }
+            else
+            {
+                return base.BuildStaticConversion(value, target);
+            }
+        }
+
         /// <summary>
         /// Gets the item <see cref="Type" /> of a dictionary <see cref="Type" />.
         /// </summary>
@@ -24,6 +97,24 @@ namespace Chr.Avro.Serialization
         protected virtual (Type Key, Type Value)? GetDictionaryTypes(Type type)
         {
             return type.GetDictionaryTypes();
+        }
+
+        /// <summary>
+        /// Creates an enumerable that ensures items from the source enumerable are boxed.
+        /// </summary>
+        /// <param name="enumerable">
+        /// An enumerable of key-value pairs of any type.
+        /// </param>
+        /// <returns>
+        /// An enumerable of key-value pairs whose keys and values are guaranteed to be boxed.
+        /// </returns>
+        private static IEnumerable<KeyValuePair<object?, object?>> Cast<TKey, TValue>(
+            IEnumerable<KeyValuePair<TKey, TValue>> enumerable)
+        {
+            foreach (var pair in enumerable)
+            {
+                yield return new KeyValuePair<object?, object?>(pair.Key, pair.Value);
+            }
         }
     }
 }

--- a/src/Chr.Avro/Serialization/RecordSerializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/RecordSerializerBuilderCase.cs
@@ -7,9 +7,9 @@ namespace Chr.Avro.Serialization
     /// <summary>
     /// Provides a base implementation for serializer builder cases that match <see cref="RecordSchema" />.
     /// </summary>
-    public abstract class RecordSerializerBuilderCase
+    public abstract class RecordSerializerBuilderCase : SerializerBuilderCase
     {
-        private static readonly Regex FuzzyCharacters = new (@"[^A-Za-z0-9]");
+        private static readonly Regex FuzzyCharacters = new(@"[^A-Za-z0-9]");
 
         /// <summary>
         /// Determines whether a <see cref="RecordField" /> name matches another name.

--- a/src/Chr.Avro/Serialization/SerializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/SerializerBuilderCase.cs
@@ -1,43 +1,9 @@
 namespace Chr.Avro.Serialization
 {
-    using System;
-    using System.Linq.Expressions;
-
     /// <summary>
     /// Provides a base serializer builder case implementation.
     /// </summary>
-    public abstract class SerializerBuilderCase
+    public abstract class SerializerBuilderCase : ExpressionBuilder
     {
-        /// <summary>
-        /// Builds an <see cref="Expression" /> representing a conversion from a source
-        /// <see cref="Type" /> to an intermediate <see cref="Type" />.
-        /// </summary>
-        /// <remarks>
-        /// See the remarks for <see cref="Expression.ConvertChecked(Expression, Type)" />.
-        /// </remarks>
-        /// <param name="value">
-        /// An <see cref="Expression" /> representing a value to be serialized.
-        /// </param>
-        /// <param name="intermediate">
-        /// A <see cref="Type" /> to convert <paramref name="value" /> to (used by the generated
-        /// serializer internally).
-        /// </param>
-        /// <returns>
-        /// An <see cref="Expression" /> representing the conversion of <paramref name="value" />
-        /// to <paramref name="intermediate" />. If <paramref name="value" /> already has type
-        /// <paramref name="intermediate" />, <paramref name="value" /> is returned as-is.
-        /// </returns>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown when no conversion to <paramref name="intermediate" /> can be built.
-        /// </exception>
-        protected virtual Expression BuildConversion(Expression value, Type intermediate)
-        {
-            if (value.Type == intermediate)
-            {
-                return value;
-            }
-
-            return Expression.ConvertChecked(value, intermediate);
-        }
     }
 }

--- a/src/Chr.Avro/Serialization/StringDeserializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/StringDeserializerBuilderCase.cs
@@ -16,7 +16,7 @@ namespace Chr.Avro.Serialization
         /// idiomatically represented as strings. If none match, the base implementation is used.
         /// </remarks>
         /// <inheritdoc />
-        protected override Expression BuildConversion(Expression value, Type target)
+        protected override Expression BuildStaticConversion(Expression value, Type target)
         {
             if (target == typeof(DateTime) || target == typeof(DateTime?))
             {
@@ -68,7 +68,7 @@ namespace Chr.Avro.Serialization
                 value = Expression.New(uriConstructor, value);
             }
 
-            return base.BuildConversion(value, target);
+            return base.BuildStaticConversion(value, target);
         }
     }
 }

--- a/src/Chr.Avro/Serialization/StringSerializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/StringSerializerBuilderCase.cs
@@ -16,53 +16,133 @@ namespace Chr.Avro.Serialization
         /// idiomatically represented as strings. If none match, the base implementation is used.
         /// </remarks>
         /// <inheritdoc />
-        protected override Expression BuildConversion(Expression value, Type intermediate)
+        protected override Expression BuildDynamicConversion(Expression value, Type target)
         {
-            if (value.Type == typeof(DateTime))
+            if (target == typeof(string))
             {
                 var convertDateTime = typeof(DateTime)
                     .GetMethod(nameof(DateTime.ToString), new[] { typeof(string), typeof(IFormatProvider) });
 
-                value = Expression.Call(
-                    value,
-                    convertDateTime,
-                    Expression.Constant("O"),
-                    Expression.Constant(CultureInfo.InvariantCulture));
-            }
-            else if (value.Type == typeof(DateTimeOffset))
-            {
                 var convertDateTimeOffset = typeof(DateTimeOffset)
                     .GetMethod(nameof(DateTimeOffset.ToString), new[] { typeof(string), typeof(IFormatProvider) });
 
-                value = Expression.Call(
-                    value,
-                    convertDateTimeOffset,
-                    Expression.Constant("O"),
-                    Expression.Constant(CultureInfo.InvariantCulture));
-            }
-            else if (value.Type == typeof(Guid))
-            {
                 var convertGuid = typeof(Guid)
                     .GetMethod(nameof(Guid.ToString), Type.EmptyTypes);
 
-                value = Expression.Call(value, convertGuid);
-            }
-            else if (value.Type == typeof(TimeSpan))
-            {
                 var convertTimeSpan = typeof(XmlConvert)
                     .GetMethod(nameof(XmlConvert.ToString), new[] { typeof(TimeSpan) });
 
-                value = Expression.Call(null, convertTimeSpan, value);
+                var getType = typeof(object)
+                    .GetMethod(nameof(object.GetType));
+
+                var isEnum = typeof(Type)
+                    .GetProperty(nameof(Type.IsEnum));
+
+                var toString = typeof(object)
+                    .GetMethod(nameof(object.ToString), Type.EmptyTypes);
+
+                var intermediate = Expression.Variable(value.Type);
+                var result = Expression.Label(target);
+
+                return Expression.Block(
+                    new[] { intermediate },
+                    Expression.Assign(intermediate, value),
+                    Expression.IfThen(
+                        Expression.TypeIs(intermediate, typeof(DateTime)),
+                        Expression.Return(
+                            result,
+                            Expression.Call(
+                                Expression.Convert(intermediate, typeof(DateTime)),
+                                convertDateTime,
+                                Expression.Constant("O"),
+                                Expression.Constant(CultureInfo.InvariantCulture)))),
+                    Expression.IfThen(
+                        Expression.TypeIs(intermediate, typeof(DateTimeOffset)),
+                        Expression.Return(
+                            result,
+                            Expression.Call(
+                                Expression.Convert(intermediate, typeof(DateTimeOffset)),
+                                convertDateTimeOffset,
+                                Expression.Constant("O"),
+                                Expression.Constant(CultureInfo.InvariantCulture)))),
+                    Expression.IfThen(
+                        Expression.TypeIs(intermediate, typeof(Guid)),
+                        Expression.Return(
+                            result,
+                            Expression.Call(
+                                Expression.Convert(intermediate, typeof(Guid)),
+                                convertGuid))),
+                    Expression.IfThen(
+                        Expression.TypeIs(intermediate, typeof(TimeSpan)),
+                        Expression.Return(
+                            result,
+                            Expression.Call(
+                                null,
+                                convertTimeSpan,
+                                Expression.Convert(intermediate, typeof(TimeSpan))))),
+                    Expression.Label(result, base.BuildDynamicConversion(intermediate, target)));
             }
-            else if (value.Type == typeof(Uri))
+            else
             {
-                var convertUri = typeof(Uri)
-                    .GetMethod(nameof(Uri.ToString));
+                return base.BuildDynamicConversion(value, target);
+            }
+        }
 
-                value = Expression.Call(value, convertUri);
+        /// <remarks>
+        /// This override includes additional conditions to handle conversions to types that can be
+        /// idiomatically represented as strings. If none match, the base implementation is used.
+        /// </remarks>
+        /// <inheritdoc />
+        protected override Expression BuildStaticConversion(Expression value, Type target)
+        {
+            if (target == typeof(string))
+            {
+                if (value.Type == typeof(DateTime))
+                {
+                    var convertDateTime = typeof(DateTime)
+                        .GetMethod(nameof(DateTime.ToString), new[] { typeof(string), typeof(IFormatProvider) });
+
+                    value = Expression.Call(
+                        value,
+                        convertDateTime,
+                        Expression.Constant("O"),
+                        Expression.Constant(CultureInfo.InvariantCulture));
+                }
+                else if (value.Type == typeof(DateTimeOffset))
+                {
+                    var convertDateTimeOffset = typeof(DateTimeOffset)
+                        .GetMethod(nameof(DateTimeOffset.ToString), new[] { typeof(string), typeof(IFormatProvider) });
+
+                    value = Expression.Call(
+                        value,
+                        convertDateTimeOffset,
+                        Expression.Constant("O"),
+                        Expression.Constant(CultureInfo.InvariantCulture));
+                }
+                else if (value.Type == typeof(Guid))
+                {
+                    var convertGuid = typeof(Guid)
+                        .GetMethod(nameof(Guid.ToString), Type.EmptyTypes);
+
+                    value = Expression.Call(value, convertGuid);
+                }
+                else if (value.Type == typeof(TimeSpan))
+                {
+                    var convertTimeSpan = typeof(XmlConvert)
+                        .GetMethod(nameof(XmlConvert.ToString), new[] { typeof(TimeSpan) });
+
+                    value = Expression.Call(null, convertTimeSpan, value);
+                }
+                else if (value.Type == typeof(Uri))
+                {
+                    var convertUri = typeof(Uri)
+                        .GetMethod(nameof(Uri.ToString));
+
+                    value = Expression.Call(value, convertUri);
+                }
             }
 
-            return base.BuildConversion(value, intermediate);
+            return base.BuildStaticConversion(value, target);
         }
     }
 }

--- a/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
@@ -29,9 +29,9 @@ namespace Chr.Avro.Serialization.Tests
 
         public static IEnumerable<object[]> ArrayData => new List<object[]>
         {
-            new object[] { Array.Empty<int>() },
-            new object[] { new int[] { -10 } },
-            new object[] { new int[] { -10, 10, -5, 5, 0 } },
+            new object[] { Array.Empty<long>() },
+            new object[] { new long[] { -10 } },
+            new object[] { new long[] { -10, 10, -5, 5, 0 } },
         };
 
         public static IEnumerable<object[]> SetData => new List<object[]>
@@ -55,12 +55,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ArrayValues(int[] value)
+        public void ArrayValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<int[]>(schema);
-            var serialize = serializerBuilder.BuildDelegate<int[]>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<long[]>(schema);
+            var serialize = serializerBuilder.BuildDelegate<long[]>(schema);
 
             using (stream)
             {
@@ -74,12 +74,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ArraySegmentValues(int[] value)
+        public void ArraySegmentValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<ArraySegment<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<ArraySegment<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<ArraySegment<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<ArraySegment<long>>(schema);
 
             using (stream)
             {
@@ -93,21 +93,40 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void CollectionValues(int[] value)
+        public void CollectionValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<Collection<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<Collection<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Collection<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<Collection<long>>(schema);
 
             using (stream)
             {
-                serialize(new Collection<int>(value), new BinaryWriter(stream));
+                serialize(new Collection<long>(value), new BinaryWriter(stream));
             }
 
             var reader = new BinaryReader(stream.ToArray());
 
             Assert.Equal(value, deserialize(ref reader));
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrayData))]
+        public void DynamicArrayValues(long[] value)
+        {
+            var schema = new ArraySchema(new LongSchema());
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new BinaryWriter(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+
+            Assert.Equal(value.Cast<object>(), deserialize(ref reader));
         }
 
         [Theory]
@@ -131,12 +150,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ICollectionValues(int[] value)
+        public void ICollectionValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<ICollection<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<ICollection<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<ICollection<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<ICollection<long>>(schema);
 
             using (stream)
             {
@@ -150,12 +169,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void IEnumerableValues(int[] value)
+        public void IEnumerableValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<IEnumerable<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<IEnumerable<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<IEnumerable<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<IEnumerable<long>>(schema);
 
             using (stream)
             {
@@ -169,12 +188,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void IImmutableListValues(int[] value)
+        public void IImmutableListValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<IImmutableList<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<IImmutableList<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<IImmutableList<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<IImmutableList<long>>(schema);
 
             using (stream)
             {
@@ -188,12 +207,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void IImmutableQueueValues(int[] value)
+        public void IImmutableQueueValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<IImmutableQueue<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<IImmutableQueue<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<IImmutableQueue<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<IImmutableQueue<long>>(schema);
 
             using (stream)
             {
@@ -226,12 +245,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void IImmutableStackValues(int[] value)
+        public void IImmutableStackValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<IImmutableStack<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<IImmutableStack<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<IImmutableStack<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<IImmutableStack<long>>(schema);
 
             using (stream)
             {
@@ -245,12 +264,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void IListValues(int[] value)
+        public void IListValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<IList<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<IList<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<IList<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<IList<long>>(schema);
 
             using (stream)
             {
@@ -264,12 +283,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void IReadOnlyCollectionValues(int[] value)
+        public void IReadOnlyCollectionValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<IReadOnlyCollection<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<IReadOnlyCollection<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<IReadOnlyCollection<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<IReadOnlyCollection<long>>(schema);
 
             using (stream)
             {
@@ -283,12 +302,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void IReadOnlyListValues(int[] value)
+        public void IReadOnlyListValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<IReadOnlyList<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<IReadOnlyList<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<IReadOnlyList<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<IReadOnlyList<long>>(schema);
 
             using (stream)
             {
@@ -321,12 +340,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ImmutableArrayValues(int[] value)
+        public void ImmutableArrayValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<ImmutableArray<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<ImmutableArray<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<ImmutableArray<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<ImmutableArray<long>>(schema);
 
             using (stream)
             {
@@ -359,12 +378,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ImmutableListValues(int[] value)
+        public void ImmutableListValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<ImmutableList<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<ImmutableList<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<ImmutableList<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<ImmutableList<long>>(schema);
 
             using (stream)
             {
@@ -378,12 +397,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ImmutableQueueValues(int[] value)
+        public void ImmutableQueueValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<ImmutableQueue<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<ImmutableQueue<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<ImmutableQueue<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<ImmutableQueue<long>>(schema);
 
             using (stream)
             {
@@ -416,12 +435,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ImmutableStackValues(int[] value)
+        public void ImmutableStackValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<ImmutableStack<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<ImmutableStack<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<ImmutableStack<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<ImmutableStack<long>>(schema);
 
             using (stream)
             {
@@ -454,16 +473,16 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void LinkedListValues(int[] value)
+        public void LinkedListValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<LinkedList<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<LinkedList<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<LinkedList<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<LinkedList<long>>(schema);
 
             using (stream)
             {
-                serialize(new LinkedList<int>(value), new BinaryWriter(stream));
+                serialize(new LinkedList<long>(value), new BinaryWriter(stream));
             }
 
             var reader = new BinaryReader(stream.ToArray());
@@ -473,12 +492,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ListValues(int[] value)
+        public void ListValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<List<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<List<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<List<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<List<long>>(schema);
 
             using (stream)
             {
@@ -492,16 +511,16 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void QueueValues(int[] value)
+        public void QueueValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<Queue<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<Queue<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Queue<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<Queue<long>>(schema);
 
             using (stream)
             {
-                serialize(new Queue<int>(value), new BinaryWriter(stream));
+                serialize(new Queue<long>(value), new BinaryWriter(stream));
             }
 
             var reader = new BinaryReader(stream.ToArray());
@@ -530,16 +549,16 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void StackValues(int[] value)
+        public void StackValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<Stack<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<Stack<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Stack<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<Stack<long>>(schema);
 
             using (stream)
             {
-                serialize(new Stack<int>(value), new BinaryWriter(stream));
+                serialize(new Stack<long>(value), new BinaryWriter(stream));
             }
 
             var reader = new BinaryReader(stream.ToArray());

--- a/tests/Chr.Avro.Binary.Tests/BooleanSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/BooleanSerializationTests.cs
@@ -41,5 +41,25 @@ namespace Chr.Avro.Serialization.Tests
 
             Assert.Equal(value, deserialize(ref reader));
         }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void DynamicBooleanValues(bool value)
+        {
+            var schema = new BooleanSchema();
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new BinaryWriter(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+
+            Assert.Equal(value, deserialize(ref reader));
+        }
     }
 }

--- a/tests/Chr.Avro.Binary.Tests/BytesSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/BytesSerializationTests.cs
@@ -24,16 +24,21 @@ namespace Chr.Avro.Serialization.Tests
             stream = new MemoryStream();
         }
 
-        public static IEnumerable<object[]> GuidData => new List<object[]>
+        public static IEnumerable<object[]> ByteArrays => new List<object[]>
+        {
+            new object[] { Array.Empty<byte>() },
+            new object[] { new byte[] { 0x00 } },
+            new object[] { new byte[] { 0xf0, 0x9f, 0x92, 0x81, 0xf0, 0x9f, 0x8e, 0x8d } },
+        };
+
+        public static IEnumerable<object[]> Guids => new List<object[]>
         {
             new object[] { Guid.Empty },
             new object[] { Guid.Parse("ed7ba470-8e54-465e-825c-99712043e01c") },
         };
 
         [Theory]
-        [InlineData(new byte[] { })]
-        [InlineData(new byte[] { 0x00 })]
-        [InlineData(new byte[] { 0xf0, 0x9f, 0x92, 0x81, 0xf0, 0x9f, 0x8e, 0x8d })]
+        [MemberData(nameof(ByteArrays))]
         public void ByteArrayValues(byte[] value)
         {
             var schema = new BytesSchema();
@@ -52,7 +57,26 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [MemberData(nameof(GuidData))]
+        [MemberData(nameof(ByteArrays))]
+        public void DynamicByteArrayValues(byte[] value)
+        {
+            var schema = new BytesSchema();
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new BinaryWriter(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+
+            Assert.Equal(value, deserialize(ref reader));
+        }
+
+        [Theory]
+        [MemberData(nameof(Guids))]
         public void GuidValues(Guid value)
         {
             var schema = new BytesSchema();
@@ -71,7 +95,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [MemberData(nameof(GuidData))]
+        [MemberData(nameof(Guids))]
         public void NullableGuidValues(Guid value)
         {
             var schema = new BytesSchema();

--- a/tests/Chr.Avro.Binary.Tests/DecimalSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/DecimalSerializationTests.cs
@@ -68,6 +68,28 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
+        [MemberData(nameof(BoundaryDecimals))]
+        public void DynamicDecimalValues(decimal value)
+        {
+            var schema = new BytesSchema()
+            {
+                LogicalType = new DecimalLogicalType(29, 14),
+            };
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new BinaryWriter(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+
+            Assert.Equal(value, deserialize(ref reader));
+        }
+
+        [Theory]
         [MemberData(nameof(ResizedDecimals))]
         public void ResizedDecimalValues(int precision, int scale, decimal value, byte[] encoding, decimal resizing)
         {

--- a/tests/Chr.Avro.Binary.Tests/DoubleSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/DoubleSerializationTests.cs
@@ -1,5 +1,6 @@
 namespace Chr.Avro.Serialization.Tests
 {
+    using System.Collections.Generic;
     using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
@@ -22,13 +23,25 @@ namespace Chr.Avro.Serialization.Tests
             stream = new MemoryStream();
         }
 
+        public static IEnumerable<object[]> Doubles => new List<object[]>
+        {
+            new object[] { double.NaN },
+            new object[] { double.NegativeInfinity },
+            new object[] { double.MinValue },
+            new object[] { 0.0 },
+            new object[] { double.MaxValue },
+            new object[] { double.PositiveInfinity },
+        };
+
+        public static IEnumerable<object[]> Integers => new List<object[]>
+        {
+            new object[] { -5 },
+            new object[] { 0 },
+            new object[] { 5 },
+        };
+
         [Theory]
-        [InlineData(double.NaN)]
-        [InlineData(double.NegativeInfinity)]
-        [InlineData(double.MinValue)]
-        [InlineData(0.0)]
-        [InlineData(double.MaxValue)]
-        [InlineData(double.PositiveInfinity)]
+        [MemberData(nameof(Doubles))]
         public void DoubleValues(double value)
         {
             var schema = new DoubleSchema();
@@ -47,9 +60,27 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(-5)]
-        [InlineData(0)]
-        [InlineData(5)]
+        [MemberData(nameof(Doubles))]
+        [MemberData(nameof(Integers))]
+        public void DynamicDoubleValues(dynamic value)
+        {
+            var schema = new DoubleSchema();
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new BinaryWriter(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+
+            Assert.Equal((double)value, deserialize(ref reader));
+        }
+
+        [Theory]
+        [MemberData(nameof(Integers))]
         public void Int32Values(int value)
         {
             var schema = new DoubleSchema();

--- a/tests/Chr.Avro.Binary.Tests/FixedSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/FixedSerializationTests.cs
@@ -24,16 +24,21 @@ namespace Chr.Avro.Serialization.Tests
             stream = new MemoryStream();
         }
 
-        public static IEnumerable<object[]> GuidData => new List<object[]>
+        public static IEnumerable<object[]> ByteArrays => new List<object[]>
+        {
+            new object[] { Array.Empty<byte>() },
+            new object[] { new byte[] { 0x00 } },
+            new object[] { new byte[] { 0xf0, 0x9f, 0x92, 0x81, 0xf0, 0x9f, 0x8e, 0x8d } },
+        };
+
+        public static IEnumerable<object[]> Guids => new List<object[]>
         {
             new object[] { Guid.Empty },
             new object[] { Guid.Parse("ed7ba470-8e54-465e-825c-99712043e01c") },
         };
 
         [Theory]
-        [InlineData(new byte[] { })]
-        [InlineData(new byte[] { 0x00 })]
-        [InlineData(new byte[] { 0xf0, 0x9f, 0x92, 0x81, 0xf0, 0x9f, 0x8e, 0x8d })]
+        [MemberData(nameof(ByteArrays))]
         public void ByteArrayValues(byte[] value)
         {
             var schema = new FixedSchema("test", value.Length);
@@ -52,7 +57,26 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [MemberData(nameof(GuidData))]
+        [MemberData(nameof(ByteArrays))]
+        public void DynamicByteArrayValues(byte[] value)
+        {
+            var schema = new FixedSchema("test", value.Length);
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new BinaryWriter(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+
+            Assert.Equal(value, deserialize(ref reader));
+        }
+
+        [Theory]
+        [MemberData(nameof(Guids))]
         public void GuidValues(Guid value)
         {
             var schema = new FixedSchema("test", 16);
@@ -71,7 +95,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [MemberData(nameof(GuidData))]
+        [MemberData(nameof(Guids))]
         public void NullableGuidValues(Guid value)
         {
             var schema = new FixedSchema("test", 16);

--- a/tests/Chr.Avro.Binary.Tests/GuidSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/GuidSerializationTests.cs
@@ -32,6 +32,28 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(Guids))]
+        public void DynamicGuidValues(Guid value)
+        {
+            var schema = new StringSchema()
+            {
+                LogicalType = new UuidLogicalType(),
+            };
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new BinaryWriter(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+
+            Assert.Equal(value.ToString(), deserialize(ref reader));
+        }
+
+        [Theory]
+        [MemberData(nameof(Guids))]
         public void GuidValues(Guid value)
         {
             var schema = new StringSchema()

--- a/tests/Chr.Avro.Binary.Tests/IntegerSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/IntegerSerializationTests.cs
@@ -1,10 +1,12 @@
 namespace Chr.Avro.Serialization.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
     using Xunit.Sdk;
+
     using BinaryReader = Chr.Avro.Serialization.BinaryReader;
     using BinaryWriter = Chr.Avro.Serialization.BinaryWriter;
 
@@ -23,9 +25,67 @@ namespace Chr.Avro.Serialization.Tests
             stream = new MemoryStream();
         }
 
+        public static IEnumerable<object[]> Bytes => new List<object[]>
+        {
+            new object[] { byte.MinValue },
+            new object[] { byte.MaxValue },
+        };
+
+        public static IEnumerable<object[]> Enums => new List<object[]>
+        {
+            new object[] { DateTimeKind.Unspecified },
+            new object[] { DateTimeKind.Utc },
+            new object[] { (DateTimeKind)(-1) },
+        };
+
+        public static IEnumerable<object[]> Int16s => new List<object[]>
+        {
+            new object[] { short.MinValue },
+            new object[] { (short)0 },
+            new object[] { short.MaxValue },
+        };
+
+        public static IEnumerable<object[]> Int32s => new List<object[]>
+        {
+            new object[] { int.MinValue },
+            new object[] { 0 },
+            new object[] { int.MaxValue },
+        };
+
+        public static IEnumerable<object[]> Int64s => new List<object[]>
+        {
+            new object[] { long.MinValue },
+            new object[] { 0L },
+            new object[] { long.MaxValue },
+        };
+
+        public static IEnumerable<object[]> SBytes => new List<object[]>
+        {
+            new object[] { sbyte.MinValue },
+            new object[] { (sbyte)0 },
+            new object[] { sbyte.MaxValue },
+        };
+
+        public static IEnumerable<object[]> UInt16s => new List<object[]>
+        {
+            new object[] { ushort.MinValue },
+            new object[] { ushort.MaxValue },
+        };
+
+        public static IEnumerable<object[]> UInt32s => new List<object[]>
+        {
+            new object[] { uint.MinValue },
+            new object[] { uint.MaxValue },
+        };
+
+        public static IEnumerable<object[]> UInt64s => new List<object[]>
+        {
+            new object[] { ulong.MinValue },
+            new object[] { ulong.MaxValue / 2 },
+        };
+
         [Theory]
-        [InlineData(byte.MinValue)]
-        [InlineData(byte.MaxValue)]
+        [MemberData(nameof(Bytes))]
         public void ByteValues(byte value)
         {
             var schema = new IntSchema();
@@ -44,9 +104,34 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(DateTimeKind.Unspecified)]
-        [InlineData(DateTimeKind.Utc)]
-        [InlineData((DateTimeKind)(-1))]
+        [MemberData(nameof(Bytes))]
+        [MemberData(nameof(Enums))]
+        [MemberData(nameof(Int16s))]
+        [MemberData(nameof(Int32s))]
+        [MemberData(nameof(Int64s))]
+        [MemberData(nameof(SBytes))]
+        [MemberData(nameof(UInt16s))]
+        [MemberData(nameof(UInt32s))]
+        [MemberData(nameof(UInt64s))]
+        public void DynamicLongValues(dynamic value)
+        {
+            var schema = new LongSchema();
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new BinaryWriter(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+
+            Assert.Equal((long)value, deserialize(ref reader));
+        }
+
+        [Theory]
+        [MemberData(nameof(Enums))]
         public void EnumValues(DateTimeKind value)
         {
             var schema = new IntSchema();
@@ -65,9 +150,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(short.MinValue)]
-        [InlineData(0)]
-        [InlineData(short.MaxValue)]
+        [MemberData(nameof(Int16s))]
         public void Int16Values(short value)
         {
             var schema = new IntSchema();
@@ -86,9 +169,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(int.MinValue)]
-        [InlineData(0)]
-        [InlineData(int.MaxValue)]
+        [MemberData(nameof(Int32s))]
         public void Int32Values(int value)
         {
             var schema = new IntSchema();
@@ -107,9 +188,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(long.MinValue)]
-        [InlineData(0)]
-        [InlineData(long.MaxValue)]
+        [MemberData(nameof(Int64s))]
         public void Int64Values(long value)
         {
             var schema = new LongSchema();
@@ -157,9 +236,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(sbyte.MinValue)]
-        [InlineData(0)]
-        [InlineData(sbyte.MaxValue)]
+        [MemberData(nameof(SBytes))]
         public void SByteValues(sbyte value)
         {
             var schema = new IntSchema();
@@ -178,8 +255,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(ushort.MinValue)]
-        [InlineData(ushort.MaxValue)]
+        [MemberData(nameof(UInt16s))]
         public void UInt16Values(ushort value)
         {
             var schema = new IntSchema();
@@ -198,8 +274,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(uint.MinValue)]
-        [InlineData(uint.MaxValue)]
+        [MemberData(nameof(UInt32s))]
         public void UInt32Values(uint value)
         {
             var schema = new IntSchema();
@@ -218,8 +293,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(ulong.MinValue)]
-        [InlineData(ulong.MaxValue / 2)]
+        [MemberData(nameof(UInt64s))]
         public void UInt64Values(ulong value)
         {
             var schema = new IntSchema();

--- a/tests/Chr.Avro.Binary.Tests/MapSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/MapSerializationTests.cs
@@ -4,6 +4,7 @@ namespace Chr.Avro.Serialization.Tests
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.IO;
+    using System.Linq;
     using Chr.Avro.Abstract;
     using Xunit;
 
@@ -69,6 +70,25 @@ namespace Chr.Avro.Serialization.Tests
             var reader = new BinaryReader(stream.ToArray());
 
             Assert.Equal(value, deserialize(ref reader));
+        }
+
+        [Theory]
+        [MemberData(nameof(StringKeyData))]
+        public void DynamicDictionaryValues(Dictionary<string, double> value)
+        {
+            var schema = new MapSchema(new DoubleSchema());
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new BinaryWriter(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+
+            Assert.Equal(value.ToDictionary(p => p.Key, p => (object)p.Value), deserialize(ref reader));
         }
 
         [Theory]

--- a/tests/Chr.Avro.Binary.Tests/NullSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/NullSerializationTests.cs
@@ -24,6 +24,26 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [InlineData(0)]
+        [InlineData(null)]
+        public void DynamicObjectValues(dynamic value)
+        {
+            var schema = new NullSchema();
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new BinaryWriter(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+
+            Assert.Equal(null, deserialize(ref reader));
+        }
+
+        [Theory]
+        [InlineData(0)]
         [InlineData(1)]
         public void Int32Values(int value)
         {

--- a/tests/Chr.Avro.Binary.Tests/RecordSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/RecordSerializationTests.cs
@@ -181,6 +181,59 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Fact]
+        public void RecordWithDynamicType()
+        {
+            var boolean = new BooleanSchema();
+            var array = new ArraySchema(boolean);
+            var map = new MapSchema(new IntSchema());
+            var @enum = new EnumSchema("Ordinal", new[] { "None", "First", "Second", "Third", "Fourth" });
+            var union = new UnionSchema(new Schema[]
+            {
+                new NullSchema(),
+                array,
+            });
+
+            var schema = new RecordSchema("AllFields")
+            {
+                Fields = new[]
+                {
+                    new RecordField("First", union),
+                    new RecordField("Second", union),
+                    new RecordField("Third", array),
+                    new RecordField("Fourth", array),
+                    new RecordField("Fifth", map),
+                    new RecordField("Sixth", map),
+                    new RecordField("Seventh", @enum),
+                    new RecordField("Eighth", @enum),
+                },
+            };
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            var value = new WithEvenFields()
+            {
+                First = new List<bool>() { false },
+                Second = new List<bool>() { false, false },
+                Third = new List<bool>() { false, false, false },
+                Fourth = new List<bool>() { false },
+                Fifth = new Dictionary<string, int>() { { "first", 1 } },
+                Sixth = new Dictionary<string, int>() { { "first", 1 }, { "second", 2 } },
+                Seventh = ImplicitEnum.First,
+                Eighth = ImplicitEnum.None,
+            };
+
+            using (stream)
+            {
+                serialize(value, new BinaryWriter(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+
+            Assert.Equal(value.Seventh.ToString(), deserialize(ref reader).Seventh);
+        }
+
+        [Fact]
         public void RecordWithMissingFields()
         {
             var boolean = new BooleanSchema();

--- a/tests/Chr.Avro.Json.Tests/ArraySerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/ArraySerializationTests.cs
@@ -27,9 +27,9 @@ namespace Chr.Avro.Serialization.Tests
 
         public static IEnumerable<object[]> ArrayData => new List<object[]>
         {
-            new object[] { Array.Empty<int>() },
-            new object[] { new int[] { -10 } },
-            new object[] { new int[] { -10, 10, -5, 5, 0 } },
+            new object[] { Array.Empty<long>() },
+            new object[] { new long[] { -10 } },
+            new object[] { new long[] { -10, 10, -5, 5, 0 } },
         };
 
         public static IEnumerable<object[]> SetData => new List<object[]>
@@ -53,12 +53,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ArrayValues(int[] value)
+        public void ArrayValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<int[]>(schema);
-            var serialize = serializerBuilder.BuildDelegate<int[]>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<long[]>(schema);
+            var serialize = serializerBuilder.BuildDelegate<long[]>(schema);
 
             using (stream)
             {
@@ -72,12 +72,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ArraySegmentValues(int[] value)
+        public void ArraySegmentValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<ArraySegment<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<ArraySegment<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<ArraySegment<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<ArraySegment<long>>(schema);
 
             using (stream)
             {
@@ -91,21 +91,40 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void CollectionValues(int[] value)
+        public void CollectionValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<Collection<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<Collection<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Collection<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<Collection<long>>(schema);
 
             using (stream)
             {
-                serialize(new Collection<int>(value), new Utf8JsonWriter(stream));
+                serialize(new Collection<long>(value), new Utf8JsonWriter(stream));
             }
 
             var reader = new Utf8JsonReader(stream.ToArray());
 
             Assert.Equal(value, deserialize(ref reader));
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrayData))]
+        public void DynamicArrayValues(long[] value)
+        {
+            var schema = new ArraySchema(new LongSchema());
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new Utf8JsonWriter(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+
+            Assert.Equal(value.Cast<object>(), deserialize(ref reader));
         }
 
         [Theory]
@@ -129,12 +148,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ICollectionValues(int[] value)
+        public void ICollectionValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<ICollection<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<ICollection<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<ICollection<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<ICollection<long>>(schema);
 
             using (stream)
             {
@@ -148,12 +167,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void IEnumerableValues(int[] value)
+        public void IEnumerableValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<IEnumerable<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<IEnumerable<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<IEnumerable<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<IEnumerable<long>>(schema);
 
             using (stream)
             {
@@ -167,12 +186,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void IImmutableListValues(int[] value)
+        public void IImmutableListValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<IImmutableList<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<IImmutableList<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<IImmutableList<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<IImmutableList<long>>(schema);
 
             using (stream)
             {
@@ -186,12 +205,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void IImmutableQueueValues(int[] value)
+        public void IImmutableQueueValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<IImmutableQueue<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<IImmutableQueue<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<IImmutableQueue<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<IImmutableQueue<long>>(schema);
 
             using (stream)
             {
@@ -224,12 +243,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void IImmutableStackValues(int[] value)
+        public void IImmutableStackValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<IImmutableStack<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<IImmutableStack<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<IImmutableStack<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<IImmutableStack<long>>(schema);
 
             using (stream)
             {
@@ -243,12 +262,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void IListValues(int[] value)
+        public void IListValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<IList<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<IList<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<IList<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<IList<long>>(schema);
 
             using (stream)
             {
@@ -262,12 +281,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void IReadOnlyCollectionValues(int[] value)
+        public void IReadOnlyCollectionValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<IReadOnlyCollection<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<IReadOnlyCollection<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<IReadOnlyCollection<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<IReadOnlyCollection<long>>(schema);
 
             using (stream)
             {
@@ -281,12 +300,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void IReadOnlyListValues(int[] value)
+        public void IReadOnlyListValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<IReadOnlyList<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<IReadOnlyList<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<IReadOnlyList<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<IReadOnlyList<long>>(schema);
 
             using (stream)
             {
@@ -319,12 +338,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ImmutableArrayValues(int[] value)
+        public void ImmutableArrayValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<ImmutableArray<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<ImmutableArray<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<ImmutableArray<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<ImmutableArray<long>>(schema);
 
             using (stream)
             {
@@ -357,12 +376,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ImmutableListValues(int[] value)
+        public void ImmutableListValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<ImmutableList<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<ImmutableList<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<ImmutableList<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<ImmutableList<long>>(schema);
 
             using (stream)
             {
@@ -376,12 +395,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ImmutableQueueValues(int[] value)
+        public void ImmutableQueueValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<ImmutableQueue<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<ImmutableQueue<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<ImmutableQueue<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<ImmutableQueue<long>>(schema);
 
             using (stream)
             {
@@ -414,12 +433,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ImmutableStackValues(int[] value)
+        public void ImmutableStackValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<ImmutableStack<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<ImmutableStack<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<ImmutableStack<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<ImmutableStack<long>>(schema);
 
             using (stream)
             {
@@ -452,16 +471,16 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void LinkedListValues(int[] value)
+        public void LinkedListValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<LinkedList<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<LinkedList<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<LinkedList<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<LinkedList<long>>(schema);
 
             using (stream)
             {
-                serialize(new LinkedList<int>(value), new Utf8JsonWriter(stream));
+                serialize(new LinkedList<long>(value), new Utf8JsonWriter(stream));
             }
 
             var reader = new Utf8JsonReader(stream.ToArray());
@@ -471,12 +490,12 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void ListValues(int[] value)
+        public void ListValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<List<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<List<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<List<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<List<long>>(schema);
 
             using (stream)
             {
@@ -490,16 +509,16 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void QueueValues(int[] value)
+        public void QueueValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<Queue<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<Queue<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Queue<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<Queue<long>>(schema);
 
             using (stream)
             {
-                serialize(new Queue<int>(value), new Utf8JsonWriter(stream));
+                serialize(new Queue<long>(value), new Utf8JsonWriter(stream));
             }
 
             var reader = new Utf8JsonReader(stream.ToArray());
@@ -528,16 +547,16 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ArrayData))]
-        public void StackValues(int[] value)
+        public void StackValues(long[] value)
         {
-            var schema = new ArraySchema(new IntSchema());
+            var schema = new ArraySchema(new LongSchema());
 
-            var deserialize = deserializerBuilder.BuildDelegate<Stack<int>>(schema);
-            var serialize = serializerBuilder.BuildDelegate<Stack<int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Stack<long>>(schema);
+            var serialize = serializerBuilder.BuildDelegate<Stack<long>>(schema);
 
             using (stream)
             {
-                serialize(new Stack<int>(value), new Utf8JsonWriter(stream));
+                serialize(new Stack<long>(value), new Utf8JsonWriter(stream));
             }
 
             var reader = new Utf8JsonReader(stream.ToArray());

--- a/tests/Chr.Avro.Json.Tests/BooleanSerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/BooleanSerializationTests.cs
@@ -39,5 +39,25 @@ namespace Chr.Avro.Serialization.Tests
 
             Assert.Equal(value, deserialize(ref reader));
         }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void DynamicBooleanValues(bool value)
+        {
+            var schema = new BooleanSchema();
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new Utf8JsonWriter(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+
+            Assert.Equal(value, deserialize(ref reader));
+        }
     }
 }

--- a/tests/Chr.Avro.Json.Tests/DecimalSerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/DecimalSerializationTests.cs
@@ -66,6 +66,28 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
+        [MemberData(nameof(BoundaryDecimals))]
+        public void DynamicDecimalValues(decimal value)
+        {
+            var schema = new BytesSchema()
+            {
+                LogicalType = new DecimalLogicalType(29, 14),
+            };
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new Utf8JsonWriter(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+
+            Assert.Equal(value, deserialize(ref reader));
+        }
+
+        [Theory]
         [MemberData(nameof(ResizedDecimals))]
         public void ResizedDecimalValues(int precision, int scale, decimal value, decimal resizing)
         {

--- a/tests/Chr.Avro.Json.Tests/DoubleSerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/DoubleSerializationTests.cs
@@ -1,5 +1,6 @@
 namespace Chr.Avro.Serialization.Tests
 {
+    using System.Collections.Generic;
     using System.IO;
     using System.Text.Json;
     using Chr.Avro.Abstract;
@@ -20,10 +21,22 @@ namespace Chr.Avro.Serialization.Tests
             stream = new MemoryStream();
         }
 
+        public static IEnumerable<object[]> Doubles => new List<object[]>
+        {
+            new object[] { double.MinValue },
+            new object[] { 0.0 },
+            new object[] { double.MaxValue },
+        };
+
+        public static IEnumerable<object[]> Integers => new List<object[]>
+        {
+            new object[] { -5 },
+            new object[] { 0 },
+            new object[] { 5 },
+        };
+
         [Theory]
-        [InlineData(double.MinValue)]
-        [InlineData(0.0)]
-        [InlineData(double.MaxValue)]
+        [MemberData(nameof(Doubles))]
         public void DoubleValues(double value)
         {
             var schema = new DoubleSchema();
@@ -42,9 +55,26 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(-5)]
-        [InlineData(0)]
-        [InlineData(5)]
+        [MemberData(nameof(Doubles))]
+        public void DynamicDoubleValues(double value)
+        {
+            var schema = new DoubleSchema();
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new Utf8JsonWriter(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+
+            Assert.Equal((double)value, deserialize(ref reader));
+        }
+
+        [Theory]
+        [MemberData(nameof(Integers))]
         public void Int32Values(int value)
         {
             var schema = new DoubleSchema();

--- a/tests/Chr.Avro.Json.Tests/FixedSerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/FixedSerializationTests.cs
@@ -22,16 +22,21 @@ namespace Chr.Avro.Serialization.Tests
             stream = new MemoryStream();
         }
 
-        public static IEnumerable<object[]> GuidData => new List<object[]>
+        public static IEnumerable<object[]> ByteArrays => new List<object[]>
+        {
+            new object[] { Array.Empty<byte>() },
+            new object[] { new byte[] { 0x00 } },
+            new object[] { new byte[] { 0xf0, 0x9f, 0x92, 0x81, 0xf0, 0x9f, 0x8e, 0x8d } },
+        };
+
+        public static IEnumerable<object[]> Guids => new List<object[]>
         {
             new object[] { Guid.Empty },
             new object[] { Guid.Parse("ed7ba470-8e54-465e-825c-99712043e01c") },
         };
 
         [Theory]
-        [InlineData(new byte[] { })]
-        [InlineData(new byte[] { 0x00 })]
-        [InlineData(new byte[] { 0xf0, 0x9f, 0x92, 0x81, 0xf0, 0x9f, 0x8e, 0x8d })]
+        [MemberData(nameof(ByteArrays))]
         public void ByteArrayValues(byte[] value)
         {
             var schema = new FixedSchema("test", value.Length);
@@ -50,7 +55,26 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [MemberData(nameof(GuidData))]
+        [MemberData(nameof(ByteArrays))]
+        public void DynamicByteArrayValues(byte[] value)
+        {
+            var schema = new FixedSchema("test", value.Length);
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new Utf8JsonWriter(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+
+            Assert.Equal(value, deserialize(ref reader));
+        }
+
+        [Theory]
+        [MemberData(nameof(Guids))]
         public void GuidValues(Guid value)
         {
             var schema = new FixedSchema("test", 16);
@@ -69,7 +93,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [MemberData(nameof(GuidData))]
+        [MemberData(nameof(Guids))]
         public void NullableGuidValues(Guid value)
         {
             var schema = new FixedSchema("test", 16);

--- a/tests/Chr.Avro.Json.Tests/GuidSerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/GuidSerializationTests.cs
@@ -30,6 +30,28 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(Guids))]
+        public void DynamicGuidValues(Guid value)
+        {
+            var schema = new StringSchema()
+            {
+                LogicalType = new UuidLogicalType(),
+            };
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new Utf8JsonWriter(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+
+            Assert.Equal(value.ToString(), deserialize(ref reader));
+        }
+
+        [Theory]
+        [MemberData(nameof(Guids))]
         public void GuidValues(Guid value)
         {
             var schema = new StringSchema()

--- a/tests/Chr.Avro.Json.Tests/IntegerSerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/IntegerSerializationTests.cs
@@ -1,6 +1,7 @@
 namespace Chr.Avro.Serialization.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Text.Json;
     using Chr.Avro.Abstract;
@@ -22,9 +23,67 @@ namespace Chr.Avro.Serialization.Tests
             stream = new MemoryStream();
         }
 
+        public static IEnumerable<object[]> Bytes => new List<object[]>
+        {
+            new object[] { byte.MinValue },
+            new object[] { byte.MaxValue },
+        };
+
+        public static IEnumerable<object[]> Enums => new List<object[]>
+        {
+            new object[] { DateTimeKind.Unspecified },
+            new object[] { DateTimeKind.Utc },
+            new object[] { (DateTimeKind)(-1) },
+        };
+
+        public static IEnumerable<object[]> Int16s => new List<object[]>
+        {
+            new object[] { short.MinValue },
+            new object[] { (short)0 },
+            new object[] { short.MaxValue },
+        };
+
+        public static IEnumerable<object[]> Int32s => new List<object[]>
+        {
+            new object[] { int.MinValue },
+            new object[] { 0 },
+            new object[] { int.MaxValue },
+        };
+
+        public static IEnumerable<object[]> Int64s => new List<object[]>
+        {
+            new object[] { long.MinValue },
+            new object[] { 0L },
+            new object[] { long.MaxValue },
+        };
+
+        public static IEnumerable<object[]> SBytes => new List<object[]>
+        {
+            new object[] { sbyte.MinValue },
+            new object[] { (sbyte)0 },
+            new object[] { sbyte.MaxValue },
+        };
+
+        public static IEnumerable<object[]> UInt16s => new List<object[]>
+        {
+            new object[] { ushort.MinValue },
+            new object[] { ushort.MaxValue },
+        };
+
+        public static IEnumerable<object[]> UInt32s => new List<object[]>
+        {
+            new object[] { uint.MinValue },
+            new object[] { uint.MaxValue },
+        };
+
+        public static IEnumerable<object[]> UInt64s => new List<object[]>
+        {
+            new object[] { ulong.MinValue },
+            new object[] { ulong.MaxValue / 2 },
+        };
+
         [Theory]
-        [InlineData(byte.MinValue)]
-        [InlineData(byte.MaxValue)]
+        [MemberData(nameof(Bytes))]
         public void ByteValues(byte value)
         {
             var schema = new IntSchema();
@@ -43,9 +102,34 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(DateTimeKind.Unspecified)]
-        [InlineData(DateTimeKind.Utc)]
-        [InlineData((DateTimeKind)(-1))]
+        [MemberData(nameof(Bytes))]
+        [MemberData(nameof(Enums))]
+        [MemberData(nameof(Int16s))]
+        [MemberData(nameof(Int32s))]
+        [MemberData(nameof(Int64s))]
+        [MemberData(nameof(SBytes))]
+        [MemberData(nameof(UInt16s))]
+        [MemberData(nameof(UInt32s))]
+        [MemberData(nameof(UInt64s))]
+        public void DynamicLongValues(dynamic value)
+        {
+            var schema = new LongSchema();
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new Utf8JsonWriter(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+
+            Assert.Equal((long)value, deserialize(ref reader));
+        }
+
+        [Theory]
+        [MemberData(nameof(Enums))]
         public void EnumValues(DateTimeKind value)
         {
             var schema = new IntSchema();
@@ -64,9 +148,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(short.MinValue)]
-        [InlineData(0)]
-        [InlineData(short.MaxValue)]
+        [MemberData(nameof(Int16s))]
         public void Int16Values(short value)
         {
             var schema = new IntSchema();
@@ -85,9 +167,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(int.MinValue)]
-        [InlineData(0)]
-        [InlineData(int.MaxValue)]
+        [MemberData(nameof(Int32s))]
         public void Int32Values(int value)
         {
             var schema = new IntSchema();
@@ -106,9 +186,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(long.MinValue)]
-        [InlineData(0)]
-        [InlineData(long.MaxValue)]
+        [MemberData(nameof(Int64s))]
         public void Int64Values(long value)
         {
             var schema = new LongSchema();
@@ -156,9 +234,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(sbyte.MinValue)]
-        [InlineData(0)]
-        [InlineData(sbyte.MaxValue)]
+        [MemberData(nameof(SBytes))]
         public void SByteValues(sbyte value)
         {
             var schema = new IntSchema();
@@ -177,8 +253,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(ushort.MinValue)]
-        [InlineData(ushort.MaxValue)]
+        [MemberData(nameof(UInt16s))]
         public void UInt16Values(ushort value)
         {
             var schema = new IntSchema();
@@ -197,8 +272,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(uint.MinValue)]
-        [InlineData(uint.MaxValue)]
+        [MemberData(nameof(UInt32s))]
         public void UInt32Values(uint value)
         {
             var schema = new LongSchema();
@@ -217,8 +291,7 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(ulong.MinValue)]
-        [InlineData(ulong.MaxValue / 2)]
+        [MemberData(nameof(UInt64s))]
         public void UInt64Values(ulong value)
         {
             var schema = new LongSchema();

--- a/tests/Chr.Avro.Json.Tests/MapSerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/MapSerializationTests.cs
@@ -4,6 +4,7 @@ namespace Chr.Avro.Serialization.Tests
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.IO;
+    using System.Linq;
     using System.Text.Json;
     using Chr.Avro.Abstract;
     using Xunit;
@@ -67,6 +68,25 @@ namespace Chr.Avro.Serialization.Tests
             var reader = new Utf8JsonReader(stream.ToArray());
 
             Assert.Equal(value, deserialize(ref reader));
+        }
+
+        [Theory]
+        [MemberData(nameof(StringKeyData))]
+        public void DynamicDictionaryValues(Dictionary<string, double> value)
+        {
+            var schema = new MapSchema(new DoubleSchema());
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new Utf8JsonWriter(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+
+            Assert.Equal(value.ToDictionary(p => p.Key, p => (object)p.Value), deserialize(ref reader));
         }
 
         [Theory]

--- a/tests/Chr.Avro.Json.Tests/NullSerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/NullSerializationTests.cs
@@ -22,6 +22,26 @@ namespace Chr.Avro.Serialization.Tests
 
         [Theory]
         [InlineData(0)]
+        [InlineData(null)]
+        public void DynamicObjectValues(dynamic value)
+        {
+            var schema = new NullSchema();
+
+            var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
+            var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
+
+            using (stream)
+            {
+                serialize(value, new Utf8JsonWriter(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+
+            Assert.Equal(null, deserialize(ref reader));
+        }
+
+        [Theory]
+        [InlineData(0)]
         [InlineData(1)]
         public void Int32Values(int value)
         {


### PR DESCRIPTION
This change enables mapping to types unknown at serde build time. This is a prerequisite for default value support as serializers need to be able to convert default value representations from JSON to binary without having a known .NET type to map to.

To support records, the deserializer builder uses `ExpandoObject` as a surrogate record type if it can, and we generate dynamic getters/setters if the type could be dynamic. The remainder of this change is mostly shuffling type selection code around. Surrogate type selection is no longer used; instead, cases that previously checked for narrow types (e.g. array cases for `IEnumerable<T>`) now support filling in a more specific type for `object`.