### PR TITLE
fix(codegen): added .net6 as target framework due to issues with directive

### DIFF
--- a/src/Chr.Avro.Codegen/Chr.Avro.Codegen.csproj
+++ b/src/Chr.Avro.Codegen/Chr.Avro.Codegen.csproj
@@ -4,7 +4,7 @@
     <Description>Experimental utilities to generate code from Avro schemas</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changed `TargetFramework` to include multi-target similar to other Chr.Avro projects (such as `Chr.Avro.Binary`,`Chr.Avro.Confluent`, `Chr.Avro.Json` and `Chr.Avro`).  

The reason behind this change is because the `NET6_0_OR_GREATER` directive is not working on .NET Standard projects (at least on ARM64 architecture).  This workaround will however work on .NET 6+ since the framework package is used instead of the netstandard one.