### PR TITLE
Add missing cache call on UUID schema reader case

### DIFF
--- a/src/Chr.Avro.Json/Representation/JsonUuidSchemaReaderCase.cs
+++ b/src/Chr.Avro.Json/Representation/JsonUuidSchemaReaderCase.cs
@@ -35,6 +35,8 @@ namespace Chr.Avro.Representation
                     {
                         LogicalType = new UuidLogicalType(),
                     };
+
+                    context.Schemas.Add(key, schema);
                 }
 
                 return JsonSchemaReaderCaseResult.FromSchema(schema);


### PR DESCRIPTION
The UUID schema reader case is missing a call to cache its schema model, so attempts to read union schemas containing UUID schemas fail with:

```
System.InvalidOperationException : Sequence contains no matching element
  Stack Trace:
     at System.Linq.ThrowHelper.ThrowNoMatchException()
   at System.Linq.Enumerable.Single[TSource](IEnumerable`1 source, Func`2 predicate)
   at Chr.Avro.Representation.JsonUnionSchemaReaderCase.<>c__DisplayClass4_0.<Read>b__1(Schema s) in /_/src/Chr.Avro.Json/Representation/JsonUnionSchemaReaderCase.cs:line 48
   at System.Linq.Enumerable.SelectArrayIterator`2.MoveNext()
   at System.String.Join(String separator, IEnumerable`1 values)
   at Chr.Avro.Representation.JsonUnionSchemaReaderCase.Read(JsonElement element, JsonSchemaReaderContext context) in /_/src/Chr.Avro.Json/Representation/JsonUnionSchemaReaderCase.cs:line 48
```

This bug also breaks schema reader semantics in that each UUID schema in the abstract model will be represented by a unique instance, though in practice, that usually doesn’t matter.