### PR TITLE
multitargeting .netstandard2.0 and .net6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ jobs:
       - name: Use .NET
         uses: actions/setup-dotnet@v3
         with:
-          global-json-file: global.json
+          dotnet-version: |
+            3.1.x
+            7.0.100
       - name: Build packages
         uses: cake-build/cake-action@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,9 @@ jobs:
       - name: Use .NET
         uses: actions/setup-dotnet@v3
         with:
-          global-json-file: global.json
+          dotnet-version: |
+            3.1.x
+            7.0.100
       - name: Run unit tests
         uses: cake-build/cake-action@v1
         with:

--- a/src/Chr.Avro.Binary/Chr.Avro.Binary.csproj
+++ b/src/Chr.Avro.Binary/Chr.Avro.Binary.csproj
@@ -4,7 +4,7 @@
     <Description>Avro binary serialization and deserialization</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Chr.Avro.Confluent/Chr.Avro.Confluent.csproj
+++ b/src/Chr.Avro.Confluent/Chr.Avro.Confluent.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Integration tools for the Confluent Kafka and Schema Registry clients</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Chr.Avro/Abstract/RecordSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/RecordSchemaBuilderCase.cs
@@ -9,6 +9,10 @@ namespace Chr.Avro.Abstract
     using System.Runtime.Serialization;
     using System.Text.RegularExpressions;
     using Chr.Avro.Infrastructure;
+    using NullabilityInfoContext = Chr.Avro.Infrastructure.NullabilityInfoContext;
+    using NullabilityState = Chr.Avro.Infrastructure.NullabilityState;
+    using NullabilityInfo = Chr.Avro.Infrastructure.NullabilityInfo;
+
 
     /// <summary>
     /// Implements a <see cref="SchemaBuilder" /> case that matches any non-array or non-primitive

--- a/src/Chr.Avro/Chr.Avro.csproj
+++ b/src/Chr.Avro/Chr.Avro.csproj
@@ -4,7 +4,7 @@
     <Description>Avro schema models</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
@@ -83,7 +83,7 @@ namespace Chr.Avro.Serialization.Tests
 
             using (stream)
             {
-                serialize(value, new BinaryWriter(stream));
+                serialize(new ArraySegment<long>(value), new BinaryWriter(stream));
             }
 
             var reader = new BinaryReader(stream.ToArray());

--- a/tests/Chr.Avro.Binary.Tests/Chr.Avro.Binary.Tests.csproj
+++ b/tests/Chr.Avro.Binary.Tests/Chr.Avro.Binary.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,5 +15,7 @@
     <ProjectReference Include="..\..\src\Chr.Avro.Binary\Chr.Avro.Binary.csproj" />
     <ProjectReference Include="..\..\src\Chr.Avro.Fixtures\Chr.Avro.Fixtures.csproj" />
   </ItemGroup>
+
+
 
 </Project>

--- a/tests/Chr.Avro.Confluent.Tests/Chr.Avro.Confluent.Tests.csproj
+++ b/tests/Chr.Avro.Confluent.Tests/Chr.Avro.Confluent.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Chr.Avro.Tests/Chr.Avro.Tests.csproj
+++ b/tests/Chr.Avro.Tests/Chr.Avro.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
PR following up our chat [here](https://github.com/ch-robinson/dotnet-avro/pull/267)

A few things worth noting:

1. I've added multi-targeting to a few projects that seemed like it may be useful in the future - but worth a thought if you'd rather have a smaller subset of projects to begin with? (For the proposed binary reader changes, just Chr.Avro.Binary would be enough, but you mentioned there are a few other ideas in the pipeline as well)

2. It might be nice to run tests under the lowest possible .NET version supporting .NetStandard 2.0, but there are a few hurdles:
  - Net Framework 4.6.1 has several incompatibilities
  - Net Framework 4.6.2 has less limitations (would still need a few changes), but mainly would need a windows-based build
  - Net Core < 3.1 isn't compatible with the current Microsoft.NET.Test.SDK version, so would need a downgrade for that
  - Hence, .NetCore 3.1 seemed like the most feasible lowest common denominator without more intrusive changes

3. Chr.Avro.Json.Tests has a few test failures when run under .NetCore 3.1 (unrelated to any changes here), so I've left this one out for the time being & will lodge a separate issue for that

