### PR TITLE
Enable code generation of DescriptionAttribute

### DIFF
--- a/src/Chr.Avro.Codegen/Codegen/CSharpCodeGenerator.cs
+++ b/src/Chr.Avro.Codegen/Codegen/CSharpCodeGenerator.cs
@@ -391,7 +391,7 @@ namespace Chr.Avro.Codegen
 
         private AttributeListSyntax[] GetDescriptionAttribute(string? documentation)
         {
-            if (string.IsNullOrEmpty(documentation) || !enableDescriptionAttributeForDocumentation)
+            if (documentation == null || string.IsNullOrEmpty(documentation) || !enableDescriptionAttributeForDocumentation)
             {
                 return Array.Empty<AttributeListSyntax>();
             }
@@ -399,7 +399,13 @@ namespace Chr.Avro.Codegen
             // Generates: [Description("documentation")]
             // https://stackoverflow.com/questions/35927427/how-to-create-an-attributesyntax-with-a-parameter
             var name = SyntaxFactory.ParseName("System.ComponentModel.DescriptionAttribute");
-            var arguments = SyntaxFactory.ParseAttributeArgumentList("(\"" + documentation + "\")");
+            var arguments = SyntaxFactory.AttributeArgumentList(
+                                SyntaxFactory.SingletonSeparatedList(
+                                    SyntaxFactory.AttributeArgument(
+                                        SyntaxFactory.LiteralExpression(
+                                            SyntaxKind.StringLiteralExpression,
+                                            SyntaxFactory.Literal(documentation)))));
+
             var attribute = SyntaxFactory.Attribute(name, arguments);
 
             var attributeList = default(SeparatedSyntaxList<AttributeSyntax>);

--- a/src/Chr.Avro.Codegen/Codegen/CSharpCodeGenerator.cs
+++ b/src/Chr.Avro.Codegen/Codegen/CSharpCodeGenerator.cs
@@ -76,7 +76,7 @@ namespace Chr.Avro.Codegen
                     })
                     .Where(field => field != null)
                     .ToArray())
-                    .AddAttributeLists(GetDescriptionAttribute(schema.Documentation)); ;
+                .AddAttributeLists(GetDescriptionAttribute(schema.Documentation));
 
             if (!string.IsNullOrEmpty(schema.Documentation))
             {

--- a/src/Chr.Avro.Codegen/Codegen/CSharpCodeGenerator.cs
+++ b/src/Chr.Avro.Codegen/Codegen/CSharpCodeGenerator.cs
@@ -27,8 +27,8 @@ namespace Chr.Avro.Codegen
         /// nullable.
         /// </param>
         /// <param name="enableDescriptionAttributeForDocumentation">
-        /// Whether schema documentation nodes should generate a System.ComponentModel.DescriptionAttribute on types and members.
-        /// nullable.
+        /// Whether enum and record schema documentation should be reflected in
+        /// <see cref="System.ComponentModel.DescriptionAttribute" />s on types and members.
         /// </param>
         public CSharpCodeGenerator(bool enableNullableReferenceTypes = true, bool enableDescriptionAttributeForDocumentation = false)
         {


### PR DESCRIPTION
I actually have one more for you. I'm not really sure that this is needed, but I implemented it as a customization here about 2 years ago, and might as well offer it to you in case it is interesting. 

It's actually 2 features:

**1) Code Generate [DescriptionAttribute]**
When generating code, in addition to generating a summary comment - also generate a DescriptionAttribute (for class, field, properties and enums). It might not be strictly necessary, but it felt symmetric since the schema generation reads it from this attribute.

**2) Add code generation test project Chr.Avro.Codegen.Tests**
This is quite fun, actually. When I wanted to test my customization of the code generation, I found a way to compile the generated code on-the-fly, load the types and assert that the description attributes was generated with correct content. I also assert that the generated type is compatible with the given Avro schema.

No hard feelings if this is overkill, and the PR is turned down :)