### PR TITLE
zero-copy double & string deserialization for .net6+

### DIFF
--- a/src/Chr.Avro.Binary/Serialization/BinaryReader.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryReader.cs
@@ -156,6 +156,9 @@ namespace Chr.Avro.Serialization
         /// </returns>
         public float ReadSingle()
         {
+#if NET6_0_OR_GREATER
+            return BinaryPrimitives.ReadSingleLittleEndian(ReadFixedSpan(4));
+#else
             var bytes = ReadFixed(4);
 
             if (!BitConverter.IsLittleEndian)
@@ -164,6 +167,7 @@ namespace Chr.Avro.Serialization
             }
 
             return BitConverter.ToSingle(bytes, 0);
+#endif
         }
 
         /// <summary>

--- a/src/Chr.Avro.Binary/Serialization/BinaryReader.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryReader.cs
@@ -1,3 +1,5 @@
+using System.Buffers.Binary;
+
 namespace Chr.Avro.Serialization
 {
     using System;
@@ -73,6 +75,10 @@ namespace Chr.Avro.Serialization
         /// </returns>
         public double ReadDouble()
         {
+#if NET6_0_OR_GREATER
+            return BinaryPrimitives.ReadDoubleLittleEndian(ReadFixedSpan(8));
+#else
+
             var bytes = ReadFixed(8);
 
             if (!BitConverter.IsLittleEndian)
@@ -81,6 +87,7 @@ namespace Chr.Avro.Serialization
             }
 
             return BitConverter.ToDouble(bytes, 0);
+#endif
         }
 
         /// <summary>
@@ -135,8 +142,7 @@ namespace Chr.Avro.Serialization
                 {
                     throw new InvalidEncodingException(index, "Unable to read a valid variable-length integer. This may indicate invalid encoding earlier in the stream.");
                 }
-            }
-            while (current > 0x7F);
+            } while (current > 0x7F);
 
             return (-(result & 0x01)) ^ ((result >> 0x01) & 0x7FFFFFFFFFFFFFFF);
         }
@@ -169,7 +175,11 @@ namespace Chr.Avro.Serialization
         /// </returns>
         public string ReadString()
         {
+#if NET6_0_OR_GREATER
+            return Encoding.UTF8.GetString(ReadBytesSpan());
+#else
             return Encoding.UTF8.GetString(ReadBytes());
+#endif
         }
     }
 }

--- a/tests/Chr.Avro.Binary.Tests/BinaryReaderTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/BinaryReaderTests.cs
@@ -54,6 +54,13 @@ namespace Chr.Avro.Serialization.Tests
             new object[] { float.PositiveInfinity, new byte[] { 0x00, 0x00, 0x80, 0x7f } },
         };
 
+        public static IEnumerable<object[]> StringEncodings => new object[][]
+        {
+            new object[] { "test", new byte[] { 0x08, 0x74, 0x65, 0x73, 0x74 } },
+            new object[] { "𝄟", new byte[] { 0x08, 0xF0, 0x9D, 0x84, 0x9F } },
+        };
+
+
         [Theory]
         [MemberData(nameof(BooleanEncodings))]
         [InlineData(true, new byte[] { 0x02 })]
@@ -85,6 +92,14 @@ namespace Chr.Avro.Serialization.Tests
         {
             var reader = new BinaryReader(encoding);
             Assert.Equal(value, reader.ReadSingle());
+        }
+
+        [Theory]
+        [MemberData(nameof(StringEncodings))]
+        public void ReadString(string value, byte[] encoding)
+        {
+            var reader = new BinaryReader(encoding);
+            Assert.Equal(value, reader.ReadString());
         }
 
         [Theory]


### PR DESCRIPTION
I've made these conditional on NET6_0_OR_GREATER for now. We could set the requirement lower, but it's probably nicer to avoid NETSTANDARD2_1_OR_GREATER for now, given the lowest tested framework (netcore3.1) already matches netstandard 2.1 - so have kept it a bit simpler (especially since only .netstandard2.0 and .net6 are targeted anyway at the moment)