### PR TITLE
Enable Documentation in Schema via Description Attribute

### DIFF
--- a/src/Chr.Avro.Fixtures/Fixtures/DescriptionAnnotatedClass.cs
+++ b/src/Chr.Avro.Fixtures/Fixtures/DescriptionAnnotatedClass.cs
@@ -1,0 +1,15 @@
+#pragma warning disable SA1401 // allow public fields
+
+namespace Chr.Avro.Fixtures
+{
+    using System.ComponentModel;
+
+    [Description("Test")]
+    public class DescriptionAnnotatedClass
+    {
+        public int UnannotatedField;
+
+        [Description("Test")]
+        public string DescriptionField;
+    }
+}

--- a/src/Chr.Avro/Abstract/RecordSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/RecordSchemaBuilderCase.cs
@@ -77,6 +77,7 @@ namespace Chr.Avro.Abstract
                 var recordSchema = new RecordSchema(GetSchemaName(type))
                 {
                     Namespace = GetSchemaNamespace(type),
+                    Documentation = type.GetAttribute<DescriptionAttribute>()?.Description,
                 };
 
                 Schema schema = recordSchema;
@@ -113,7 +114,10 @@ namespace Chr.Avro.Abstract
                         continue;
                     }
 
-                    var field = new RecordField(GetFieldName(member), SchemaBuilder.BuildSchema(memberType, context));
+                    var field = new RecordField(GetFieldName(member), SchemaBuilder.BuildSchema(memberType, context))
+                    {
+                        Documentation = member.GetAttribute<DescriptionAttribute>()?.Description,
+                    };
 
                     if (NullableReferenceTypeBehavior == NullableReferenceTypeBehavior.Annotated)
                     {

--- a/tests/Chr.Avro.Tests/Abstract/SchemaBuilderShould.cs
+++ b/tests/Chr.Avro.Tests/Abstract/SchemaBuilderShould.cs
@@ -172,6 +172,14 @@ namespace Chr.Avro.Tests
         }
 
         [Fact]
+        public void BuildClassesWithDescriptionAttributes()
+        {
+            var schema = Assert.IsType<RecordSchema>(builder.BuildSchema<DescriptionAnnotatedClass>());
+            Assert.NotNull(schema.Documentation);
+            Assert.NotNull(schema.Fields.First(f => f.Name == nameof(DescriptionAnnotatedClass.DescriptionField)).Documentation);
+        }
+
+        [Fact]
         public void BuildClassesWithNullableProperties()
         {
             var context = new SchemaBuilderContext();


### PR DESCRIPTION
## What
Enabling the `[Description("")]` attribute to be used on the classes and/or class members to populate the `doc` fields within the generated Avro schema

## Why
As discussed here #131 .
This is very useful for embedded documentation. The Description attribute seems like a perfect for this and it keeps code and documentation close together to avoid drifts.