### PR TITLE
Support .NET 9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
           - target: net462
             os: windows-latest
           - target: net8.0
+          - target: net9.0
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - name: Pull code

--- a/benchmarks/dotnet/Chr.Avro.Benchmarks.csproj
+++ b/benchmarks/dotnet/Chr.Avro.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/benchmarks/dotnet/Program.cs
+++ b/benchmarks/dotnet/Program.cs
@@ -74,7 +74,7 @@ namespace Chr.Avro.Benchmarks
                 {
                     yield return new Result()
                     {
-                        Runtime = "net8.0",
+                        Runtime = "net9.0",
                         Library = runner.Library,
                         Suite = runner.Suite,
                         Iterations = runner.Iterations,

--- a/examples/Chr.Avro.DefaultValuesExample/Chr.Avro.DefaultValuesExample.csproj
+++ b/examples/Chr.Avro.DefaultValuesExample/Chr.Avro.DefaultValuesExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Chr.Avro.NodaTimeExample/Chr.Avro.NodaTimeExample.csproj
+++ b/examples/Chr.Avro.NodaTimeExample/Chr.Avro.NodaTimeExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Chr.Avro.UnionTypeExample/Chr.Avro.UnionTypeExample.csproj
+++ b/examples/Chr.Avro.UnionTypeExample/Chr.Avro.UnionTypeExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "$schema": "https://json.schemastore.org/global",
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "8.0.100"
+    "version": "9.0.100"
   }
 }

--- a/src/Chr.Avro.Cli/Chr.Avro.Cli.csproj
+++ b/src/Chr.Avro.Cli/Chr.Avro.Cli.csproj
@@ -5,7 +5,7 @@
     <IsPackable>true</IsPackable>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <ToolCommandName>dotnet-avro</ToolCommandName>
   </PropertyGroup>
 

--- a/tests/Chr.Avro.Binary.Tests/Chr.Avro.Binary.Tests.csproj
+++ b/tests/Chr.Avro.Binary.Tests/Chr.Avro.Binary.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Chr.Avro.Codegen.Tests/Chr.Avro.Codegen.Tests.csproj
+++ b/tests/Chr.Avro.Codegen.Tests/Chr.Avro.Codegen.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Chr.Avro.Confluent.Tests/Chr.Avro.Confluent.Tests.csproj
+++ b/tests/Chr.Avro.Confluent.Tests/Chr.Avro.Confluent.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Chr.Avro.Json.Tests/Chr.Avro.Json.Tests.csproj
+++ b/tests/Chr.Avro.Json.Tests/Chr.Avro.Json.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Chr.Avro.Tests/Chr.Avro.Tests.csproj
+++ b/tests/Chr.Avro.Tests/Chr.Avro.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This adds a net9 target to the CLI and the test projects and retargets the example projects. Support for < net8 will be dropped from the CLI at the next major release.