### PR TITLE
Use built-in `NullabilityInfoContext` when available

### DIFF
--- a/src/Chr.Avro/Abstract/RecordSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/RecordSchemaBuilderCase.cs
@@ -9,10 +9,11 @@ namespace Chr.Avro.Abstract
     using System.Runtime.Serialization;
     using System.Text.RegularExpressions;
     using Chr.Avro.Infrastructure;
+    #if !NET6_0_OR_GREATER
     using NullabilityInfoContext = Chr.Avro.Infrastructure.NullabilityInfoContext;
     using NullabilityState = Chr.Avro.Infrastructure.NullabilityState;
     using NullabilityInfo = Chr.Avro.Infrastructure.NullabilityInfo;
-
+    #endif
 
     /// <summary>
     /// Implements a <see cref="SchemaBuilder" /> case that matches any non-array or non-primitive

--- a/src/Chr.Avro/Infrastructure/NullabilityInfo.cs
+++ b/src/Chr.Avro/Infrastructure/NullabilityInfo.cs
@@ -1,3 +1,4 @@
+#if !NET6_0_OR_GREATER
 namespace Chr.Avro.Infrastructure
 {
     using System;
@@ -70,3 +71,4 @@ namespace Chr.Avro.Infrastructure
         public NullabilityInfo[] GenericTypeArguments { get; }
     }
 }
+#endif

--- a/src/Chr.Avro/Infrastructure/NullabilityInfoContext.cs
+++ b/src/Chr.Avro/Infrastructure/NullabilityInfoContext.cs
@@ -1,3 +1,4 @@
+#if !NET6_0_OR_GREATER
 namespace Chr.Avro.Infrastructure
 {
     using System;
@@ -572,3 +573,4 @@ namespace Chr.Avro.Infrastructure
         }
     }
 }
+#endif

--- a/src/Chr.Avro/Infrastructure/NullabilityState.cs
+++ b/src/Chr.Avro/Infrastructure/NullabilityState.cs
@@ -1,3 +1,4 @@
+#if !NET6_0_OR_GREATER
 namespace Chr.Avro.Infrastructure
 {
     /// <summary>
@@ -26,3 +27,4 @@ namespace Chr.Avro.Infrastructure
         Nullable,
     }
 }
+#endif


### PR DESCRIPTION
#184 introduced support for nullable reference types. Since `NullabilityInfoContext` wasn’t available prior to .NET 6, we shipped a fallback implementation in Chr.Avro. Now that the library includes a net6 target, we should use the runtime implementation.