### PR TITLE
Use `[EnumMember]` values when serializing enum types to `"string"`

### DIFF
--- a/src/Chr.Avro/Abstract/EnumSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/EnumSchemaBuilderCase.cs
@@ -69,22 +69,10 @@ namespace Chr.Avro.Abstract
                         Namespace = GetSchemaNamespace(type),
                     };
 
-                    foreach (var member in type.GetMembers(BindingFlags.Public | BindingFlags.Static)
+                    foreach (var member in type.GetEnumMembers()
                         .OrderBy(field => Enum.Parse(type, field.Name))
                         .ThenBy(field => field.Name))
                     {
-                        if (!type.HasAttribute<DataContractAttribute>()
-                            && member.HasAttribute<NonSerializedAttribute>())
-                        {
-                            continue;
-                        }
-
-                        if (type.HasAttribute<DataContractAttribute>()
-                            && !member.HasAttribute<EnumMemberAttribute>())
-                        {
-                            continue;
-                        }
-
                         enumSchema.Symbols.Add(GetSymbol(member));
                     }
 
@@ -164,16 +152,7 @@ namespace Chr.Avro.Abstract
         /// </returns>
         protected virtual string GetSymbol(MemberInfo member)
         {
-            if (member.DeclaringType.HasAttribute<DataContractAttribute>()
-                && member.GetAttribute<EnumMemberAttribute>() is EnumMemberAttribute memberAttribute
-                && !string.IsNullOrEmpty(memberAttribute.Value))
-            {
-                return memberAttribute.Value;
-            }
-            else
-            {
-                return member.Name;
-            }
+            return member.GetEnumMemberName();
         }
     }
 }

--- a/src/Chr.Avro/Abstract/RecordSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/RecordSchemaBuilderCase.cs
@@ -95,24 +95,12 @@ namespace Chr.Avro.Abstract
                     throw new InvalidOperationException($"A schema for {type} already exists on the schema builder context.", exception);
                 }
 
-                foreach (var member in type.GetMembers(MemberVisibility)
+                foreach (var member in type.GetDataMembers(MemberVisibility)
                     .OrderBy(member => type.HasAttribute<DataContractAttribute>()
                         ? member.GetAttribute<DataMemberAttribute>()?.Order ?? 0
                         : default)
                     .ThenBy(member => member.Name))
                 {
-                    if (!type.HasAttribute<DataContractAttribute>()
-                        && member.HasAttribute<NonSerializedAttribute>())
-                    {
-                        continue;
-                    }
-
-                    if (type.HasAttribute<DataContractAttribute>()
-                        && !member.HasAttribute<DataMemberAttribute>())
-                    {
-                        continue;
-                    }
-
                     var memberType = member switch
                     {
                         FieldInfo fieldInfo => fieldInfo.FieldType,
@@ -174,16 +162,7 @@ namespace Chr.Avro.Abstract
         /// </returns>
         protected virtual string GetFieldName(MemberInfo member)
         {
-            if (member.DeclaringType.HasAttribute<DataContractAttribute>()
-                && member.GetAttribute<DataMemberAttribute>() is DataMemberAttribute memberAttribute
-                && !string.IsNullOrEmpty(memberAttribute.Name))
-            {
-                return memberAttribute.Name;
-            }
-            else
-            {
-                return member.Name;
-            }
+            return member.GetDataMemberName();
         }
 
         /// <summary>
@@ -365,7 +344,7 @@ namespace Chr.Avro.Abstract
                     {
                         return new BytesSchema()
                         {
-                            LogicalType = logicalType
+                            LogicalType = logicalType,
                         };
                     }
 


### PR DESCRIPTION
Closes #214.