### PR TITLE
multitargeting .netstandard2.0 and .net6

### DIFF
--- a/src/Chr.Avro.Binary/Chr.Avro.Binary.csproj
+++ b/src/Chr.Avro.Binary/Chr.Avro.Binary.csproj
@@ -4,7 +4,7 @@
     <Description>Avro binary serialization and deserialization</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Chr.Avro.Confluent/Chr.Avro.Confluent.csproj
+++ b/src/Chr.Avro.Confluent/Chr.Avro.Confluent.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Integration tools for the Confluent Kafka and Schema Registry clients</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Chr.Avro.Json/Chr.Avro.Json.csproj
+++ b/src/Chr.Avro.Json/Chr.Avro.Json.csproj
@@ -4,7 +4,7 @@
     <Description>Avro JSON serialization and deserialization</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Chr.Avro/Abstract/RecordSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/RecordSchemaBuilderCase.cs
@@ -9,6 +9,10 @@ namespace Chr.Avro.Abstract
     using System.Runtime.Serialization;
     using System.Text.RegularExpressions;
     using Chr.Avro.Infrastructure;
+    using NullabilityInfoContext = Chr.Avro.Infrastructure.NullabilityInfoContext;
+    using NullabilityState = Chr.Avro.Infrastructure.NullabilityState;
+    using NullabilityInfo = Chr.Avro.Infrastructure.NullabilityInfo;
+
 
     /// <summary>
     /// Implements a <see cref="SchemaBuilder" /> case that matches any non-array or non-primitive

--- a/src/Chr.Avro/Chr.Avro.csproj
+++ b/src/Chr.Avro/Chr.Avro.csproj
@@ -4,7 +4,7 @@
     <Description>Avro schema models</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
PR based on our chat [here](https://github.com/ch-robinson/dotnet-avro/pull/267).

A few thoughts for this one here:
1. You mentioned "configuring CI for both targets" - I'm probably not seeing the wood for the trees, but best I could see that looks to already be working out of the box. Unit tests are run correctly for all target frameworks individually by dotnet test, and dotnet pack includes targets for all configured frameworks as well. Please shout of course if I missed anything / any other CI concerns?
2. This PR would multitarget a subset of the library projects, but the choice was admittedly a bit arbitrary. For the proposed BinaryReader changes, multitargeting Chr.Avro.Binary would be enough - but you mentioned a few other pending changes as well, so I've added other projects that I reckon _might_ use newer features at some point. Worth a think though if you'd rather keep it down to a smaller (or even larger) set of the projects for now?
3. For the proposed BinaryReader changes, .netstandard 2.1 and .net5 would be enough; not sure if you'd be keen on a fairly extensive set of target frameworks though, so have kept it to .Net6 for now as the benefit of being all too granular here is probably limited anyway
