### PR TITLE
Test netstandard2.0 target on .NET Framework

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,7 @@ jobs:
       - name: Use .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: |
-            3.1.x
-            7.0.100
+          global-json-file: global.json
       - name: Build packages
         uses: cake-build/cake-action@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,17 +5,25 @@ on: push
 jobs:
   test:
     name: Run library tests
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: net462
+            os: windows-latest
+          - target: net7.0
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - name: Pull code
         uses: actions/checkout@v3
       - name: Use .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: |
-            3.1.x
-            7.0.100
+          global-json-file: global.json
       - name: Run unit tests
-        uses: cake-build/cake-action@v1
-        with:
-          target: Test
+        run: |
+          set -e
+          dotnet test --framework ${{ matrix.target }} tests\\Chr.Avro.Tests
+          dotnet test --framework ${{ matrix.target }} tests\\Chr.Avro.Binary.Tests
+          dotnet test --framework ${{ matrix.target }} tests\\Chr.Avro.Json.Tests
+          dotnet test --framework ${{ matrix.target }} tests\\Chr.Avro.Confluent.Tests
+        shell: bash

--- a/src/Chr.Avro.Fixtures/Chr.Avro.Fixtures.csproj
+++ b/src/Chr.Avro.Fixtures/Chr.Avro.Fixtures.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Chr.Avro.Fixtures/Fixtures/RangeAnnotatedPropertiesClass.cs
+++ b/src/Chr.Avro.Fixtures/Fixtures/RangeAnnotatedPropertiesClass.cs
@@ -4,16 +4,28 @@ namespace Chr.Avro.Fixtures
 
     public class RangeAnnotatedPropertiesClass
     {
+#if NET6_0_OR_GREATER
         [Range(typeof(decimal), "0.00", "999999.99", ConvertValueInInvariantCulture = true)]
+#else
+        [Range(typeof(decimal), "0.00", "999999.99")]
+#endif
         public decimal Currency { get; set; }
 
+#if NET6_0_OR_GREATER
         [Range(typeof(decimal?), "0.00", "999999.99", ConvertValueInInvariantCulture = true)]
+#else
+        [Range(typeof(decimal?), "0.00", "999999.99")]
+#endif
         public decimal? NullableCurrency { get; set; }
 
+#if NET6_0_OR_GREATER
         [Range(typeof(decimal), "-.500", ".500", ConvertValueInInvariantCulture = true)]
+#else
+        [Range(typeof(decimal), "-.500", ".500")]
+#endif
         public decimal FractionOnly { get; set; }
 
-        [Range(typeof(decimal), "-5", "5", ConvertValueInInvariantCulture = true)]
+        [Range(typeof(decimal), "-5", "5")]
         public decimal WholeOnly { get; set; }
 
         [Range(0.0, 1.0)]

--- a/src/Chr.Avro.Json/Chr.Avro.Json.csproj
+++ b/src/Chr.Avro.Json/Chr.Avro.Json.csproj
@@ -4,11 +4,14 @@
     <Description>Avro JSON serialization and deserialization</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Json" Version="4.7.0" />
   </ItemGroup>
 

--- a/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
@@ -72,6 +72,7 @@ namespace Chr.Avro.Serialization.Tests
             Assert.Equal(value, deserialize(ref reader));
         }
 
+#if NET6_0_OR_GREATER
         [Theory]
         [MemberData(nameof(ArrayData))]
         public void ArraySegmentValues(long[] value)
@@ -90,6 +91,7 @@ namespace Chr.Avro.Serialization.Tests
 
             Assert.Equal(value, deserialize(ref reader));
         }
+#endif
 
         [Theory]
         [MemberData(nameof(ArrayData))]

--- a/tests/Chr.Avro.Binary.Tests/Chr.Avro.Binary.Tests.csproj
+++ b/tests/Chr.Avro.Binary.Tests/Chr.Avro.Binary.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>netcoreapp3.1;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,7 +15,5 @@
     <ProjectReference Include="..\..\src\Chr.Avro.Binary\Chr.Avro.Binary.csproj" />
     <ProjectReference Include="..\..\src\Chr.Avro.Fixtures\Chr.Avro.Fixtures.csproj" />
   </ItemGroup>
-
-
 
 </Project>

--- a/tests/Chr.Avro.Binary.Tests/UnionSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/UnionSerializationTests.cs
@@ -200,12 +200,12 @@ namespace Chr.Avro.Serialization.Tests
                 },
             });
 
-            var deserialize = deserializerBuilder.BuildDelegate<OrderCreatedEvent>(schema);
 
-            var serialize = new BinarySerializerBuilder(BinarySerializerBuilder
-                .CreateDefaultCaseBuilders()
-                .Prepend(builder => new OrderSerializerBuilderCase(builder)))
-                .BuildDelegate<OrderEvent>(schema);
+            var serializerCases = BinarySerializerBuilder.CreateDefaultCaseBuilders().ToList();
+            serializerCases.Insert(0, builder => new OrderSerializerBuilderCase(builder));
+
+            var deserialize = deserializerBuilder.BuildDelegate<OrderCreatedEvent>(schema);
+            var serialize = new BinarySerializerBuilder(serializerCases).BuildDelegate<OrderEvent>(schema);
 
             var value = new OrderCreatedEvent
             {
@@ -260,15 +260,14 @@ namespace Chr.Avro.Serialization.Tests
                 },
             };
 
-            var deserialize = new BinaryDeserializerBuilder(BinaryDeserializerBuilder
-                .CreateDefaultCaseBuilders()
-                .Prepend(builder => new OrderDeserializerBuilderCase(builder)))
-                .BuildDelegate<EventContainer>(schema);
+            var deserializerCases = BinaryDeserializerBuilder.CreateDefaultCaseBuilders().ToList();
+            deserializerCases.Insert(0, builder => new OrderDeserializerBuilderCase(builder));
 
-            var serialize = new BinarySerializerBuilder(BinarySerializerBuilder
-                .CreateDefaultCaseBuilders()
-                .Prepend(builder => new OrderSerializerBuilderCase(builder)))
-                .BuildDelegate<EventContainer>(schema);
+            var serializerCases = BinarySerializerBuilder.CreateDefaultCaseBuilders().ToList();
+            serializerCases.Insert(0, builder => new OrderSerializerBuilderCase(builder));
+
+            var deserialize = new BinaryDeserializerBuilder(deserializerCases).BuildDelegate<EventContainer>(schema);
+            var serialize = new BinarySerializerBuilder(serializerCases).BuildDelegate<EventContainer>(schema);
 
             var creation = new EventContainer
             {
@@ -342,15 +341,14 @@ namespace Chr.Avro.Serialization.Tests
                 },
             };
 
-            var deserialize = new BinaryDeserializerBuilder(BinaryDeserializerBuilder
-                .CreateDefaultCaseBuilders()
-                .Prepend(builder => new OrderDeserializerBuilderCase(builder)))
-                .BuildDelegate<EventContainer>(schema);
+            var deserializerCases = BinaryDeserializerBuilder.CreateDefaultCaseBuilders().ToList();
+            deserializerCases.Insert(0, builder => new OrderDeserializerBuilderCase(builder));
 
-            var serialize = new BinarySerializerBuilder(BinarySerializerBuilder
-                .CreateDefaultCaseBuilders()
-                .Prepend(builder => new OrderSerializerBuilderCase(builder)))
-                .BuildDelegate<EventContainer>(schema);
+            var serializerCases = BinarySerializerBuilder.CreateDefaultCaseBuilders().ToList();
+            serializerCases.Insert(0, builder => new OrderSerializerBuilderCase(builder));
+
+            var deserialize = new BinaryDeserializerBuilder(deserializerCases).BuildDelegate<EventContainer>(schema);
+            var serialize = new BinarySerializerBuilder(serializerCases).BuildDelegate<EventContainer>(schema);
 
             var creation = new EventContainer
             {
@@ -424,15 +422,14 @@ namespace Chr.Avro.Serialization.Tests
                 },
             };
 
-            var deserialize = new BinaryDeserializerBuilder(BinaryDeserializerBuilder
-                .CreateDefaultCaseBuilders()
-                .Prepend(builder => new OrderDeserializerBuilderCase(builder)))
-                .BuildDelegate<EventContainer>(schema);
+            var deserializerCases = BinaryDeserializerBuilder.CreateDefaultCaseBuilders().ToList();
+            deserializerCases.Insert(0, builder => new OrderDeserializerBuilderCase(builder));
 
-            var serialize = new BinarySerializerBuilder(BinarySerializerBuilder
-                .CreateDefaultCaseBuilders()
-                .Prepend(builder => new OrderSerializerBuilderCase(builder)))
-                .BuildDelegate<EventContainer>(schema);
+            var serializerCases = BinarySerializerBuilder.CreateDefaultCaseBuilders().ToList();
+            serializerCases.Insert(0, builder => new OrderSerializerBuilderCase(builder));
+
+            var deserialize = new BinaryDeserializerBuilder(deserializerCases).BuildDelegate<EventContainer>(schema);
+            var serialize = new BinarySerializerBuilder(serializerCases).BuildDelegate<EventContainer>(schema);
 
             var empty = new EventContainer
             {

--- a/tests/Chr.Avro.Confluent.Tests/Chr.Avro.Confluent.Tests.csproj
+++ b/tests/Chr.Avro.Confluent.Tests/Chr.Avro.Confluent.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>netcoreapp3.1;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Chr.Avro.Json.Tests/ArraySerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/ArraySerializationTests.cs
@@ -70,6 +70,7 @@ namespace Chr.Avro.Serialization.Tests
             Assert.Equal(value, deserialize(ref reader));
         }
 
+#if NET6_0_OR_GREATER
         [Theory]
         [MemberData(nameof(ArrayData))]
         public void ArraySegmentValues(long[] value)
@@ -88,6 +89,7 @@ namespace Chr.Avro.Serialization.Tests
 
             Assert.Equal(value, deserialize(ref reader));
         }
+#endif
 
         [Theory]
         [MemberData(nameof(ArrayData))]

--- a/tests/Chr.Avro.Json.Tests/Chr.Avro.Json.Tests.csproj
+++ b/tests/Chr.Avro.Json.Tests/Chr.Avro.Json.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Chr.Avro.Json.Tests/JsonDefaultValueShould.cs
+++ b/tests/Chr.Avro.Json.Tests/JsonDefaultValueShould.cs
@@ -9,7 +9,7 @@ namespace Chr.Avro.Abstract.Tests
         [Fact]
         public void ConvertValueToObject()
         {
-            var document = JsonSerializer.Deserialize<JsonDocument>("1");
+            using var document = JsonDocument.Parse("1");
             var element = document.RootElement;
 
             var schema = new IntSchema();
@@ -22,7 +22,7 @@ namespace Chr.Avro.Abstract.Tests
         [Fact]
         public void ThrowWhenConstructedWithNullSchema()
         {
-            var document = JsonSerializer.Deserialize<JsonDocument>("1");
+            using var document = JsonDocument.Parse("1");
             var element = document.RootElement;
 
             Assert.Throws<ArgumentNullException>(() => new JsonDefaultValue(element, null));
@@ -31,7 +31,7 @@ namespace Chr.Avro.Abstract.Tests
         [Fact]
         public void UseFirstChildOfUnionSchema()
         {
-            var document = JsonSerializer.Deserialize<JsonDocument>("1");
+            using var document = JsonDocument.Parse("1");
             var element = document.RootElement;
 
             var @int = new IntSchema();

--- a/tests/Chr.Avro.Json.Tests/UnionSerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/UnionSerializationTests.cs
@@ -190,12 +190,11 @@ namespace Chr.Avro.Serialization.Tests
                 },
             });
 
-            var deserialize = deserializerBuilder.BuildDelegate<OrderCreatedEvent>(schema);
+            var serializerCases = JsonSerializerBuilder.CreateDefaultCaseBuilders().ToList();
+            serializerCases.Insert(0, builder => new OrderSerializerBuilderCase(builder));
 
-            var serialize = new JsonSerializerBuilder(JsonSerializerBuilder
-                .CreateDefaultCaseBuilders()
-                .Prepend(builder => new OrderSerializerBuilderCase(builder)))
-                .BuildDelegate<OrderEvent>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<OrderCreatedEvent>(schema);
+            var serialize = new JsonSerializerBuilder(serializerCases).BuildDelegate<OrderEvent>(schema);
 
             var value = new OrderCreatedEvent
             {
@@ -250,15 +249,14 @@ namespace Chr.Avro.Serialization.Tests
                 },
             };
 
-            var deserialize = new JsonDeserializerBuilder(JsonDeserializerBuilder
-                .CreateDefaultCaseBuilders()
-                .Prepend(builder => new OrderDeserializerBuilderCase(builder)))
-                .BuildDelegate<EventContainer>(schema);
+            var deserializerCases = JsonDeserializerBuilder.CreateDefaultCaseBuilders().ToList();
+            deserializerCases.Insert(0, builder => new OrderDeserializerBuilderCase(builder));
 
-            var serialize = new JsonSerializerBuilder(JsonSerializerBuilder
-                .CreateDefaultCaseBuilders()
-                .Prepend(builder => new OrderSerializerBuilderCase(builder)))
-                .BuildDelegate<EventContainer>(schema);
+            var serializerCases = JsonSerializerBuilder.CreateDefaultCaseBuilders().ToList();
+            serializerCases.Insert(0, builder => new OrderSerializerBuilderCase(builder));
+
+            var deserialize = new JsonDeserializerBuilder(deserializerCases).BuildDelegate<EventContainer>(schema);
+            var serialize = new JsonSerializerBuilder(serializerCases).BuildDelegate<EventContainer>(schema);
 
             var creation = new EventContainer
             {
@@ -332,15 +330,14 @@ namespace Chr.Avro.Serialization.Tests
                 },
             };
 
-            var deserialize = new JsonDeserializerBuilder(JsonDeserializerBuilder
-                .CreateDefaultCaseBuilders()
-                .Prepend(builder => new OrderDeserializerBuilderCase(builder)))
-                .BuildDelegate<EventContainer>(schema);
+            var deserializerCases = JsonDeserializerBuilder.CreateDefaultCaseBuilders().ToList();
+            deserializerCases.Insert(0, builder => new OrderDeserializerBuilderCase(builder));
 
-            var serialize = new JsonSerializerBuilder(JsonSerializerBuilder
-                .CreateDefaultCaseBuilders()
-                .Prepend(builder => new OrderSerializerBuilderCase(builder)))
-                .BuildDelegate<EventContainer>(schema);
+            var serializerCases = JsonSerializerBuilder.CreateDefaultCaseBuilders().ToList();
+            serializerCases.Insert(0, builder => new OrderSerializerBuilderCase(builder));
+
+            var deserialize = new JsonDeserializerBuilder(deserializerCases).BuildDelegate<EventContainer>(schema);
+            var serialize = new JsonSerializerBuilder(serializerCases).BuildDelegate<EventContainer>(schema);
 
             var creation = new EventContainer
             {
@@ -414,15 +411,14 @@ namespace Chr.Avro.Serialization.Tests
                 },
             };
 
-            var deserialize = new JsonDeserializerBuilder(JsonDeserializerBuilder
-                .CreateDefaultCaseBuilders()
-                .Prepend(builder => new OrderDeserializerBuilderCase(builder)))
-                .BuildDelegate<EventContainer>(schema);
+            var deserializerCases = JsonDeserializerBuilder.CreateDefaultCaseBuilders().ToList();
+            deserializerCases.Insert(0, builder => new OrderDeserializerBuilderCase(builder));
 
-            var serialize = new JsonSerializerBuilder(JsonSerializerBuilder
-                .CreateDefaultCaseBuilders()
-                .Prepend(builder => new OrderSerializerBuilderCase(builder)))
-                .BuildDelegate<EventContainer>(schema);
+            var serializerCases = JsonSerializerBuilder.CreateDefaultCaseBuilders().ToList();
+            serializerCases.Insert(0, builder => new OrderSerializerBuilderCase(builder));
+
+            var deserialize = new JsonDeserializerBuilder(deserializerCases).BuildDelegate<EventContainer>(schema);
+            var serialize = new JsonSerializerBuilder(serializerCases).BuildDelegate<EventContainer>(schema);
 
             var empty = new EventContainer
             {

--- a/tests/Chr.Avro.Tests/Chr.Avro.Tests.csproj
+++ b/tests/Chr.Avro.Tests/Chr.Avro.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>netcoreapp3.1;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Chr.Avro.Tests/Chr.Avro.Tests.csproj
+++ b/tests/Chr.Avro.Tests/Chr.Avro.Tests.csproj
@@ -11,6 +11,10 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="System.Text.Json" Version="4.7.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Chr.Avro\Chr.Avro.csproj" />
     <ProjectReference Include="..\..\src\Chr.Avro.Fixtures\Chr.Avro.Fixtures.csproj" />


### PR DESCRIPTION
This adds an additional CI target for .NET Framework on Windows. I’m removing the netcoreapp3.1 target introduced in #269 as .NET Core 3.1 is out of support; we can evaluate additional targets if we discover issues that aren’t caught by this configuration.

Testing against .NET Framework surfaced a few issues:

* The `ConvertValueInInvariantCulture` property is not available on `RangeAnnotation` in .NET Framework 4.6.2; I fenced that property with 2fffc7b5e601cf579086f37a574610d892efd6d8.
* `JsonSerializer.Deserialize<JsonDocument>(...)` only works on .NET 5 or better (#270). `JsonDocument.Parse` works across the board, so a6ce06eee465d56b76a792f61cc21b1962f84c8b uses that instead.
* The JSON union deserializer builder could generate an empty switch; fixed with fcb5709fe40afb58b862218b26c34003a9e873da.
* Implicit conversions between `ArraySegment<T>` and `T[]` were not introduced until .NET Standard 2.1, so deserialization to `ArraySegment<T>` fails on earlier versions (#272). The fix for that is nuanced enough to be addressed separately, so for now I’m fencing those tests.

cc @fabianoliver