### PR TITLE
Support mapping string schemas to `Enum` types

### DIFF
--- a/docs/cli/index.js
+++ b/docs/cli/index.js
@@ -55,17 +55,17 @@ module.exports = [{
 {"name":"Example.Models.ExampleModel",type":"record",fields:[{"name":"Text","type":"string"}]}`
   }],
   options: [...clrTypeOptions, {
-    name: 'enums-as-ints',
+    name: 'enum-behavior',
     required: false,
-    summary: 'Whether enums should be represented as integers.'
+    summary: 'The type of schema that enum types should be represented by. Options are "symbolic" (generate an "enum" schema; the default behavior), "integral" (generate an "int" or "long" schema based on the underlying type; the behavior for all flag enums), and "nominal" (generate a "string" schema).'
   }, {
     name: 'nullable-references',
     required: false,
-    summary: 'Which reference types should be represented with nullable union schemas. Options are annotated (use nullable annotations if available), none, and all.'
+    summary: 'Which reference types should be represented with nullable union schemas. Options are "annotated" (use nullable annotations if available; the default behavior), "none", and "all".'
   }, {
     name: 'temporal-behavior',
     required: false,
-    summary: 'Whether timestamps should be represented with "string" schemas (ISO 8601) or "long" schemas (timestamp logical types). Options are iso8601, epochmilliseconds, and epochmicroseconds.'
+    summary: 'Whether timestamps should be represented with "string" schemas (ISO 8601) or "long" schemas (timestamp logical types). Options are "iso8601", "epochmilliseconds", and "epochmicroseconds".'
   }]
 }, {
   name: 'generate',

--- a/docs/src/pages/internals/mapping.js
+++ b/docs/src/pages/internals/mapping.js
@@ -168,7 +168,7 @@ export default function MappingPage () {
       </ul>
       <p>By default, Chr.Avro also honors data contract attributes if a <DotnetReference id='T:System.Runtime.Serialization.DataContractAttribute' /> is present on the enumeration. In that case, if <DotnetReference id='P:System.Runtime.Serialization.EnumMemberAttribute.Value' /> is set on an enumerator, the custom value must match the symbol exactly. If it’s not set, the enumerator name will be compared inexactly as described above.</p>
       <p>To change or extend this behavior, implement <DotnetReference id='T:Chr.Avro.Resolution.ITypeResolver' /> or extend one of the existing resolvers (<DotnetReference id='T:Chr.Avro.Resolution.ReflectionResolver' /> and <DotnetReference id='T:Chr.Avro.Resolution.DataContractResolver' />).</p>
-      <p>Because enum types are able to be implicitly converted to and from integral types, Chr.Avro can map any integral type to <Highlight inline language='avro'>"enum"</Highlight> as well.</p>
+      <p>Because <Highlight inline language='avro'>"enum"</Highlight> symbols are represented as strings, Chr.Avro also supports mapping enum schemas to <DotnetReference id='T:System.String' />. On serialization, if the name of the enumerator is not a symbol in the schema, <DotnetReference id='T:System.ArgumentException' /> will be thrown.</p>
 
       <h2 id='maps'>Maps</h2>
       <p>Avro’s <Highlight inline language='avro'>"map"</Highlight> type represents a map of keys (assumed to be strings) to values. Chr.Avro can map a .NET type to <Highlight inline language='avro'>"map"</Highlight> if any of the following is true:</p>
@@ -321,6 +321,7 @@ export default function MappingPage () {
         </tbody>
       </table>
       <p>Whether a schema is <Highlight inline language='avro'>"int"</Highlight> or <Highlight inline language='avro'>"long"</Highlight> has no impact on serialization. Integers are <ExternalLink to='https://avro.apache.org/docs/current/spec.html#binary_encoding'>zig-zag encoded</ExternalLink>, so they take up as much space as they need. For that reason, Chr.Avro imposes no constraints on which numeric types can be serialized or deserialized to <Highlight inline language='avro'>"int"</Highlight> or <Highlight inline language='avro'>"long"</Highlight>—if a conversion exists, the binary serializer and deserializer will use it.</p>
+      <p>Because enum types are able to be implicitly converted to and from integral types, Chr.Avro can map any enum type to <Highlight inline language='avro'>"int"</Highlight> or <Highlight inline language='avro'>"long"</Highlight> as well.</p>
       <h3>Non-integral types</h3>
       <p>On the non-integral side, .NET types are mapped to their respective Avro types:</p>
       <table>

--- a/src/Chr.Avro.Cli/Cli/CreateSchemaVerb.cs
+++ b/src/Chr.Avro.Cli/Cli/CreateSchemaVerb.cs
@@ -33,13 +33,13 @@ namespace Chr.Avro.Cli
         [Option('a', "assembly", HelpText = "The name of or path to an assembly to load (multiple space-separated values accepted).")]
         public IEnumerable<string> AssemblyNames { get; set; }
 
-        [Option("enums-as-integers", HelpText = "Whether enums should be represented with \"int\" or \"long\" schemas.")]
-        public bool EnumsAsIntegers { get; set; }
+        [Option("enum-behavior", HelpText = "The type of schema that enum types should be represented by. Options are \"symbolic\" (generate an \"enum\" schema; the default behavior), \"integral\" (generate an \"int\" or \"long\" schema based on the underlying type; the behavior for all flag enums), and \"nominal\" (generate a \"string\" schema).")]
+        public EnumBehavior EnumBehavior { get; set; }
 
-        [Option("nullable-references", HelpText = "Which reference types should be represented with nullable union schemas. Options are annotated (use nullable annotations if available), none, and all.", Default = NullableReferenceTypeBehavior.Annotated)]
+        [Option("nullable-references", HelpText = "Which reference types should be represented with nullable union schemas. Options are \"annotated\" (use nullable annotations if available; the default behavior), \"none\", and \"all\".", Default = NullableReferenceTypeBehavior.Annotated)]
         public NullableReferenceTypeBehavior NullableReferences { get; set; }
 
-        [Option("temporal-behavior", HelpText = "Whether timestamps should be represented with \"string\" schemas (ISO 8601) or \"long\" schemas (timestamp logical types). Options are iso8601, epochmilliseconds, and epochmicroseconds.")]
+        [Option("temporal-behavior", HelpText = "Whether timestamps should be represented with \"string\" schemas (ISO 8601) or \"long\" schemas (timestamp logical types). Options are \"iso8601\", \"epochmilliseconds\", and \"epochmicroseconds\".")]
         public TemporalBehavior TemporalBehavior { get; set; }
 
         [Option('t', "type", Required = true, HelpText = "The type to build a schema for.")]
@@ -60,7 +60,7 @@ namespace Chr.Avro.Cli
             var type = ((IClrTypeOptions)this).ResolveType();
 
             var builder = new SchemaBuilder(
-                enumBehavior: EnumsAsIntegers ? EnumBehavior.Integral : EnumBehavior.Symbolic,
+                enumBehavior: EnumBehavior,
                 nullableReferenceTypeBehavior: NullableReferences,
                 temporalBehavior: TemporalBehavior);
 

--- a/src/Chr.Avro/Abstract/EnumBehavior.cs
+++ b/src/Chr.Avro/Abstract/EnumBehavior.cs
@@ -12,8 +12,14 @@ namespace Chr.Avro.Abstract
 
         /// <summary>
         /// Build an <see cref="IntSchema" /> or <see cref="LongSchema" /> based on the enum type’s
-        /// underlying integral type.
+        /// underlying integral type. This behavior will be used for flag enums regardless of the
+        /// behavior selected.
         /// </summary>
         Integral,
+
+        /// <summary>
+        /// Build a <see cref="StringSchema" />.
+        /// </summary>
+        Nominal,
     }
 }

--- a/src/Chr.Avro/Abstract/EnumSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/EnumSchemaBuilderCase.cs
@@ -53,7 +53,15 @@ namespace Chr.Avro.Abstract
             {
                 Schema schema;
 
-                if (type.GetAttribute<FlagsAttribute>() == null && EnumBehavior == EnumBehavior.Symbolic)
+                if (type.GetAttribute<FlagsAttribute>() is not null || EnumBehavior == EnumBehavior.Integral)
+                {
+                    schema = SchemaBuilder.BuildSchema(type.GetEnumUnderlyingType(), context);
+                }
+                else if (EnumBehavior == EnumBehavior.Nominal)
+                {
+                    schema = new StringSchema();
+                }
+                else
                 {
                     schema = new EnumSchema(type.Name)
                     {
@@ -66,10 +74,6 @@ namespace Chr.Avro.Abstract
                             .Select(field => field.Name)
                             .ToList(),
                     };
-                }
-                else
-                {
-                    schema = SchemaBuilder.BuildSchema(type.GetEnumUnderlyingType(), context);
                 }
 
                 try

--- a/src/Chr.Avro/Serialization/StringDeserializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/StringDeserializerBuilderCase.cs
@@ -46,6 +46,15 @@ namespace Chr.Avro.Serialization
                         Expression.Constant(DateTimeStyles.RoundtripKind)),
                     target);
             }
+            else if (target.IsEnum)
+            {
+                var parseEnum = typeof(Enum)
+                    .GetMethod(nameof(Enum.Parse), new[] { typeof(Type), value.Type });
+
+                value = Expression.Convert(
+                    Expression.Call(null, parseEnum, Expression.Constant(target), value),
+                    target);
+            }
             else if (target == typeof(Guid) || target == typeof(Guid?))
             {
                 var guidConstructor = typeof(Guid)

--- a/src/Chr.Avro/Serialization/StringSerializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/StringSerializerBuilderCase.cs
@@ -66,6 +66,13 @@ namespace Chr.Avro.Serialization
                                 Expression.Constant("O"),
                                 Expression.Constant(CultureInfo.InvariantCulture)))),
                     Expression.IfThen(
+                        Expression.Property(Expression.Call(intermediate, getType), isEnum),
+                        Expression.Return(
+                            result,
+                            Expression.Call(
+                                intermediate,
+                                toString))),
+                    Expression.IfThen(
                         Expression.TypeIs(intermediate, typeof(Guid)),
                         Expression.Return(
                             result,
@@ -118,6 +125,13 @@ namespace Chr.Avro.Serialization
                         convertDateTimeOffset,
                         Expression.Constant("O"),
                         Expression.Constant(CultureInfo.InvariantCulture));
+                }
+                else if (value.Type.IsEnum)
+                {
+                    var convertEnum = typeof(Enum)
+                        .GetMethod(nameof(Enum.ToString), Type.EmptyTypes);
+
+                    value = Expression.Call(value, convertEnum);
                 }
                 else if (value.Type == typeof(Guid))
                 {

--- a/tests/Chr.Avro.Binary.Tests/StringSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/StringSerializationTests.cs
@@ -38,6 +38,12 @@ namespace Chr.Avro.Serialization.Tests
             new object[] { new DateTimeOffset(new DateTime(2000, 01, 01, 0, 0, 0, DateTimeKind.Utc)) },
         };
 
+        public static IEnumerable<object[]> Enums => new List<object[]>
+        {
+            new object[] { DateTimeKind.Unspecified },
+            new object[] { DateTimeKind.Local },
+        };
+
         public static IEnumerable<object[]> Guids => new List<object[]>
         {
             new object[] { Guid.Empty },
@@ -208,6 +214,25 @@ namespace Chr.Avro.Serialization.Tests
             // comparing two DateTimeOffsets doesn’t necessarily ensure that they’re identical:
             Assert.Equal(value.DateTime, decoded.Value.DateTime);
             Assert.Equal(value.Offset, decoded.Value.Offset);
+        }
+
+        [Theory]
+        [MemberData(nameof(Enums))]
+        public void EnumValues(DateTimeKind value)
+        {
+            var schema = new StringSchema();
+
+            var deserialize = deserializerBuilder.BuildDelegate<DateTimeKind>(schema);
+            var serialize = serializerBuilder.BuildDelegate<DateTimeKind>(schema);
+
+            using (stream)
+            {
+                serialize(value, new BinaryWriter(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+
+            Assert.Equal(value, deserialize(ref reader));
         }
 
         [Theory]

--- a/tests/Chr.Avro.Json.Tests/StringSerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/StringSerializationTests.cs
@@ -36,6 +36,12 @@ namespace Chr.Avro.Serialization.Tests
             new object[] { new DateTimeOffset(new DateTime(2000, 01, 01, 0, 0, 0, DateTimeKind.Utc)) },
         };
 
+        public static IEnumerable<object[]> Enums => new List<object[]>
+        {
+            new object[] { DateTimeKind.Unspecified },
+            new object[] { DateTimeKind.Local },
+        };
+
         public static IEnumerable<object[]> Guids => new List<object[]>
         {
             new object[] { Guid.Empty },
@@ -205,6 +211,25 @@ namespace Chr.Avro.Serialization.Tests
             // comparing two DateTimeOffsets doesn’t necessarily ensure that they’re identical:
             Assert.Equal(value.DateTime, decoded.Value.DateTime);
             Assert.Equal(value.Offset, decoded.Value.Offset);
+        }
+
+        [Theory]
+        [MemberData(nameof(Enums))]
+        public void EnumValues(DateTimeKind value)
+        {
+            var schema = new StringSchema();
+
+            var deserialize = deserializerBuilder.BuildDelegate<DateTimeKind>(schema);
+            var serialize = serializerBuilder.BuildDelegate<DateTimeKind>(schema);
+
+            using (stream)
+            {
+                serialize(value, new Utf8JsonWriter(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+
+            Assert.Equal(value, deserialize(ref reader));
         }
 
         [Theory]


### PR DESCRIPTION
This change implements the reverse of #161, serializing and deserializing .NET enums as string schemas. Since we already support mapping to integral types, this change is consistent with the library’s behavior generally.