### PR TITLE
Generate safe names for record schemas created from generic types

### DIFF
--- a/src/Chr.Avro.Fixtures/Fixtures/GenericClass.cs
+++ b/src/Chr.Avro.Fixtures/Fixtures/GenericClass.cs
@@ -1,0 +1,7 @@
+namespace Chr.Avro.Fixtures
+{
+    public class GenericClass<T>
+    {
+        public T Item { get; set; }
+    }
+}

--- a/tests/Chr.Avro.Tests/Abstract/SchemaBuilderShould.cs
+++ b/tests/Chr.Avro.Tests/Abstract/SchemaBuilderShould.cs
@@ -89,6 +89,22 @@ namespace Chr.Avro.Tests
         }
 
         [Fact]
+        public void BuildClassesWithGenericParameters()
+        {
+            var schema = Assert.IsType<RecordSchema>(builder.BuildSchema<GenericClass<string>>());
+            Assert.Collection(
+                schema.Fields,
+                field =>
+                {
+                    Assert.Equal(nameof(GenericClass<string>.Item), field.Name);
+                    Assert.IsType<StringSchema>(field.Type);
+                });
+            Assert.Null(schema.LogicalType);
+            Assert.Equal("GenericClass_String", schema.Name);
+            Assert.Equal(typeof(GenericClass<string>).Namespace, schema.Namespace);
+        }
+
+        [Fact]
         public void BuildClassesWithMultipleRecursion()
         {
             var schema = Assert.IsType<RecordSchema>(builder.BuildSchema<CircularClassA>());


### PR DESCRIPTION
Previously, building a schema for a generic type would fail with an exception like the following:

```
Chr.Avro.Abstract.InvalidNameException: "Chr.Avro.Fixtures`1" is not a valid Avro name.
```

This change sanitizes those names and also enables the name/namespace derivation to be overridden.