### PR TITLE
Fix broken serde build checks in `registry-test` verb

### DIFF
--- a/src/Chr.Avro.Cli/Cli/TestSchemaVerb.cs
+++ b/src/Chr.Avro.Cli/Cli/TestSchemaVerb.cs
@@ -2,7 +2,7 @@ namespace Chr.Avro.Cli
 {
     using System;
     using System.Collections.Generic;
-    using System.Reflection;
+    using System.Linq.Expressions;
     using System.Threading.Tasks;
     using Chr.Avro.Representation;
     using Chr.Avro.Serialization;
@@ -59,29 +59,25 @@ namespace Chr.Avro.Cli
             try
             {
                 var builder = new BinaryDeserializerBuilder();
-                var method = typeof(BinaryDeserializerBuilder)
-                    .GetMethod(nameof(BinaryDeserializerBuilder.BuildDelegate))
-                    .MakeGenericMethod(type);
+                var context = new BinaryDeserializerBuilderContext();
 
-                method.Invoke(builder, new[] { schema });
+                builder.BuildExpression(type, schema, context);
             }
-            catch (TargetInvocationException exception) when (exception.InnerException is Exception inner)
+            catch (Exception exception)
             {
-                throw new ProgramException(message: $"A deserializer cannot be created for {type}: {inner.Message}", inner: inner);
+                throw new ProgramException(message: $"A deserializer cannot be created for {type}: {exception.Message}", inner: exception);
             }
 
             try
             {
                 var builder = new BinarySerializerBuilder();
-                var method = typeof(IBinarySerializerBuilder)
-                    .GetMethod(nameof(IBinarySerializerBuilder.BuildDelegate))
-                    .MakeGenericMethod(type);
+                var context = new BinarySerializerBuilderContext();
 
-                method.Invoke(builder, new[] { schema });
+                builder.BuildExpression(Expression.Parameter(type), schema, context);
             }
-            catch (TargetInvocationException exception) when (exception.InnerException is Exception inner)
+            catch (Exception exception)
             {
-                throw new ProgramException(message: $"A serializer cannot be created for {type}: {inner.Message}", inner: inner);
+                throw new ProgramException(message: $"A serializer cannot be created for {type}: {exception.Message}", inner: exception);
             }
 
             Console.Error.WriteLine($"{type} is compatible with the schema.");


### PR DESCRIPTION
`registry-test` relies on reflective method invocations that are no longer correct after signature changes in 8.0.0:

```
Unhandled exception. System.Reflection.TargetParameterCountException: Parameter count mismatch.
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
   at Chr.Avro.Cli.TestSchemaVerb.Run() in /_/src/Chr.Avro.Cli/Cli/TestSchemaVerb.cs:line 62
   at Chr.Avro.Cli.Verb.Execute() in /_/src/Chr.Avro.Cli/Cli/Verb.cs:line 12   at Chr.Avro.Cli.Program.<Main>(String[] args)
```

This change switches to the `BuildExpression` methods which produce the same results.