### PR TITLE
Fix schema generation for nullable `Uri`

### DIFF
--- a/src/Chr.Avro.Fixtures/Fixtures/NullableMemberClass.cs
+++ b/src/Chr.Avro.Fixtures/Fixtures/NullableMemberClass.cs
@@ -13,6 +13,8 @@ namespace Chr.Avro.Fixtures
 
         public string ObliviousStringProperty { get; set; }
 
+        public Uri ObliviousUriProperty { get; set; }
+
         public string[] ObliviousArrayOfStringsProperty { get; set; }
 
         public List<string> ObliviousListOfStringsProperty { get; set; }
@@ -27,6 +29,10 @@ namespace Chr.Avro.Fixtures
         public string StringProperty { get; set; }
 
         public string? NullableStringProperty { get; set; }
+
+        public Uri UriProperty { get; set; }
+
+        public Uri? NullableUriProperty { get; set; }
 
         public string[] ArrayOfStringsProperty { get; set; }
 

--- a/src/Chr.Avro/Abstract/BytesSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/BytesSchemaBuilderCase.cs
@@ -37,11 +37,9 @@ namespace Chr.Avro.Abstract
         {
             if (type == typeof(byte[]))
             {
-                var bytesSchema = new BytesSchema();
+                Schema schema = new BytesSchema();
 
-                Schema schema = bytesSchema;
-
-                if (!type.IsValueType && NullableReferenceTypeBehavior == NullableReferenceTypeBehavior.All)
+                if (NullableReferenceTypeBehavior == NullableReferenceTypeBehavior.All)
                 {
                     if (!context.Schemas.TryGetValue(NullableType, out var nullSchema))
                     {

--- a/src/Chr.Avro/Abstract/SchemaBuilder.cs
+++ b/src/Chr.Avro/Abstract/SchemaBuilder.cs
@@ -114,7 +114,7 @@ namespace Chr.Avro.Abstract
                 // built-ins:
                 builder => new DurationSchemaBuilderCase(),
                 builder => new TimestampSchemaBuilderCase(temporalBehavior),
-                builder => new UriSchemaBuilderCase(),
+                builder => new UriSchemaBuilderCase(nullableReferenceTypeBehavior),
                 builder => new UuidSchemaBuilderCase(),
 
                 // classes and structs:

--- a/src/Chr.Avro/Abstract/StringSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/StringSchemaBuilderCase.cs
@@ -37,11 +37,9 @@ namespace Chr.Avro.Abstract
         {
             if (type == typeof(string))
             {
-                var stringSchema = new StringSchema();
+                Schema schema = new StringSchema();
 
-                Schema schema = stringSchema;
-
-                if (!type.IsValueType && NullableReferenceTypeBehavior == NullableReferenceTypeBehavior.All)
+                if (NullableReferenceTypeBehavior == NullableReferenceTypeBehavior.All)
                 {
                     if (!context.Schemas.TryGetValue(NullableType, out var nullSchema))
                     {

--- a/src/Chr.Avro/Abstract/UriSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/UriSchemaBuilderCase.cs
@@ -8,6 +8,22 @@ namespace Chr.Avro.Abstract
     public class UriSchemaBuilderCase : SchemaBuilderCase, ISchemaBuilderCase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="UriSchemaBuilderCase" /> class.
+        /// </summary>
+        /// <param name="nullableReferenceTypeBehavior">
+        /// The behavior to use to determine nullability of reference types.
+        /// </param>
+        public UriSchemaBuilderCase(NullableReferenceTypeBehavior nullableReferenceTypeBehavior)
+        {
+            NullableReferenceTypeBehavior = nullableReferenceTypeBehavior;
+        }
+
+        /// <summary>
+        /// Gets the behavior used to determine nullability of reference types.
+        /// </summary>
+        public NullableReferenceTypeBehavior NullableReferenceTypeBehavior { get; }
+
+        /// <summary>
         /// Builds a <see cref="StringSchema" />.
         /// </summary>
         /// <returns>
@@ -21,18 +37,28 @@ namespace Chr.Avro.Abstract
         {
             if (type == typeof(Uri))
             {
-                var uriSchema = new StringSchema();
+                Schema schema = new StringSchema();
+
+                if (NullableReferenceTypeBehavior == NullableReferenceTypeBehavior.All)
+                {
+                    if (!context.Schemas.TryGetValue(NullableType, out var nullSchema))
+                    {
+                        context.Schemas.Add(NullableType, nullSchema = new NullSchema());
+                    }
+
+                    schema = new UnionSchema(new[] { nullSchema, schema });
+                }
 
                 try
                 {
-                    context.Schemas.Add(type, uriSchema);
+                    context.Schemas.Add(type, schema);
                 }
                 catch (ArgumentException exception)
                 {
                     throw new InvalidOperationException($"A schema for {type} already exists on the schema builder context.", exception);
                 }
 
-                return SchemaBuilderCaseResult.FromSchema(uriSchema);
+                return SchemaBuilderCaseResult.FromSchema(schema);
             }
             else
             {

--- a/tests/Chr.Avro.Tests/Abstract/SchemaBuilderShould.cs
+++ b/tests/Chr.Avro.Tests/Abstract/SchemaBuilderShould.cs
@@ -194,7 +194,8 @@ namespace Chr.Avro.Tests
                 type => Assert.Equal(typeof(object), type),
                 type => Assert.Equal(typeof(Guid), type),
                 type => Assert.Equal(typeof(List<string>), type),
-                type => Assert.Equal(typeof(Guid?), type));
+                type => Assert.Equal(typeof(Guid?), type),
+                type => Assert.Equal(typeof(Uri), type));
 
             Assert.Collection(
                 schema.Fields,
@@ -441,6 +442,22 @@ namespace Chr.Avro.Tests
                 },
                 field =>
                 {
+                    Assert.Equal(nameof(NullableMemberClass.NullableUriProperty), field.Name);
+
+                    var union = Assert.IsType<UnionSchema>(field.Type);
+                    Assert.Collection(
+                        union.Schemas,
+                        child =>
+                        {
+                            Assert.IsType<NullSchema>(child);
+                        },
+                        child =>
+                        {
+                            Assert.IsType<StringSchema>(child);
+                        });
+                },
+                field =>
+                {
                     Assert.Equal(nameof(NullableMemberClass.ObliviousArrayOfStringsProperty), field.Name);
 
                     var array = Assert.IsType<ArraySchema>(field.Type);
@@ -488,7 +505,17 @@ namespace Chr.Avro.Tests
                 },
                 field =>
                 {
+                    Assert.Equal(nameof(NullableMemberClass.ObliviousUriProperty), field.Name);
+                    Assert.IsType<StringSchema>(field.Type);
+                },
+                field =>
+                {
                     Assert.Equal(nameof(NullableMemberClass.StringProperty), field.Name);
+                    Assert.IsType<StringSchema>(field.Type);
+                },
+                field =>
+                {
+                    Assert.Equal(nameof(NullableMemberClass.UriProperty), field.Name);
                     Assert.IsType<StringSchema>(field.Type);
                 });
             Assert.Null(schema.LogicalType);


### PR DESCRIPTION
The `Uri` schema builder case does not include logic to create a nullable union when `NullableReferenceTypeBehavior` is `All`. Fixes https://github.com/ch-robinson/dotnet-avro/issues/277.