### PR TITLE
Clean up analysis warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
 
   <PropertyGroup>
+    <AnalysisLevel>7</AnalysisLevel>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\Chr.Avro.snk</AssemblyOriginatorKeyFile>
     <AssemblyVersion>8.0.0.0</AssemblyVersion>
     <Authors>C.H. Robinson</Authors>
@@ -21,7 +22,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.376">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
       <IncludeAssets>Analyzers</IncludeAssets>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Chr.Avro.Binary/Serialization/BinaryReader.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryReader.cs
@@ -30,7 +30,7 @@ namespace Chr.Avro.Serialization
         /// <summary>
         /// Gets the current position of the reader.
         /// </summary>
-        public long Index => index;
+        public readonly long Index => index;
 
         /// <summary>
         /// Reads a Boolean value from the current position and advances the reader.
@@ -142,7 +142,8 @@ namespace Chr.Avro.Serialization
                 {
                     throw new InvalidEncodingException(index, "Unable to read a valid variable-length integer. This may indicate invalid encoding earlier in the stream.");
                 }
-            } while (current > 0x7F);
+            }
+            while (current > 0x7F);
 
             return (-(result & 0x01)) ^ ((result >> 0x01) & 0x7FFFFFFFFFFFFFFF);
         }

--- a/src/Chr.Avro.Codegen/Codegen/CSharpCodeGenerator.cs
+++ b/src/Chr.Avro.Codegen/Codegen/CSharpCodeGenerator.cs
@@ -125,7 +125,7 @@ namespace Chr.Avro.Codegen
                 .GroupBy(s => s.Namespace)
                 .OrderBy(g => g.Key);
 
-            if (candidates.Count() < 1)
+            if (!candidates.Any())
             {
                 throw new UnsupportedSchemaException(schema, $"Code can only be generated for enums and records.");
             }
@@ -307,7 +307,7 @@ namespace Chr.Avro.Codegen
 
                     try
                     {
-                        return GetPropertyType(others.Single(), nulls.Count() > 0);
+                        return GetPropertyType(others.Single(), nulls.Any());
                     }
                     catch (InvalidOperationException exception)
                     {

--- a/src/Chr.Avro.Codegen/Codegen/NamespaceRewriter.cs
+++ b/src/Chr.Avro.Codegen/Codegen/NamespaceRewriter.cs
@@ -80,7 +80,7 @@
             // VisitQualifiedName doesn’t hit these
             var children = node.ChildNodes().OfType<NameSyntax>();
 
-            if (children.Count() > 0)
+            if (children.Any())
             {
                 result = result.ReplaceNodes(children, (child, rewritten) => Reduce(child));
             }

--- a/src/Chr.Avro.Json/Serialization/JsonEnumSerializerBuilderCase.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonEnumSerializerBuilderCase.cs
@@ -42,12 +42,8 @@ namespace Chr.Avro.Serialization
                     ? fields
                         .Select(field =>
                         {
-                            var match = symbols.Find(symbol => IsMatch(symbol, field));
-
-                            if (match == null)
-                            {
-                                throw new UnsupportedTypeException(type, $"{type} has a field {field.Name} that cannot be serialized.");
-                            }
+                            var match = symbols.Find(symbol => IsMatch(symbol, field))
+                                ?? throw new UnsupportedTypeException(type, $"{type} has a field {field.Name} that cannot be serialized.");
 
                             if (symbols.FindLast(symbol => IsMatch(symbol, field)) != match)
                             {

--- a/src/Chr.Avro/Abstract/FixedSchema.cs
+++ b/src/Chr.Avro/Abstract/FixedSchema.cs
@@ -51,7 +51,7 @@ namespace Chr.Avro.Abstract
             {
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException("A fixed schema cannot have a negative size.");
+                    throw new ArgumentOutOfRangeException(nameof(value), "A fixed schema cannot have a negative size.");
                 }
 
                 size = value;

--- a/src/Chr.Avro/Abstract/ObjectDefaultValue.cs
+++ b/src/Chr.Avro/Abstract/ObjectDefaultValue.cs
@@ -17,7 +17,7 @@ namespace Chr.Avro.Abstract
         /// <param name="schema">
         /// A <see cref="Schema" /> that can be used to read the value.
         /// </param>
-        public ObjectDefaultValue(TValue value, Schema schema)
+        public ObjectDefaultValue(TValue? value, Schema schema)
             : base(schema)
         {
             Value = value;
@@ -26,7 +26,7 @@ namespace Chr.Avro.Abstract
         /// <summary>
         /// Gets or sets the <see cref="object" /> representation of the value.
         /// </summary>
-        public TValue Value { get; set; }
+        public TValue? Value { get; set; }
 
         /// <inheritdoc />
         /// <exception cref="UnsupportedTypeException">

--- a/src/Chr.Avro/Abstract/RecordSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/RecordSchemaBuilderCase.cs
@@ -10,9 +10,9 @@ namespace Chr.Avro.Abstract
     using System.Text.RegularExpressions;
     using Chr.Avro.Infrastructure;
     #if !NET6_0_OR_GREATER
+    using NullabilityInfo = Chr.Avro.Infrastructure.NullabilityInfo;
     using NullabilityInfoContext = Chr.Avro.Infrastructure.NullabilityInfoContext;
     using NullabilityState = Chr.Avro.Infrastructure.NullabilityState;
-    using NullabilityInfo = Chr.Avro.Infrastructure.NullabilityInfo;
     #endif
 
     /// <summary>

--- a/src/Chr.Avro/Infrastructure/ConstrainedSet.cs
+++ b/src/Chr.Avro/Infrastructure/ConstrainedSet.cs
@@ -17,6 +17,7 @@ namespace Chr.Avro.Infrastructure
     /// The type of the elements in the <see cref="ConstrainedSet{T}" />.
     /// </typeparam>
     internal class ConstrainedSet<T> : ICollection<T>, IReadOnlyCollection<T>
+        where T : notnull
     {
         private readonly IDictionary<T, LinkedListNode<T>> dictionary;
 

--- a/src/Chr.Avro/Infrastructure/ConstrainedSetExtensions.cs
+++ b/src/Chr.Avro/Infrastructure/ConstrainedSetExtensions.cs
@@ -29,6 +29,7 @@ namespace Chr.Avro.Infrastructure
         /// A new <see cref="ConstrainedSet{T}" /> instance.
         /// </returns>
         internal static ConstrainedSet<T> ToConstrainedSet<T>(this IEnumerable<T> enumerable, Func<T, ConstrainedSet<T>, bool>? predicate = null)
+            where T : notnull
         {
             if (enumerable == null)
             {

--- a/src/Chr.Avro/Serialization/ArrayDeserializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/ArrayDeserializerBuilderCase.cs
@@ -175,7 +175,7 @@ namespace Chr.Avro.Serialization
             var itemType = type.GetEnumerableType() ?? throw new ArgumentException($"{type} is not an enumerable type.");
 
             return type.GetConstructors()
-                .Where(constructor => constructor.GetParameters().Count() == 1)
+                .Where(constructor => constructor.GetParameters().Length == 1)
                 .FirstOrDefault(constructor => constructor.GetParameters().First().ParameterType
                     .IsAssignableFrom(typeof(IEnumerable<>).MakeGenericType(itemType)));
         }

--- a/src/Chr.Avro/Serialization/MapDeserializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/MapDeserializerBuilderCase.cs
@@ -101,7 +101,7 @@ namespace Chr.Avro.Serialization
             var (keyType, valueType) = type.GetDictionaryTypes() ?? throw new ArgumentException($"{type} is not a dictionary type.");
 
             return type.GetConstructors()
-                .Where(constructor => constructor.GetParameters().Count() == 1)
+                .Where(constructor => constructor.GetParameters().Length == 1)
                 .FirstOrDefault(constructor => constructor.GetParameters().First().ParameterType
                     .IsAssignableFrom(typeof(IDictionary<,>).MakeGenericType(keyType, valueType)));
         }

--- a/tests/Chr.Avro.Binary.Tests/BinaryReaderTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/BinaryReaderTests.cs
@@ -60,7 +60,6 @@ namespace Chr.Avro.Serialization.Tests
             new object[] { "𝄟", new byte[] { 0x08, 0xF0, 0x9D, 0x84, 0x9F } },
         };
 
-
         [Theory]
         [MemberData(nameof(BooleanEncodings))]
         [InlineData(true, new byte[] { 0x02 })]

--- a/tests/Chr.Avro.Binary.Tests/UnionSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/UnionSerializationTests.cs
@@ -200,7 +200,6 @@ namespace Chr.Avro.Serialization.Tests
                 },
             });
 
-
             var serializerCases = BinarySerializerBuilder.CreateDefaultCaseBuilders().ToList();
             serializerCases.Insert(0, builder => new OrderSerializerBuilderCase(builder));
 


### PR DESCRIPTION
Bump StyleCop to latest and clean up some style issues that accumulated since the 8.x series.

I’m leaving the `GetMethod`-related stuff alone for now since that’s a noisier set of changes, and it’d be nice to check those at build time rather than just sprinkling `!` everywhere.