### PR TITLE
Fix binary record deserializer delegate return type

### DIFF
--- a/src/Chr.Avro.Binary/Serialization/BinaryRecordDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryRecordDeserializerBuilderCase.cs
@@ -63,7 +63,7 @@ namespace Chr.Avro.Serialization
                     // since record deserialization is potentially recursive, create a top-level
                     // reference:
                     var parameter = Expression.Parameter(
-                        Expression.GetDelegateType(context.Reader.Type.MakeByRefType(), underlying));
+                        Expression.GetDelegateType(context.Reader.Type.MakeByRefType(), type));
 
                     if (!context.References.TryGetValue((recordSchema, type), out var reference))
                     {


### PR DESCRIPTION
Using the underlying type as the return type for the record delegate prevents a deserializer from building for nullable structs. This was likely a typo from when the resolution framework was removed in 8.0.0; the same code in the JSON deserializer builder does not have the defect.