### PR TITLE
Ensure values written for int schemas don't exceed int32 bounds

### DIFF
--- a/src/Chr.Avro.Binary/Serialization/BinaryIntSerializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryIntSerializerBuilderCase.cs
@@ -19,7 +19,7 @@ namespace Chr.Avro.Serialization
         /// otherwise.
         /// </returns>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when <paramref name="type" /> cannot be converted to <see cref="long" />.
+        /// Thrown when <paramref name="type" /> cannot be converted to <see cref="int" />.
         /// </exception>
         /// <inheritdoc />
         public virtual BinarySerializerBuilderCaseResult BuildExpression(Expression value, Type type, Schema schema, BinarySerializerBuilderContext context)
@@ -27,12 +27,12 @@ namespace Chr.Avro.Serialization
             if (schema is IntSchema intSchema)
             {
                 var writeInteger = typeof(BinaryWriter)
-                    .GetMethod(nameof(BinaryWriter.WriteInteger), new[] { typeof(long) });
+                    .GetMethod(nameof(BinaryWriter.WriteInteger), new[] { typeof(int) });
 
                 try
                 {
                     return BinarySerializerBuilderCaseResult.FromExpression(
-                        Expression.Call(context.Writer, writeInteger, BuildConversion(value, typeof(long))));
+                        Expression.Call(context.Writer, writeInteger, BuildConversion(value, typeof(int))));
                 }
                 catch (InvalidOperationException exception)
                 {

--- a/src/Chr.Avro.Binary/Serialization/BinaryWriter.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryWriter.cs
@@ -88,6 +88,31 @@ namespace Chr.Avro.Serialization
         /// Writes a variable-length integer to the current position and advances the writer.
         /// </summary>
         /// <param name="value">
+        /// An <see cref="int" /> value.
+        /// </param>
+        public void WriteInteger(int value)
+        {
+            var encoded = (uint)((value << 1) ^ (value >> 31));
+
+            do
+            {
+                var current = encoded & 0x7FU;
+                encoded >>= 7;
+
+                if (encoded != 0)
+                {
+                    current |= 0x80U;
+                }
+
+                stream.WriteByte((byte)current);
+            }
+            while (encoded != 0U);
+        }
+
+        /// <summary>
+        /// Writes a variable-length integer to the current position and advances the writer.
+        /// </summary>
+        /// <param name="value">
         /// A <see cref="long" /> value.
         /// </param>
         public void WriteInteger(long value)

--- a/src/Chr.Avro.Json/Serialization/JsonIntSerializerBuilderCase.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonIntSerializerBuilderCase.cs
@@ -20,7 +20,7 @@ namespace Chr.Avro.Serialization
         /// otherwise.
         /// </returns>
         /// <exception cref="UnsupportedTypeException">
-        /// Thrown when <paramref name="type" /> cannot be converted to <see cref="long" />.
+        /// Thrown when <paramref name="type" /> cannot be converted to <see cref="int" />.
         /// </exception>
         /// <inheritdoc />
         public virtual JsonSerializerBuilderCaseResult BuildExpression(Expression value, Type type, Schema schema, JsonSerializerBuilderContext context)

--- a/tests/Chr.Avro.Binary.Tests/BinaryWriterTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/BinaryWriterTests.cs
@@ -54,17 +54,23 @@ namespace Chr.Avro.Serialization.Tests
             new object[] { double.PositiveInfinity, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x7f } },
         };
 
-        public static IEnumerable<object[]> IntegerEncodings => new List<object[]>
+        public static IEnumerable<object[]> Int32Encodings => new List<object[]>
         {
-            new object[] { 0L, new byte[] { 0x00 } },
-            new object[] { -1L, new byte[] { 0x01 } },
-            new object[] { 1L, new byte[] { 0x02 } },
-            new object[] { -2L, new byte[] { 0x03 } },
-            new object[] { 2L, new byte[] { 0x04 } },
-            new object[] { -64L, new byte[] { 0x7f } },
-            new object[] { 64L, new byte[] { 0x80, 0x01 } },
-            new object[] { -8192L, new byte[] { 0xff, 0x7f } },
-            new object[] { 8192L, new byte[] { 0x80, 0x80, 0x01 } },
+            new object[] { 0, new byte[] { 0x00 } },
+            new object[] { -1, new byte[] { 0x01 } },
+            new object[] { 1, new byte[] { 0x02 } },
+            new object[] { -2, new byte[] { 0x03 } },
+            new object[] { 2, new byte[] { 0x04 } },
+            new object[] { -64, new byte[] { 0x7f } },
+            new object[] { 64, new byte[] { 0x80, 0x01 } },
+            new object[] { -8192, new byte[] { 0xff, 0x7f } },
+            new object[] { 8192, new byte[] { 0x80, 0x80, 0x01 } },
+            new object[] { int.MinValue, new byte[] { 0xff, 0xff, 0xff, 0xff, 0x0f } },
+            new object[] { int.MaxValue, new byte[] { 0xfe, 0xff, 0xff, 0xff, 0x0f } },
+        };
+
+        public static IEnumerable<object[]> Int64Encodings => new List<object[]>
+        {
             new object[] { -4611686018427387904L, new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f } },
             new object[] { 4611686018427387904L, new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01 } },
             new object[] { long.MinValue, new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01 } },
@@ -108,8 +114,21 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Theory]
-        [MemberData(nameof(IntegerEncodings))]
-        public void WritesIntegers(long value, byte[] encoding)
+        [MemberData(nameof(Int32Encodings))]
+        public void WritesInt32s(int value, byte[] encoding)
+        {
+            using (stream)
+            {
+                writer.WriteInteger(value);
+            }
+
+            Assert.Equal(encoding, stream.ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(Int32Encodings))]
+        [MemberData(nameof(Int64Encodings))]
+        public void WritesInt64s(long value, byte[] encoding)
         {
             using (stream)
             {

--- a/tests/Chr.Avro.Binary.Tests/IntegerSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/IntegerSerializationTests.cs
@@ -75,7 +75,7 @@ namespace Chr.Avro.Serialization.Tests
         public static IEnumerable<object[]> UInt32s => new List<object[]>
         {
             new object[] { uint.MinValue },
-            new object[] { uint.MaxValue },
+            new object[] { uint.MaxValue / 2 },
         };
 
         public static IEnumerable<object[]> UInt64s => new List<object[]>
@@ -296,7 +296,7 @@ namespace Chr.Avro.Serialization.Tests
         [MemberData(nameof(UInt64s))]
         public void UInt64Values(ulong value)
         {
-            var schema = new IntSchema();
+            var schema = new LongSchema();
 
             var deserialize = deserializerBuilder.BuildDelegate<ulong>(schema);
             var serialize = serializerBuilder.BuildDelegate<ulong>(schema);


### PR DESCRIPTION
Fixes #120.