### PR TITLE
fixed the case of a schema without a scale field 

### DIFF
--- a/src/Chr.Avro.Json/Representation/JsonDecimalSchemaReaderCase.cs
+++ b/src/Chr.Avro.Json/Representation/JsonDecimalSchemaReaderCase.cs
@@ -44,13 +44,13 @@ namespace Chr.Avro.Representation
 
                 if (type.ValueEquals(JsonSchemaToken.Bytes))
                 {
-                    var key = $"{JsonSchemaToken.Bytes}!{JsonSchemaToken.Decimal}!{precision.GetInt32()}!{(scale.Equals(default) ? 0 : scale.GetInt32())}";
+                    var key = $"{JsonSchemaToken.Bytes}!{JsonSchemaToken.Decimal}!{precision.GetInt32()}!{(scale.ValueKind == JsonValueKind.Undefined ? 0 : scale.GetInt32())}";
 
                     if (!context.Schemas.TryGetValue(key, out var schema))
                     {
                         schema = new BytesSchema()
                         {
-                            LogicalType = new DecimalLogicalType(precision.GetInt32(), scale.Equals(default) ? 0 : scale.GetInt32()),
+                            LogicalType = new DecimalLogicalType(precision.GetInt32(), scale.ValueKind == JsonValueKind.Undefined ? 0 : scale.GetInt32()),
                         };
 
                         context.Schemas.Add(key, schema);
@@ -76,7 +76,7 @@ namespace Chr.Avro.Representation
 
                     var schema = new FixedSchema(QualifyName(name.GetString(), scope), size.GetInt32())
                     {
-                        LogicalType = new DecimalLogicalType(precision.GetInt32(), scale.Equals(default) ? 0 : scale.GetInt32()),
+                        LogicalType = new DecimalLogicalType(precision.GetInt32(), scale.ValueKind == JsonValueKind.Undefined ? 0 : scale.GetInt32()),
                     };
 
                     if (element.TryGetProperty(JsonAttributeToken.Aliases, out var aliases))

--- a/tests/Chr.Avro.Json.Tests/JsonRepresentationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/JsonRepresentationTests.cs
@@ -40,7 +40,6 @@ namespace Chr.Avro.Representation.Tests
         public static IEnumerable<object[]> DecimalLogicalTypeRepresentations => new List<object[]>
         {
             new object[] { "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":10,\"scale\":6}" },
-            new object[] { "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":29}", "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":29,\"scale\":0}" },
             new object[] { "{\"name\":\"temperatures.Celcius\",\"type\":\"fixed\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":3,\"size\":4}" },
         };
 
@@ -68,6 +67,11 @@ namespace Chr.Avro.Representation.Tests
             new object[] { "{\"type\":\"map\",\"values\":\"null\"}" },
             new object[] { "{\"type\":\"map\",\"values\":\"double\"}" },
             new object[] { "{\"type\":\"map\",\"values\":[\"null\",\"double\",\"int\"]}" },
+        };
+
+        public static IEnumerable<object[]> OptionalFieldRepresentations => new List<object[]>
+        {
+            new object[] { "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":29,\"scale\":0}", "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":29}" },
         };
 
         public static IEnumerable<object[]> PrimitiveSchemaRepresentations => new List<object[]>
@@ -118,6 +122,7 @@ namespace Chr.Avro.Representation.Tests
 
         [Theory]
         [MemberData(nameof(AliasedNamedSchemaRepresentations))]
+        [MemberData(nameof(OptionalFieldRepresentations))]
         [MemberData(nameof(PrimitiveSchemaRepresentations))]
         public void AsymmetricRepresentations(string @out, string @in)
         {

--- a/tests/Chr.Avro.Json.Tests/JsonRepresentationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/JsonRepresentationTests.cs
@@ -40,6 +40,7 @@ namespace Chr.Avro.Representation.Tests
         public static IEnumerable<object[]> DecimalLogicalTypeRepresentations => new List<object[]>
         {
             new object[] { "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":10,\"scale\":6}" },
+            new object[] { "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":29}", "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":29,\"scale\":0}" },
             new object[] { "{\"name\":\"temperatures.Celcius\",\"type\":\"fixed\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":3,\"size\":4}" },
         };
 
@@ -152,9 +153,9 @@ namespace Chr.Avro.Representation.Tests
         [MemberData(nameof(TimestampLogicalTypeRepresentations))]
         [MemberData(nameof(UnionSchemaRepresentations))]
         [MemberData(nameof(UuidLogicalTypeRepresentations))]
-        public void SymmetricRepresentations(string schema)
+        public void SymmetricRepresentations(string schema, string expectedOverride = null)
         {
-            Assert.Equal(schema, writer.Write(reader.Read(schema)));
+            Assert.Equal(expectedOverride ?? schema, writer.Write(reader.Read(schema)));
         }
     }
 }


### PR DESCRIPTION
By the spec, when without scale a default 0 should be used.
Added unit test for regression testing.

Reported the issue with details on how to replicate in issue #321 