### PR TITLE
Add default enum value to schema model

### DIFF
--- a/src/Chr.Avro.Json/Representation/JsonEnumSchemaReaderCase.cs
+++ b/src/Chr.Avro.Json/Representation/JsonEnumSchemaReaderCase.cs
@@ -55,6 +55,16 @@ namespace Chr.Avro.Representation
                         .ToArray();
                 }
 
+                if (element.TryGetProperty(JsonAttributeToken.Default, out var @default))
+                {
+                    schema.Default = @default.GetString();
+
+                    if (!schema.Symbols.Contains(schema.Default))
+                    {
+                        throw new InvalidSchemaException($"The default value \"{schema.Default}\" is not a symbol in {schema.FullName}.");
+                    }
+                }
+
                 if (element.TryGetProperty(JsonAttributeToken.Doc, out var doc))
                 {
                     schema.Documentation = doc.GetString();

--- a/src/Chr.Avro.Json/Representation/JsonEnumSchemaWriterCase.cs
+++ b/src/Chr.Avro.Json/Representation/JsonEnumSchemaWriterCase.cs
@@ -47,6 +47,16 @@ namespace Chr.Avro.Representation
                             json.WriteEndArray();
                         }
 
+                        if (enumSchema.Default is not null)
+                        {
+                            if (!enumSchema.Symbols.Contains(enumSchema.Default))
+                            {
+                                throw new InvalidSchemaException($"The default value \"{enumSchema.Default}\" is not a symbol in {enumSchema.FullName}.");
+                            }
+
+                            json.WriteString(JsonAttributeToken.Default, enumSchema.Default);
+                        }
+
                         if (!string.IsNullOrEmpty(enumSchema.Documentation))
                         {
                             json.WriteString(JsonAttributeToken.Doc, enumSchema.Documentation);

--- a/src/Chr.Avro/Abstract/EnumSchema.cs
+++ b/src/Chr.Avro/Abstract/EnumSchema.cs
@@ -39,6 +39,11 @@ namespace Chr.Avro.Abstract
         }
 
         /// <summary>
+        /// Gets or sets the default value of the enum.
+        /// </summary>
+        public string? Default { get; set; }
+
+        /// <summary>
         /// Gets or sets the human-readable description of the enum.
         /// </summary>
         public string? Documentation { get; set; }

--- a/tests/Chr.Avro.Json.Tests/JsonRepresentationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/JsonRepresentationTests.cs
@@ -42,6 +42,7 @@ namespace Chr.Avro.Representation.Tests
         {
             new object[] { "{\"name\":\"Empty\",\"type\":\"enum\",\"symbols\":[]}" },
             new object[] { "{\"name\":\"cards.Suit\",\"type\":\"enum\",\"symbols\":[\"CLUBS\",\"DIAMONDS\",\"HEARTS\",\"SPADES\"]}" },
+            new object[] { "{\"name\":\"measurements.TemperatureScale\",\"default\":\"CELSIUS\",\"type\":\"enum\",\"symbols\":[\"FAHRENHEIT\",\"CELSIUS\"]}" },
         };
 
         public static IEnumerable<object[]> FixedSchemaRepresentations => new List<object[]>


### PR DESCRIPTION
This is a chaser to #178 to support default enum values (https://avro.apache.org/docs/current/spec.html#Enums) as well as default record field values.