### PR TITLE
Add C# record support to code generator

### DIFF
--- a/docs/cli/generate.md
+++ b/docs/cli/generate.md
@@ -62,6 +62,9 @@ namespace Example.Models
 `--nullable-references`
 :   Whether reference types selected for nullable record fields should be annotated as nullable.
 
+`--record-type`
+:   Which kind of C# type to generate for records. Options are `class` (the default behavior) and `record`.
+
 #### Resolve schema by ID
 
 `-i`, `--id`

--- a/src/Chr.Avro.Cli/Cli/GenerateCodeVerb.cs
+++ b/src/Chr.Avro.Cli/Cli/GenerateCodeVerb.cs
@@ -52,6 +52,9 @@ namespace Chr.Avro.Cli
         [Option("nullable-references", HelpText = "Whether reference types selected for nullable record fields should be annotated as nullable.")]
         public bool NullableReferences { get; set; }
 
+        [Option("record-type", HelpText = "Which kind of C# type to generate for records.")]
+        public RecordType RecordType { get; set; }
+
         [Option('v', "version", SetName = BySubjectSet, HelpText = "The version of the schema.")]
         public int? SchemaVersion { get; set; }
 
@@ -59,7 +62,8 @@ namespace Chr.Avro.Cli
         {
             var generator = new CSharpCodeGenerator(
                 enableDescriptionAttributeForDocumentation: ComponentModelAnnotations,
-                enableNullableReferenceTypes: NullableReferences);
+                enableNullableReferenceTypes: NullableReferences,
+                recordType: RecordType);
             var reader = new JsonSchemaReader();
             var schema = reader.Read(await ((ISchemaResolutionOptions)this).ResolveSchema());
 

--- a/src/Chr.Avro.Codegen/Codegen/RecordType.cs
+++ b/src/Chr.Avro.Codegen/Codegen/RecordType.cs
@@ -1,0 +1,18 @@
+namespace Chr.Avro.Codegen
+{
+    /// <summary>
+    /// Options for representing Avro records in C#.
+    /// </summary>
+    public enum RecordType
+    {
+        /// <summary>
+        /// Represent Avro records as C# classes.
+        /// </summary>
+        Class,
+
+        /// <summary>
+        /// Represent Avro records as C# records.
+        /// </summary>
+        Record,
+    }
+}


### PR DESCRIPTION
This adds a `--record-type` option to the `dotnet avro generate` command that allows the user to select whether to generate classes or records (requested in #261).