### PR TITLE
Add default value support to schema model

### DIFF
--- a/src/Chr.Avro.Json/Abstract/JsonDefaultValue.cs
+++ b/src/Chr.Avro.Json/Abstract/JsonDefaultValue.cs
@@ -1,0 +1,68 @@
+namespace Chr.Avro.Abstract
+{
+    using System.Text;
+    using System.Text.Json;
+    using Chr.Avro.Serialization;
+
+    /// <summary>
+    /// Wraps the default value of a <see cref="RecordField" /> represented as JSON.
+    /// </summary>
+    public class JsonDefaultValue : DefaultValue
+    {
+        private readonly IJsonDeserializerBuilder deserializerBuilder;
+
+        private JsonElement element;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonDefaultValue" /> class.
+        /// </summary>
+        /// <param name="element">
+        /// The value represented as a <see cref="JsonElement" />.
+        /// </param>
+        /// <param name="schema">
+        /// A <see cref="Schema" /> that can be used to read the value.
+        /// </param>
+        /// <param name="deserializerBuilder">
+        /// A deserializer builder instance to use when deserializing the value to .NET objects. If
+        /// none is provided, the default <see cref="JsonDeserializerBuilder" /> will be used.
+        /// </param>
+        public JsonDefaultValue(JsonElement element, Schema schema, IJsonDeserializerBuilder? deserializerBuilder = default)
+            : base(schema)
+        {
+            Element = element;
+
+            this.deserializerBuilder = deserializerBuilder ?? new JsonDeserializerBuilder();
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="JsonElement" /> representation of the value.
+        /// </summary>
+        public JsonElement Element
+        {
+            get
+            {
+                return element;
+            }
+
+            set
+            {
+                // A new element is returned only if the element (or its parent) is not the result
+                // of a previous call to .Clone:
+                element = value.Clone();
+            }
+        }
+
+        /// <inheritdoc />
+        public override T ToObject<T>()
+        {
+            var reader = ToJsonReader();
+
+            return deserializerBuilder.BuildDelegate<T>(Schema)(ref reader);
+        }
+
+        private Utf8JsonReader ToJsonReader()
+        {
+            return new Utf8JsonReader(Encoding.UTF8.GetBytes(Element.GetRawText()));
+        }
+    }
+}

--- a/src/Chr.Avro.Json/JsonAttributeToken.cs
+++ b/src/Chr.Avro.Json/JsonAttributeToken.cs
@@ -11,6 +11,11 @@ namespace Chr.Avro
         public const string Aliases = "aliases";
 
         /// <summary>
+        /// The record field default value key.
+        /// </summary>
+        public const string Default = "default";
+
+        /// <summary>
         /// The enum/record schema documentation key.
         /// </summary>
         public const string Doc = "doc";

--- a/src/Chr.Avro.Json/Representation/JsonRecordSchemaWriterCase.cs
+++ b/src/Chr.Avro.Json/Representation/JsonRecordSchemaWriterCase.cs
@@ -79,9 +79,25 @@ namespace Chr.Avro.Representation
                         json.WriteStartObject();
                         json.WriteString(JsonAttributeToken.Name, field.Name);
 
-                        if (!canonical && !string.IsNullOrEmpty(field.Documentation))
+                        if (!canonical)
                         {
-                            json.WriteString(JsonAttributeToken.Doc, field.Documentation);
+                            if (field.Default != null)
+                            {
+                                if (field.Default is JsonDefaultValue jsonDefault)
+                                {
+                                    json.WritePropertyName(JsonAttributeToken.Default);
+                                    jsonDefault.Element.WriteTo(json);
+                                }
+                                else
+                                {
+                                    throw new UnsupportedSchemaException(schema, $"The default value of the {field.Name} field on {recordSchema} must be a JSON value.");
+                                }
+                            }
+
+                            if (!string.IsNullOrEmpty(field.Documentation))
+                            {
+                                json.WriteString(JsonAttributeToken.Doc, field.Documentation);
+                            }
                         }
 
                         json.WritePropertyName(JsonAttributeToken.Type);

--- a/src/Chr.Avro.Json/Representation/JsonSchemaReader.cs
+++ b/src/Chr.Avro.Json/Representation/JsonSchemaReader.cs
@@ -5,6 +5,7 @@ namespace Chr.Avro.Representation
     using System.IO;
     using System.Text.Json;
     using Chr.Avro.Abstract;
+    using Chr.Avro.Serialization;
 
     /// <summary>
     /// Reads JSON-serialized Avro schemas.
@@ -15,8 +16,13 @@ namespace Chr.Avro.Representation
         /// Initializes a new instance of the <see cref="JsonSchemaReader" /> class configured with
         /// the default list of cases.
         /// </summary>
-        public JsonSchemaReader()
-            : this(CreateDefaultCaseBuilders())
+        /// <param name="deserializerBuilder">
+        /// A deserializer builder instance to use when deserializing default values to .NET
+        /// objects. If none is provided, the default <see cref="JsonDeserializerBuilder" />
+        /// will be used.
+        /// </param>
+        public JsonSchemaReader(IJsonDeserializerBuilder? deserializerBuilder = default)
+            : this(CreateDefaultCaseBuilders(deserializerBuilder))
         {
         }
 
@@ -50,11 +56,18 @@ namespace Chr.Avro.Representation
         /// <summary>
         /// Creates the default list of case builders.
         /// </summary>
+        /// <param name="deserializerBuilder">
+        /// A deserializer builder instance to use when deserializing deserializing default values
+        /// to .NET objects. If none is provided, the default <see cref="JsonDeserializerBuilder" />
+        /// will be used.
+        /// </param>
         /// <returns>
         /// A list of case builders that matches all types defined in the Avro spec.
         /// </returns>
-        public static IEnumerable<Func<IJsonSchemaReader, IJsonSchemaReaderCase>> CreateDefaultCaseBuilders()
+        public static IEnumerable<Func<IJsonSchemaReader, IJsonSchemaReaderCase>> CreateDefaultCaseBuilders(IJsonDeserializerBuilder? deserializerBuilder = default)
         {
+            deserializerBuilder ??= new JsonDeserializerBuilder();
+
             return new Func<IJsonSchemaReader, IJsonSchemaReaderCase>[]
             {
                 // logical types:
@@ -77,7 +90,7 @@ namespace Chr.Avro.Representation
                 // named:
                 reader => new JsonEnumSchemaReaderCase(),
                 reader => new JsonFixedSchemaReaderCase(),
-                reader => new JsonRecordSchemaReaderCase(reader),
+                reader => new JsonRecordSchemaReaderCase(deserializerBuilder, reader),
 
                 // others:
                 reader => new JsonPrimitiveSchemaReaderCase(),

--- a/src/Chr.Avro/Abstract/DefaultValue.cs
+++ b/src/Chr.Avro/Abstract/DefaultValue.cs
@@ -1,0 +1,59 @@
+namespace Chr.Avro.Abstract
+{
+    using System;
+    using System.Linq;
+
+    /// <summary>
+    /// Wraps the default value of a <see cref="RecordField" />.
+    /// </summary>
+    public abstract class DefaultValue
+    {
+        private Schema schema = default!;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultValue" /> class.
+        /// </summary>
+        /// <param name="schema">
+        /// A <see cref="Schema" /> that can be used to read the value.
+        /// </param>
+        public DefaultValue(Schema schema)
+        {
+            Schema = schema;
+        }
+
+        /// <summary>
+        /// Gets or sets the schema that can be used to read the value.
+        /// </summary>
+        public Schema Schema
+        {
+            get
+            {
+                return schema ?? throw new InvalidOperationException();
+            }
+
+            set
+            {
+                schema = value switch
+                {
+                    null => throw new ArgumentNullException(nameof(value), "Schema cannot be null."),
+                    UnionSchema unionSchema => unionSchema.Schemas.First(),
+                    Schema schema => schema
+                };
+            }
+        }
+
+        /// <summary>
+        /// Gets the value as a .NET object.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The <see cref="Type" /> to map the value to.
+        /// </typeparam>
+        /// <returns>
+        /// The value as <typeparamref name="T" />.
+        /// </returns>
+        /// <exception cref="UnsupportedTypeException">
+        /// Thrown when the value cannot be mapped to <typeparamref name="T" />.
+        /// </exception>
+        public abstract T ToObject<T>();
+    }
+}

--- a/src/Chr.Avro/Abstract/RecordField.cs
+++ b/src/Chr.Avro/Abstract/RecordField.cs
@@ -30,6 +30,11 @@ namespace Chr.Avro.Abstract
         }
 
         /// <summary>
+        /// Gets or sets the default value of the field.
+        /// </summary>
+        public DefaultValue? Default { get; set; }
+
+        /// <summary>
         /// Gets or sets the human-readable description of the field.
         /// </summary>
         public string? Documentation { get; set; }

--- a/tests/Chr.Avro.Json.Tests/JsonDefaultValueShould.cs
+++ b/tests/Chr.Avro.Json.Tests/JsonDefaultValueShould.cs
@@ -1,0 +1,45 @@
+namespace Chr.Avro.Abstract.Tests
+{
+    using System;
+    using System.Text.Json;
+    using Xunit;
+
+    public class JsonDefaultValueShould
+    {
+        [Fact]
+        public void ConvertValueToObject()
+        {
+            var document = JsonSerializer.Deserialize<JsonDocument>("1");
+            var element = document.RootElement;
+
+            var schema = new IntSchema();
+
+            var defaultValue = new JsonDefaultValue(element, schema);
+            Assert.Equal(JsonValueKind.Number, defaultValue.Element.ValueKind);
+            Assert.Equal(1, defaultValue.ToObject<int>());
+        }
+
+        [Fact]
+        public void ThrowWhenConstructedWithNullSchema()
+        {
+            var document = JsonSerializer.Deserialize<JsonDocument>("1");
+            var element = document.RootElement;
+
+            Assert.Throws<ArgumentNullException>(() => new JsonDefaultValue(element, null));
+        }
+
+        [Fact]
+        public void UseFirstChildOfUnionSchema()
+        {
+            var document = JsonSerializer.Deserialize<JsonDocument>("1");
+            var element = document.RootElement;
+
+            var @int = new IntSchema();
+            var @string = new StringSchema();
+            var union = new UnionSchema(new Schema[] { @int, @string });
+
+            var defaultValue = new JsonDefaultValue(element, union);
+            Assert.Equal(@int, defaultValue.Schema);
+        }
+    }
+}

--- a/tests/Chr.Avro.Json.Tests/JsonRepresentationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/JsonRepresentationTests.cs
@@ -75,7 +75,9 @@ namespace Chr.Avro.Representation.Tests
             new object[] { "{\"name\":\"Empty\",\"type\":\"record\",\"fields\":[]}" },
             new object[] { "{\"name\":\"Empty\",\"aliases\":[\"Empty\"],\"type\":\"record\",\"fields\":[]}" },
             new object[] { "{\"name\":\"cards.Card\",\"type\":\"record\",\"fields\":[{\"name\":\"suit\",\"type\":{\"name\":\"cards.Suit\",\"type\":\"enum\",\"symbols\":[\"CLUBS\",\"DIAMONDS\",\"HEARTS\",\"SPADES\"]}},{\"name\":\"number\",\"type\":\"int\"}]}" },
-            new object[] { "{\"name\":\"lists.Node\",\"type\":\"record\",\"fields\":[{\"name\":\"value\",\"type\":\"int\"},{\"name\":\"next\",\"type\":\"lists.Node\"}]}" },
+            new object[] { "{\"name\":\"lists.Node\",\"type\":\"record\",\"fields\":[{\"name\":\"value\",\"type\":\"int\"},{\"name\":\"next\",\"type\":[\"null\",\"lists.Node\"]}]}" },
+            new object[] { "{\"name\":\"lists.Node\",\"type\":\"record\",\"fields\":[{\"name\":\"value\",\"type\":\"int\"},{\"name\":\"next\",\"default\":null,\"type\":[\"null\",\"lists.Node\"]}]}" },
+            new object[] { "{\"name\":\"measurements.Temperature\",\"type\":\"record\",\"fields\":[{\"name\":\"scale\",\"default\":\"CELSIUS\",\"type\":{\"name\":\"measurements.TemperatureScale\",\"type\":\"enum\",\"symbols\":[\"FAHRENHEIT\",\"CELSIUS\"]}}]}" },
         };
 
         public static IEnumerable<object[]> TimeLogicalTypeRepresentations => new List<object[]>

--- a/tests/Chr.Avro.Tests/Abstract/RecordFieldShould.cs
+++ b/tests/Chr.Avro.Tests/Abstract/RecordFieldShould.cs
@@ -9,6 +9,20 @@ namespace Chr.Avro.Tests
     public class RecordFieldShould
     {
         [Fact]
+        public void SetDefault()
+        {
+            var field = new RecordField("test", new NullSchema());
+            Assert.Null(field.Default);
+
+            var defaultValue = new MockDefaultValue(field.Type);
+            field.Default = defaultValue;
+            Assert.Equal(defaultValue, field.Default);
+
+            field.Default = null;
+            Assert.Null(field.Default);
+        }
+
+        [Fact]
         public void SetDocumentation()
         {
             var field = new RecordField("test", new NullSchema());

--- a/tests/Chr.Avro.Tests/MockDefaultValue.cs
+++ b/tests/Chr.Avro.Tests/MockDefaultValue.cs
@@ -1,0 +1,17 @@
+namespace Chr.Avro.Tests
+{
+    using Chr.Avro.Abstract;
+
+    public class MockDefaultValue : DefaultValue
+    {
+        public MockDefaultValue(Schema schema)
+            : base(schema)
+        {
+        }
+
+        public override T ToObject<T>()
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
This change adds a `Default` property to the `RecordField` type and implements reading/writing default values from/to JSON schema representations. Serialization remains unchanged for now; #176 is a prerequisite for getting that to work as expected.

To keep the default value implementation agnostic to encoding, the `DefaultValue` class is abstract and implemented by encoding-specific subclasses. Then, serde builders can call the `.ToObject<T>` method to get an object without having to worry about how to deserialize the value. There are some downsides to this approach: the big one is that a deserializer builder is tied to a default value, but that doesn’t have any practical impact on performance, and I think it’s an okay tradeoff to make for the simplicity of `.ToObject<T>`. There’s also a hacky check in `JsonSchemaWriter`—if a non-JSON default value is passed in, it’ll throw (since `.ToObject<dynamic>` doesn’t work reliably yet), but that’s something we’ll be able to remove once we have dynamic serdes nailed down.