### PR TITLE
feat: added DateOnly type in code generator

### DIFF
--- a/src/Chr.Avro.Codegen/Codegen/CSharpCodeGenerator.cs
+++ b/src/Chr.Avro.Codegen/Codegen/CSharpCodeGenerator.cs
@@ -251,6 +251,13 @@ namespace Chr.Avro.Codegen
                     value = true;
                     break;
 
+#if NET6_0_OR_GREATER
+                case IntSchema i when l.LogicalType is DateLogicalType t:
+                    type = SyntaxFactory.ParseTypeName("global::System.DateOnly");
+                    value = true;
+                    break;
+#endif
+
                 case StringSchema s when s.LogicalType is UuidLogicalType:
                     type = SyntaxFactory.ParseTypeName("global::System.Guid");
                     value = true;


### PR DESCRIPTION
Added support to `DateOnly` data type when generating class if type in Avro is `int` and logical type in Avro is `date`.

The implementation is similar to the `DateTime` data type.

Chr.Avro already supports `DateOnly` schema generation - https://github.com/ch-robinson/dotnet-avro/blob/main/src/Chr.Avro/Abstract/DateSchemaBuilderCase.cs#L46-L49.  This same logic is applied in this PR.