### PR TITLE
Add NodaTime example

### DIFF
--- a/Chr.Avro.sln
+++ b/Chr.Avro.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29411.108
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34321.82
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C81476EF-47D3-4B1C-9CE6-C62540F6EBEC}"
 EndProject
@@ -15,13 +15,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chr.Avro.Codegen", "src\Chr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chr.Avro.Confluent", "src\Chr.Avro.Confluent\Chr.Avro.Confluent.csproj", "{097405A9-C0A0-4ED4-8843-18D6C87F039B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chr.Avro.Fixtures", "src\Chr.Avro.Fixtures\Chr.Avro.Fixtures.csproj", "{7E843FB7-BC38-4501-9CF2-6AB1565CD690}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chr.Avro.Fixtures", "src\Chr.Avro.Fixtures\Chr.Avro.Fixtures.csproj", "{7E843FB7-BC38-4501-9CF2-6AB1565CD690}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chr.Avro.Json", "src\Chr.Avro.Json\Chr.Avro.Json.csproj", "{ECD02FE5-7124-4711-9349-7245BC6BAB4F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chr.Avro.Json", "src\Chr.Avro.Json\Chr.Avro.Json.csproj", "{ECD02FE5-7124-4711-9349-7245BC6BAB4F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{8A836E7F-D023-410B-8F1A-327B08EF23E5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chr.Avro.DefaultValuesExample", "examples\Chr.Avro.DefaultValuesExample\Chr.Avro.DefaultValuesExample.csproj", "{9535E0F4-5CA1-4C61-973A-BC7CC49AF6FD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chr.Avro.DefaultValuesExample", "examples\Chr.Avro.DefaultValuesExample\Chr.Avro.DefaultValuesExample.csproj", "{9535E0F4-5CA1-4C61-973A-BC7CC49AF6FD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chr.Avro.UnionTypeExample", "examples\Chr.Avro.UnionTypeExample\Chr.Avro.UnionTypeExample.csproj", "{015EBB31-9AD7-4B8B-91B5-39FEBAB2634E}"
 EndProject
@@ -34,6 +34,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chr.Avro.Confluent.Tests", "tests\Chr.Avro.Confluent.Tests\Chr.Avro.Confluent.Tests.csproj", "{4F2941EC-ECF6-4AE2-B150-438D3DF4B322}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chr.Avro.Json.Tests", "tests\Chr.Avro.Json.Tests\Chr.Avro.Json.Tests.csproj", "{C9DE3AD1-B33D-4A9F-BCD5-4D06C4174582}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chr.Avro.NodaTimeExample", "examples\Chr.Avro.NodaTimeExample\Chr.Avro.NodaTimeExample.csproj", "{AE1B2999-C82E-499E-82F2-BD6997662DB5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -201,6 +203,21 @@ Global
 		{C9DE3AD1-B33D-4A9F-BCD5-4D06C4174582}.Release|x64.Build.0 = Release|Any CPU
 		{C9DE3AD1-B33D-4A9F-BCD5-4D06C4174582}.Release|x86.ActiveCfg = Release|Any CPU
 		{C9DE3AD1-B33D-4A9F-BCD5-4D06C4174582}.Release|x86.Build.0 = Release|Any CPU
+		{AE1B2999-C82E-499E-82F2-BD6997662DB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE1B2999-C82E-499E-82F2-BD6997662DB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE1B2999-C82E-499E-82F2-BD6997662DB5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AE1B2999-C82E-499E-82F2-BD6997662DB5}.Debug|x64.Build.0 = Debug|Any CPU
+		{AE1B2999-C82E-499E-82F2-BD6997662DB5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AE1B2999-C82E-499E-82F2-BD6997662DB5}.Debug|x86.Build.0 = Debug|Any CPU
+		{AE1B2999-C82E-499E-82F2-BD6997662DB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE1B2999-C82E-499E-82F2-BD6997662DB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE1B2999-C82E-499E-82F2-BD6997662DB5}.Release|x64.ActiveCfg = Release|Any CPU
+		{AE1B2999-C82E-499E-82F2-BD6997662DB5}.Release|x64.Build.0 = Release|Any CPU
+		{AE1B2999-C82E-499E-82F2-BD6997662DB5}.Release|x86.ActiveCfg = Release|Any CPU
+		{AE1B2999-C82E-499E-82F2-BD6997662DB5}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{8C1D2691-B960-45EB-8D0F-BEBA179D7121} = {C81476EF-47D3-4B1C-9CE6-C62540F6EBEC}
@@ -216,6 +233,7 @@ Global
 		{8AE182C3-AD3E-4B31-AF1F-4E269A223E84} = {108FC1A0-2BA3-45F1-931F-A078CACE3E6F}
 		{4F2941EC-ECF6-4AE2-B150-438D3DF4B322} = {108FC1A0-2BA3-45F1-931F-A078CACE3E6F}
 		{C9DE3AD1-B33D-4A9F-BCD5-4D06C4174582} = {108FC1A0-2BA3-45F1-931F-A078CACE3E6F}
+		{AE1B2999-C82E-499E-82F2-BD6997662DB5} = {8A836E7F-D023-410B-8F1A-327B08EF23E5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3FB8E1F9-2B4F-4FFD-BD28-79DEC02D2903}

--- a/examples/Chr.Avro.NodaTimeExample/Chr.Avro.NodaTimeExample.csproj
+++ b/examples/Chr.Avro.NodaTimeExample/Chr.Avro.NodaTimeExample.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NodaTime" Version="3.1.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Chr.Avro.Confluent\Chr.Avro.Confluent.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/Chr.Avro.NodaTimeExample/Infrastructure/NodaTimeAsStringSerializerBuilderCase.cs
+++ b/examples/Chr.Avro.NodaTimeExample/Infrastructure/NodaTimeAsStringSerializerBuilderCase.cs
@@ -1,0 +1,48 @@
+namespace Chr.Avro.NodaTimeExample.Infrastructure
+{
+    using System;
+    using System.Linq.Expressions;
+    using Chr.Avro.Abstract;
+    using Chr.Avro.Serialization;
+
+    public class NodaTimeAsStringSerializerBuilderCase : BinaryStringSerializerBuilderCase
+    {
+        public override BinarySerializerBuilderCaseResult BuildExpression(Expression value, Type type, Schema schema, BinarySerializerBuilderContext context)
+        {
+            if (schema is StringSchema stringSchema)
+            {
+                if (value.Type != typeof(NodaTime.Instant))
+                {
+                    return BinarySerializerBuilderCaseResult.FromException(new UnsupportedTypeException(type, $"{nameof(NodaTimeAsStringSerializerBuilderCase)} can only be applied to {nameof(StringSchema)}s."));
+                }
+
+                var writeString = typeof(BinaryWriter).GetMethod(nameof(BinaryWriter.WriteString), new[] { typeof(string) });
+
+                try
+                {
+                    return BinarySerializerBuilderCaseResult.FromExpression(
+                        Expression.Call(context.Writer, writeString!, GetExpression(value, typeof(string))));
+                }
+                catch (InvalidOperationException exception)
+                {
+                    throw new UnsupportedTypeException(type, $"Failed to map {stringSchema} to {type}.", exception);
+                }
+            }
+            else
+            {
+                return BinarySerializerBuilderCaseResult.FromException(new UnsupportedSchemaException(schema, $"{nameof(BinaryStringSerializerBuilderCase)} can only be applied to {nameof(StringSchema)}s."));
+            }
+        }
+
+        private Expression GetExpression(Expression value, Type target)
+        {
+            var methodInfo = typeof(NodaTime.Instant).GetMethod(nameof(NodaTime.Instant.ToDateTimeOffset), Array.Empty<Type>())
+                ?? throw new NullReferenceException("Tried to find the method 'NodaTime.Instant.ToDateTimeOffset()', but it seem to have disappeared.");
+
+            // This is: value = value.ToDateTimeOffset();
+            // The base class implementation will fruther handle the value as normal DateTimeOffset.
+            value = Expression.Call(value, methodInfo);
+            return BuildStaticConversion(value, target);
+        }
+    }
+}

--- a/examples/Chr.Avro.NodaTimeExample/Infrastructure/NodaTimeAsTimestampSerializerBuilderCase.cs
+++ b/examples/Chr.Avro.NodaTimeExample/Infrastructure/NodaTimeAsTimestampSerializerBuilderCase.cs
@@ -1,0 +1,57 @@
+namespace Chr.Avro.NodaTimeExample.Infrastructure
+{
+    using System;
+    using System.Linq.Expressions;
+    using Chr.Avro.Abstract;
+    using Chr.Avro.Serialization;
+
+    public class NodaTimeAsTimestampSerializerBuilderCase : BinaryTimestampSerializerBuilderCase
+    {
+        /// <summary>
+        /// Builds a <see cref="BinarySerializer{T}" /> for a <see cref="TimestampLogicalType" />.
+        /// </summary>
+        /// <returns>
+        /// A successful <see cref="BinarySerializerBuilderCaseResult" /> if <paramref name="schema" />
+        /// has a <see cref="TimestampLogicalType" />; an unsuccessful <see cref="BinarySerializerBuilderCaseResult" />
+        /// otherwise.
+        /// </returns>
+        /// <exception cref="UnsupportedSchemaException">
+        /// Thrown when <paramref name="schema" /> is not a <see cref="LongSchema" /> or when
+        /// <paramref name="schema" /> does not have a <see cref="MicrosecondTimestampLogicalType" />
+        /// or a <see cref="MillisecondTimestampLogicalType" />.
+        /// </exception>
+        /// <exception cref="UnsupportedTypeException">
+        /// Thrown when <paramref name="type" /> cannot be converted to <see cref="DateTimeOffset" />.
+        /// </exception>
+        /// <inheritdoc />
+        public override BinarySerializerBuilderCaseResult BuildExpression(Expression value, Type type, Schema schema, BinarySerializerBuilderContext context)
+        {
+            if (schema.LogicalType is TimestampLogicalType)
+            {
+                if (schema is not LongSchema)
+                {
+                    throw new UnsupportedSchemaException(schema);
+                }
+
+                var nodaTimeType = typeof(NodaTime.Instant);
+
+                // If NodaTime.Instant just change the Expression to a DateTimeOffset
+                if (type == nodaTimeType)
+                {
+                    var methodInfo = nodaTimeType.GetMethod(nameof(NodaTime.Instant.ToDateTimeOffset), Array.Empty<Type>())
+                        ?? throw new NullReferenceException("Tried to find the method 'NodaTime.Instant.ToDateTimeOffset()', but it seem to have disappeared.");
+
+                    // Code: value = value.ToDateTimeOffset();
+                    // The base class implementation will fruther handle the value as normal DateTimeOffset.
+                    value = Expression.Call(value, methodInfo);
+                }
+
+                return base.BuildExpression(value, type, schema, context);
+            }
+            else
+            {
+                return BinarySerializerBuilderCaseResult.FromException(new UnsupportedSchemaException(schema, $"{nameof(NodaTimeAsTimestampSerializerBuilderCase)} can only be applied schemas with a {nameof(TimestampLogicalType)}."));
+            }
+        }
+    }
+}

--- a/examples/Chr.Avro.NodaTimeExample/Infrastructure/NodaTimeDeserializerBuilderCase.cs
+++ b/examples/Chr.Avro.NodaTimeExample/Infrastructure/NodaTimeDeserializerBuilderCase.cs
@@ -1,0 +1,95 @@
+namespace Chr.Avro.NodaTimeExample.Infrastructure
+{
+    using System;
+    using System.Linq.Expressions;
+    using Chr.Avro.Abstract;
+    using Chr.Avro.Serialization;
+    using NodaTime;
+
+    public class NodaTimeDeserializerBuilderCase : BinaryTimestampDeserializerBuilderCase
+    {
+        private readonly BinaryStringDeserializerBuilderCase stringDeserializer = new();
+
+        public override BinaryDeserializerBuilderCaseResult BuildExpression(Type type, Schema schema, BinaryDeserializerBuilderContext context)
+        {
+            if (schema is StringSchema)
+            {
+                // Fallback to default implementation if not NodaTime
+                if (!(type == typeof(NodaTime.Instant) || type == typeof(NodaTime.Instant?)))
+                {
+                    return base.BuildExpression(type, schema, context);
+                }
+
+                // Use default conversion from string to DateTimeOffset
+                var dateTimeOffset = stringDeserializer.BuildExpression(typeof(DateTimeOffset), schema, context).Expression;
+
+                var instantFromDateTimeOffset = typeof(Instant).GetMethod(nameof(Instant.FromDateTimeOffset), System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public, new[] { typeof(DateTimeOffset) });
+
+                try
+                {
+                    // Code: NodaTime.Instant.FromDateTimeOffset(dateTimeOffset);
+                    return BinaryDeserializerBuilderCaseResult.FromExpression(
+                        BuildConversion(
+                            Expression.Call(instantFromDateTimeOffset!, dateTimeOffset!),
+                            type));
+                }
+                catch (InvalidOperationException exception)
+                {
+                    throw new UnsupportedTypeException(type, $"Failed to map {schema} to {type}.", exception);
+                }
+            }
+            else if (schema.LogicalType is TimestampLogicalType)
+            {
+                if (schema is not LongSchema)
+                {
+                    throw new UnsupportedSchemaException(schema, $"{nameof(TimestampLogicalType)} deserializers can only be built for {nameof(LongSchema)}s.");
+                }
+
+                // Fallback to default implementation if not NodaTime
+                if (!(type == typeof(Instant) || type == typeof(Instant?)))
+                {
+                    return base.BuildExpression(type, schema, context);
+                }
+
+                var factor = schema.LogicalType switch
+                {
+                    MicrosecondTimestampLogicalType => TimeSpan.TicksPerMillisecond / 1000,
+                    MillisecondTimestampLogicalType => TimeSpan.TicksPerMillisecond,
+                    _ => throw new UnsupportedSchemaException(schema, $"{schema.LogicalType} is not a supported {nameof(TimestampLogicalType)}."),
+                };
+
+                var readInteger = typeof(BinaryReader)
+                    .GetMethod(nameof(BinaryReader.ReadInteger), Type.EmptyTypes);
+
+                Expression expression = Expression.Call(context.Reader, readInteger!);
+
+                var addTicks = typeof(DateTime)
+                    .GetMethod(nameof(DateTime.AddTicks), new[] { typeof(long) });
+
+                var fromDateTimeUtc = typeof(NodaTime.Instant).GetMethod(nameof(NodaTime.Instant.FromDateTimeUtc), new[] { typeof(DateTime) });
+
+                try
+                {
+                    // Code: return NodaTime.Instant.FromDateTimeUtc( Epoch.AddTicks(value * factor) );
+                    return BinaryDeserializerBuilderCaseResult.FromExpression(
+                        BuildConversion(
+                            Expression.Call(
+                                fromDateTimeUtc!,
+                                Expression.Call(
+                                    Expression.Constant(Epoch),
+                                    addTicks!,
+                                    Expression.Multiply(expression, Expression.Constant(factor)))),
+                            type));
+                }
+                catch (InvalidOperationException exception)
+                {
+                    throw new UnsupportedTypeException(type, $"Failed to map {schema} to {type}.", exception);
+                }
+            }
+            else
+            {
+                return BinaryDeserializerBuilderCaseResult.FromException(new UnsupportedSchemaException(schema, $"{nameof(NodaTimeDeserializerBuilderCase)} can only be applied to schemas with a {nameof(TimestampLogicalType)} and NodaTime properties."));
+            }
+        }
+    }
+}

--- a/examples/Chr.Avro.NodaTimeExample/Infrastructure/NodaTimeSchemaBuilderCase.cs
+++ b/examples/Chr.Avro.NodaTimeExample/Infrastructure/NodaTimeSchemaBuilderCase.cs
@@ -14,7 +14,7 @@ namespace Chr.Avro.NodaTimeExample.Infrastructure
 
         public SchemaBuilderCaseResult BuildSchema(Type type, SchemaBuilderContext context)
         {
-            // Handle NodaTime.Instant exactly the same as the base class.
+            // Handle NodaTime.Instant like the TimestampSchemaBuilderCase
             if (type == typeof(NodaTime.Instant))
             {
                 Schema timestampSchema = TemporalBehavior switch

--- a/examples/Chr.Avro.NodaTimeExample/Infrastructure/NodaTimeSchemaBuilderCase.cs
+++ b/examples/Chr.Avro.NodaTimeExample/Infrastructure/NodaTimeSchemaBuilderCase.cs
@@ -1,0 +1,52 @@
+namespace Chr.Avro.NodaTimeExample.Infrastructure
+{
+    using System;
+    using Chr.Avro.Abstract;
+
+    public class NodaTimeSchemaBuilderCase : SchemaBuilderCase, ISchemaBuilderCase
+    {
+        public NodaTimeSchemaBuilderCase(TemporalBehavior temporalBehavior)
+        {
+            TemporalBehavior = temporalBehavior;
+        }
+
+        public TemporalBehavior TemporalBehavior { get; }
+
+        public SchemaBuilderCaseResult BuildSchema(Type type, SchemaBuilderContext context)
+        {
+            // Handle NodaTime.Instant exactly the same as the base class.
+            if (type == typeof(NodaTime.Instant))
+            {
+                Schema timestampSchema = TemporalBehavior switch
+                {
+                    TemporalBehavior.EpochMicroseconds => new LongSchema()
+                    {
+                        LogicalType = new MicrosecondTimestampLogicalType(),
+                    },
+                    TemporalBehavior.EpochMilliseconds => new LongSchema()
+                    {
+                        LogicalType = new MillisecondTimestampLogicalType(),
+                    },
+                    TemporalBehavior.Iso8601 => new StringSchema(),
+                    _ => throw new ArgumentOutOfRangeException(nameof(TemporalBehavior)),
+                };
+
+                try
+                {
+                    // Important: Add NodaTime-type here, not DateTime or DateTimeOffset.
+                    context.Schemas.Add(type, timestampSchema);
+                }
+                catch (ArgumentException exception)
+                {
+                    throw new InvalidOperationException($"A schema for {type} already exists on the schema builder context.", exception);
+                }
+
+                return SchemaBuilderCaseResult.FromSchema(timestampSchema);
+            }
+            else
+            {
+                return SchemaBuilderCaseResult.FromException(new UnsupportedTypeException(type, $"{nameof(TimestampSchemaBuilderCase)} can only be applied to the {nameof(NodaTime.Instant)} type."));
+            }
+        }
+    }
+}

--- a/examples/Chr.Avro.NodaTimeExample/Models/Player.cs
+++ b/examples/Chr.Avro.NodaTimeExample/Models/Player.cs
@@ -1,0 +1,14 @@
+namespace Chr.Avro.NodaTimeExample.Models
+{
+    using System;
+    using NodaTime;
+
+    public class Player
+    {
+        public Guid Id { get; set; }
+
+        public string Nickname { get; set; }
+
+        public Instant LastLogin { get; set; }
+    }
+}

--- a/examples/Chr.Avro.NodaTimeExample/Program.cs
+++ b/examples/Chr.Avro.NodaTimeExample/Program.cs
@@ -1,0 +1,164 @@
+namespace Chr.Avro.NodaTimeExample
+{
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Chr.Avro.Abstract;
+    using Chr.Avro.Confluent;
+    using Chr.Avro.NodaTimeExample.Infrastructure;
+    using Chr.Avro.NodaTimeExample.Models;
+    using Chr.Avro.Serialization;
+    using global::Confluent.Kafka;
+    using global::Confluent.Kafka.Admin;
+    using global::Confluent.Kafka.SyncOverAsync;
+    using global::Confluent.SchemaRegistry;
+
+    internal class Program
+    {
+        private const string BootstrapServers = "localhost:9092";
+        private const string SchemaRegistries = "http://localhost:8081";
+        private const string Topic = "noda-time-example";
+
+        private static readonly TimeSpan AssignmentTimeout = TimeSpan.FromSeconds(15);
+
+        public static async Task<int> Main()
+        {
+            using var registryClient = CreateSchemaRegistryClient();
+            using var admin = CreateAdmin();
+            using var consumer = CreateConsumer(registryClient);
+            using var producer = await CreateProducer(registryClient, AutomaticRegistrationBehavior.Always, TemporalBehavior.EpochMilliseconds); // Can also be TemporalBehavior.Iso8601
+
+            Console.WriteLine($"Creating {Topic}...");
+            await EnsureTopicExists(admin);
+
+            consumer.Subscribe(Topic);
+            var assignmentSignal = new CancellationTokenSource(AssignmentTimeout);
+
+            Console.WriteLine($"Subscribing to {Topic}...");
+
+            while (consumer.Assignment.Count < 1)
+            {
+                if (assignmentSignal.IsCancellationRequested)
+                {
+                    Console.Error.WriteLine($"Failed to receive partition assigment for {Topic} within {AssignmentTimeout.TotalSeconds} seconds.");
+                    return 1;
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+
+            var player1 = new Player
+            {
+                Id = Guid.NewGuid(),
+                Nickname = "Todd Bonzalez",
+                LastLogin = NodaTime.Instant.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            };
+
+            await producer.ProduceAsync(Topic, new Message<Guid, Player>
+            {
+                Key = player1.Id,
+                Value = player1,
+            });
+
+            var result = consumer.Consume();
+            var playerOne = result.Message.Value;
+            Console.WriteLine($"Received update for {playerOne.Nickname} with last login {playerOne.LastLogin}.");
+
+            return 0;
+        }
+
+        private static IAdminClient CreateAdmin()
+        {
+            return new AdminClientBuilder(
+                new AdminClientConfig
+                {
+                    BootstrapServers = BootstrapServers,
+                })
+                .Build();
+        }
+
+        private static IConsumer<Guid, Player> CreateConsumer(
+            ISchemaRegistryClient registryClient)
+        {
+            var deserializerBuilder = new BinaryDeserializerBuilder(
+                BinaryDeserializerBuilder.CreateDefaultCaseBuilders()
+                    .Prepend(builder => new NodaTimeDeserializerBuilderCase()));
+
+            return new ConsumerBuilder<Guid, Player>(
+                new ConsumerConfig
+                {
+                    BootstrapServers = BootstrapServers,
+                    EnableAutoCommit = false,
+                    GroupId = $"noda-time-example-{Guid.NewGuid()}",
+                })
+                .SetAvroKeyDeserializer(registryClient)
+                .SetValueDeserializer(new AsyncSchemaRegistryDeserializer<Player>(
+                    registryClient,
+                    deserializerBuilder).AsSyncOverAsync())
+                .Build();
+        }
+
+        private static async Task<IProducer<Guid, Player>> CreateProducer(
+            ISchemaRegistryClient registryClient,
+            AutomaticRegistrationBehavior automaticRegistrationBehavior,
+            TemporalBehavior temporalBehavior)
+        {
+            var schemaBuilder = new SchemaBuilder(
+                SchemaBuilder.CreateDefaultCaseBuilders()
+                    .Prepend(builder => new NodaTimeSchemaBuilderCase(temporalBehavior)));
+
+            using var serializerBuilder = new SchemaRegistrySerializerBuilder(
+                registryClient,
+                schemaBuilder,
+                serializerBuilder: new BinarySerializerBuilder(
+                    BinarySerializerBuilder.CreateDefaultCaseBuilders()
+                        .Prepend(builder => new NodaTimeAsStringSerializerBuilderCase())
+                        .Prepend(builder => new NodaTimeAsTimestampSerializerBuilderCase())));
+
+            var producerBuilder = new ProducerBuilder<Guid, Player>(
+                new ProducerConfig
+                {
+                    BootstrapServers = BootstrapServers,
+                });
+
+            await producerBuilder.SetAvroKeySerializer(
+                registryClient,
+                SubjectNameStrategy.Topic.ConstructKeySubjectName(Topic),
+                automaticRegistrationBehavior);
+
+            await producerBuilder.SetAvroValueSerializer(
+                serializerBuilder,
+                SubjectNameStrategy.Topic.ConstructValueSubjectName(Topic),
+                automaticRegistrationBehavior);
+
+            return producerBuilder.Build();
+        }
+
+        private static ISchemaRegistryClient CreateSchemaRegistryClient()
+        {
+            return new CachedSchemaRegistryClient(
+                new SchemaRegistryConfig
+                {
+                    Url = SchemaRegistries,
+                });
+        }
+
+        private static async Task EnsureTopicExists(IAdminClient admin)
+        {
+            var metadata = admin.GetMetadata(Topic, TimeSpan.FromSeconds(15));
+
+            if (!metadata.Topics.Any(m => m.Topic == Topic))
+            {
+                await admin.CreateTopicsAsync(
+                    new[]
+                    {
+                        new TopicSpecification
+                        {
+                            Name = Topic,
+                        },
+                    });
+            }
+        }
+    }
+}

--- a/examples/Chr.Avro.NodaTimeExample/Program.cs
+++ b/examples/Chr.Avro.NodaTimeExample/Program.cs
@@ -33,7 +33,6 @@ namespace Chr.Avro.NodaTimeExample
             Console.WriteLine($"Creating {Topic}...");
             await EnsureTopicExists(admin);
 
-            Console.WriteLine($"Subscribing {Topic}...");
             consumer.Subscribe(Topic);
 
             var producedPlayer = new Player
@@ -43,18 +42,16 @@ namespace Chr.Avro.NodaTimeExample
                 LastLogin = NodaTime.Instant.FromDateTimeOffset(DateTimeOffset.UtcNow),
             };
 
-            Console.WriteLine($"Producing player with LastLogin {producedPlayer.LastLogin}...");
+            Console.WriteLine($"Producing player with NodaTime Instant {producedPlayer.LastLogin}");
             await producer.ProduceAsync(Topic, new Message<Guid, Player>
             {
                 Key = producedPlayer.Id,
                 Value = producedPlayer,
             });
 
-            Console.WriteLine($"Consuming {Topic}...");
             var result = consumer.Consume();
-            var consumedPlayer = result.Message.Value;
 
-            Console.WriteLine($"Received player with LastLogin {consumedPlayer.LastLogin}.");
+            Console.WriteLine($"Consumed player with NodaTime Instant {result.Message.Value.LastLogin}");
 
             return 0;
         }
@@ -79,6 +76,7 @@ namespace Chr.Avro.NodaTimeExample
             return new ConsumerBuilder<Guid, Player>(
                 new ConsumerConfig
                 {
+                    AutoOffsetReset = AutoOffsetReset.Earliest,
                     BootstrapServers = BootstrapServers,
                     EnableAutoCommit = false,
                     GroupId = $"noda-time-example-{Guid.NewGuid()}",


### PR DESCRIPTION
The issue https://github.com/ch-robinson/dotnet-avro/issues/222 requests a demonstration on how to enable NodaTime support.  This PR constributes an example for schema generation, serialization and deserialization.

Note that
- The schema generation considers the TemporalBehavior parameter and delegates to string or timestamp behavior.
- The value is serialized in the same behavior as a DateTimeOffset

This PR is setup as a draft for now, since: 
- The test suite I have "on my computer/in my own solution" should be reorganized to fit in the example
- The program in the example should be run - I did a best effort for now.