### PR TITLE
implement `DefaultValue` for enums in the schema builder

### DIFF
--- a/src/Chr.Avro.Fixtures/Fixtures/DefaultValueDataContractEnum.cs
+++ b/src/Chr.Avro.Fixtures/Fixtures/DefaultValueDataContractEnum.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+using System.Runtime.Serialization;
+
+namespace Chr.Avro.Fixtures
+{
+    [DefaultValue(Third)]
+    [DataContract]
+    public enum DefaultValueDataContractEnum
+    {
+        [EnumMember]
+        First,
+        [EnumMember]
+        Second,
+        [EnumMember(Value = "AliasedDefaultValue")]
+        Third,
+        [EnumMember]
+        Fourth,
+    }
+}

--- a/src/Chr.Avro.Fixtures/Fixtures/DefaultValueEnum.cs
+++ b/src/Chr.Avro.Fixtures/Fixtures/DefaultValueEnum.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel;
+
+namespace Chr.Avro.Fixtures
+{
+    [DefaultValue(DefaultValue)]
+    public enum DefaultValueEnum
+    {
+        DefaultValue,
+        First,
+        Second,
+        Third,
+        Fourth,
+    }
+}

--- a/src/Chr.Avro/Abstract/EnumSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/EnumSchemaBuilderCase.cs
@@ -1,6 +1,7 @@
 namespace Chr.Avro.Abstract
 {
     using System;
+    using System.ComponentModel;
     using System.Linq;
     using System.Reflection;
     using System.Runtime.Serialization;
@@ -67,6 +68,7 @@ namespace Chr.Avro.Abstract
                     var enumSchema = new EnumSchema(GetSchemaName(type))
                     {
                         Namespace = GetSchemaNamespace(type),
+                        Default = type.GetAttribute<DefaultValueAttribute>()?.Value?.ToString()
                     };
 
                     foreach (var member in type.GetEnumMembers()

--- a/src/Chr.Avro/Abstract/EnumSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/EnumSchemaBuilderCase.cs
@@ -107,7 +107,7 @@ namespace Chr.Avro.Abstract
             if (enumDefaultValue is null)
                 return null;
             var matchedMember = enumMembers
-                .Single(member => member.Name == enumDefaultValue.ToString());
+                .Single(member => member.Name == Enum.GetName(type, enumDefaultValue));
             return GetSymbol(matchedMember);
         }
 

--- a/tests/Chr.Avro.Tests/Abstract/SchemaBuilderShould.cs
+++ b/tests/Chr.Avro.Tests/Abstract/SchemaBuilderShould.cs
@@ -708,6 +708,16 @@ namespace Chr.Avro.Tests
             Assert.Equal(nameof(DefaultValueEnum.DefaultValue), schema.Default);
         }
 
+        [Fact]
+        public void BuildEnumsWithAnAliasedDefault()
+        {
+            var schema = Assert.IsType<EnumSchema>(builder.BuildSchema<DefaultValueDataContractEnum>());
+            Assert.Null(schema.LogicalType);
+            Assert.Equal(typeof(DefaultValueDataContractEnum).Name, schema.Name);
+            Assert.Equal(typeof(DefaultValueDataContractEnum).Namespace, schema.Namespace);
+            Assert.Equal("AliasedDefaultValue", schema.Default);
+        }
+
         [Theory]
         [InlineData(typeof(float))]
         public void BuildFloats(Type type)

--- a/tests/Chr.Avro.Tests/Abstract/SchemaBuilderShould.cs
+++ b/tests/Chr.Avro.Tests/Abstract/SchemaBuilderShould.cs
@@ -698,6 +698,16 @@ namespace Chr.Avro.Tests
             Assert.Null(schema.LogicalType);
         }
 
+        [Fact]
+        public void BuildEnumsWithADefault()
+        {
+            var schema = Assert.IsType<EnumSchema>(builder.BuildSchema<DefaultValueEnum>());
+            Assert.Null(schema.LogicalType);
+            Assert.Equal(typeof(DefaultValueEnum).Name, schema.Name);
+            Assert.Equal(typeof(DefaultValueEnum).Namespace, schema.Namespace);
+            Assert.Equal(nameof(DefaultValueEnum.DefaultValue), schema.Default);
+        }
+
         [Theory]
         [InlineData(typeof(float))]
         public void BuildFloats(Type type)


### PR DESCRIPTION
I use the CLI command `create` and noticed that it was missing support for `DefaultValue` on enums, which is otherwise supported in your serialization code. 

I have added it in the simple way that works for my use case (resulting in output like `"type":{"name":"SomeEnum","default":"First","type":"enum","symbols":["First","Second","Third"]}`). 

It's unclear to me whether the additional branches of the if-else in `EnumSchemaBuilderCase` should be extended with the default feature.