### PR TITLE
Support .NET 7

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - name: Pull code
         uses: actions/checkout@v2
+      - name: Use .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          global-json-file: global.json
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - name: Pull code
         uses: actions/checkout@v2
+      - name: Use .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          global-json-file: global.json
       - name: Build packages
         uses: cake-build/cake-action@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ jobs:
     steps:
       - name: Pull code
         uses: actions/checkout@v2
+      - name: Use .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          global-json-file: global.json
       - name: Run unit tests
         uses: cake-build/cake-action@v1
         with:

--- a/benchmarks/dotnet/Chr.Avro.Benchmarks.csproj
+++ b/benchmarks/dotnet/Chr.Avro.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/benchmarks/dotnet/Program.cs
+++ b/benchmarks/dotnet/Program.cs
@@ -74,7 +74,7 @@ namespace Chr.Avro.Benchmarks
                 {
                     yield return new Result()
                     {
-                        Runtime = "net6.0",
+                        Runtime = "net7.0",
                         Library = runner.Library,
                         Suite = runner.Suite,
                         Iterations = runner.Iterations,

--- a/examples/Chr.Avro.DefaultValuesExample/Chr.Avro.DefaultValuesExample.csproj
+++ b/examples/Chr.Avro.DefaultValuesExample/Chr.Avro.DefaultValuesExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Chr.Avro.UnionTypeExample/Chr.Avro.UnionTypeExample.csproj
+++ b/examples/Chr.Avro.UnionTypeExample/Chr.Avro.UnionTypeExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/global",
+  "sdk": {
+    "rollForward": "latestFeature",
+    "version": "7.0.100"
+  }
+}

--- a/src/Chr.Avro.Cli/Chr.Avro.Cli.csproj
+++ b/src/Chr.Avro.Cli/Chr.Avro.Cli.csproj
@@ -5,7 +5,7 @@
     <IsPackable>true</IsPackable>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <ToolCommandName>dotnet-avro</ToolCommandName>
   </PropertyGroup>
 

--- a/tests/Chr.Avro.Binary.Tests/Chr.Avro.Binary.Tests.csproj
+++ b/tests/Chr.Avro.Binary.Tests/Chr.Avro.Binary.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Chr.Avro.Confluent.Tests/Chr.Avro.Confluent.Tests.csproj
+++ b/tests/Chr.Avro.Confluent.Tests/Chr.Avro.Confluent.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Chr.Avro.Json.Tests/Chr.Avro.Json.Tests.csproj
+++ b/tests/Chr.Avro.Json.Tests/Chr.Avro.Json.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Chr.Avro.Tests/Chr.Avro.Tests.csproj
+++ b/tests/Chr.Avro.Tests/Chr.Avro.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Chr.Avro.Cli needs to be released with support for .NET 7. Per the [Microsoft support policy](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core), we no longer need to support .NET 5 or .NET Core 3.1 after December 13, so the next major version will drop those CLI targets.

This change also locks CI to a major SDK, which we hadn’t been doing.