### PR TITLE
Fix possible dynamic binding exception in Schema Registry serializer

### DIFF
--- a/src/Chr.Avro.Confluent/Confluent/SchemaRegistryDeserializerBuilder.cs
+++ b/src/Chr.Avro.Confluent/Confluent/SchemaRegistryDeserializerBuilder.cs
@@ -213,8 +213,9 @@ namespace Chr.Avro.Confluent
 
             var inner = DeserializerBuilder.BuildDelegateExpression<T>(schema);
             var span = Expression.Parameter(typeof(ReadOnlySpan<byte>));
+            var reader = inner.Parameters[0];
 
-            var readerConstructor = inner.Parameters[0].Type
+            var readerConstructor = reader.Type
                 .GetConstructor(new[] { span.Type });
 
             if (schema is BytesSchema)


### PR DESCRIPTION
When building Schema Registry serializers for dynamic types, serialization may fail:

```csharp
using var builder = new SchemaRegistrySerializerBuilder(registry);
var context = new SerializationContext(MessageComponentType.Value, "some-topic");
var serializer = await builder.Build<dynamic>(schemaId);

dynamic value = new ExpandoObject();
value.Field = "some text";

serializer.Serialize(value, context);
```

```
Error:

Microsoft.CSharp.RuntimeBinder.RuntimeBinderException: Cannot perform runtime binding on a null reference
   at CallSite.Target(Closure , CallSite , ExpandoObject )
   at System.Dynamic.UpdateDelegates.UpdateAndExecute1[T0,TRet](CallSite site, T0 arg0)
   at ExampleRecord serializer(Closure , ExpandoObject , BinaryWriter )
   at Chr.Avro.Confluent.DelegateSerializer`1.Serialize(T data, SerializationContext context)
```