### PR TITLE
Expose ReadOnlySpan<byte> from BinaryReader

### DIFF
--- a/src/Chr.Avro.Binary/Serialization/BinaryReader.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryReader.cs
@@ -53,6 +53,18 @@ namespace Chr.Avro.Serialization
         }
 
         /// <summary>
+        /// Reads variable-length binary data from the current position and advances the reader.
+        /// </summary>
+        /// <returns>
+        /// An span of <see cref="byte" />s with length specified by the integer at the current
+        /// position.
+        /// </returns>
+        public ReadOnlySpan<byte> ReadSpan()
+        {
+            return ReadFixedSpan((int)ReadInteger());
+        }
+
+        /// <summary>
         /// Reads a double-precision floating-point number from the current position and advances
         /// the reader.
         /// </summary>
@@ -82,10 +94,23 @@ namespace Chr.Avro.Serialization
         /// </returns>
         public byte[] ReadFixed(int length)
         {
+            return ReadFixedSpan(length).ToArray();
+        }
+
+        /// <summary>
+        /// Reads fixed-length binary data from the current position and advances the reader.
+        /// </summary>
+        /// <param name="length">
+        /// The number of bytes to read.
+        /// </param>
+        /// <returns>
+        /// An span of <see cref="byte" />s with length specified by <paramref name="length" />.
+        /// </returns>
+        public ReadOnlySpan<byte> ReadFixedSpan(int length)
+        {
             var slice = data.Slice(index, length);
             index += length;
-
-            return slice.ToArray();
+            return slice;
         }
 
         /// <summary>

--- a/src/Chr.Avro.Binary/Serialization/BinaryReader.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryReader.cs
@@ -59,7 +59,7 @@ namespace Chr.Avro.Serialization
         /// An span of <see cref="byte" />s with length specified by the integer at the current
         /// position.
         /// </returns>
-        public ReadOnlySpan<byte> ReadSpan()
+        public ReadOnlySpan<byte> ReadBytesSpan()
         {
             return ReadFixedSpan((int)ReadInteger());
         }


### PR DESCRIPTION
This PR exposes ReadOnlySpan<byte> from BinaryReader to offer an allocation-free alternative to the current ReadBytes.

Specific use cases would for example be custom IBinaryDeserializerBuilderCase-implementations that may intern strings directly on deserialization via [StringPools](https://www.nuget.org/packages/Microsoft.Toolkit.HighPerformance), and/or choose to skip deserialization of strings entirely if they're not bound to any DTO property.

If you would like to merge this PR here, I would be tempted to create a separate follow-PR and include a few more optimisations:
- BinaryDeserializer.ReadString use Encoding.GetString(ReadOnlySpan&lt;byte&gt;)
- ReadDouble to use BinaryPrimitives.ReadDoubleLittleEndian(ReadOnlySpan&lt;byte&gt;)

To avoid the extra array allocations there as well. Those functions are only available in netstandard2.1+ and .net5+ respectively, so would require addition additional target frameworks to Chr.Avro.Binary etc. in order to use those via conditional compilation. Let me know if you'd be open to / interested in such a change?