### PR TITLE
Add support for enums avro schema doc

### DIFF
--- a/src/Chr.Avro.Fixtures/Fixtures/DescriptionAnnotatedEnum.cs
+++ b/src/Chr.Avro.Fixtures/Fixtures/DescriptionAnnotatedEnum.cs
@@ -1,0 +1,13 @@
+namespace Chr.Avro.Fixtures
+{
+    using System.ComponentModel;
+
+    [Description("Test")]
+    public enum DescriptionAnnotatedEnum
+    {
+        First,
+        Second,
+        Third,
+        Fourth,
+    }
+}

--- a/src/Chr.Avro/Abstract/EnumSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/EnumSchemaBuilderCase.cs
@@ -71,7 +71,8 @@ namespace Chr.Avro.Abstract
                     var enumSchema = new EnumSchema(GetSchemaName(type))
                     {
                         Namespace = GetSchemaNamespace(type),
-                        Default = GetDefaultValue(type, enumMembers)
+                        Default = GetDefaultValue(type, enumMembers),
+                        Documentation = type.GetAttribute<DescriptionAttribute>()?.Description
                     };
 
                     foreach (var member in enumMembers

--- a/tests/Chr.Avro.Tests/Abstract/SchemaBuilderShould.cs
+++ b/tests/Chr.Avro.Tests/Abstract/SchemaBuilderShould.cs
@@ -180,6 +180,13 @@ namespace Chr.Avro.Tests
         }
 
         [Fact]
+        public void BuildEnumsWithDescriptionAttributes()
+        {
+            var schema = Assert.IsType<EnumSchema>(builder.BuildSchema<DescriptionAnnotatedEnum>());
+            Assert.NotNull(schema.Documentation);
+        }
+
+        [Fact]
         public void BuildClassesWithNullableProperties()
         {
             var context = new SchemaBuilderContext();


### PR DESCRIPTION
# What
The Avro schema spec supports `doc` on enums: https://avro.apache.org/docs/1.11.1/specification/#enums

This PR uses the `System.ComponentModel.DescriptionAttribute` for populating the enum doc node in Avro schemas.

# Why
As discussed here https://github.com/ch-robinson/dotnet-avro/issues/131 .
The PR https://github.com/ch-robinson/dotnet-avro/pull/219 implements this for record schemas.

This implements the same strategy for enums.

*Note*
We had a list of local customizations (documentation, null handling, enum default values, DateOnly, TimeOnly, NodaTime), and most of these have been fixed in the later releases. Brilliant! This PR is a contribution to get rid of one more :)


