### PR TITLE
fix: fall back to default value when dynamic member is absent

### DIFF
--- a/src/Chr.Avro.Binary/Serialization/BinaryRecordSerializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryRecordSerializerBuilderCase.cs
@@ -85,7 +85,7 @@ namespace Chr.Avro.Serialization
                                     // if the type could be dynamic, attempt to use a dynamic getter:
                                     if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type) || type == typeof(object))
                                     {
-                                        inner = this.BuildDynamicGet(argument, field.Name);
+                                        inner = this.BuildDynamicGet(argument, field.Name, field.Default);
                                     }
                                     else
                                     {

--- a/src/Chr.Avro.Json/Serialization/JsonRecordSerializerBuilderCase.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonRecordSerializerBuilderCase.cs
@@ -99,7 +99,7 @@ namespace Chr.Avro.Serialization
                                 // if the type could be dynamic, attempt to use a dynamic getter:
                                 if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type) || type == typeof(object))
                                 {
-                                    inner = this.BuildDynamicGet(argument, field.Name);
+                                    inner = this.BuildDynamicGet(argument, field.Name, field.Default);
                                 }
                                 else
                                 {

--- a/src/Chr.Avro/Infrastructure/Binders.cs
+++ b/src/Chr.Avro/Infrastructure/Binders.cs
@@ -1,0 +1,90 @@
+namespace Chr.Avro.Infrastructure
+{
+    using System;
+    using System.Dynamic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Reflection;
+    using Chr.Avro.Abstract;
+
+    /// <summary>
+    /// Provides binder implementations for dynamic operations.
+    /// </summary>
+    internal static class Binders
+    {
+        /// <summary>
+        /// Creates a new <see cref="GetMemberBinder" /> that falls back to an optional default value.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the member to get (case sensitive).
+        /// </param>
+        /// <param name="defaultValue">
+        /// An optional value to return when no member matching <paramref name="name" /> is
+        /// present. If null, get will throw <see cref="MissingMemberException" /> if the member
+        /// does not exist.
+        /// </param>
+        /// <returns>
+        /// A <see cref="GetMemberBinder" /> instance.
+        /// </returns>
+        public static GetMemberBinder GetMember(
+            string name,
+            DefaultValue? defaultValue = default)
+        {
+            var fallback = defaultValue switch
+            {
+                null => null,
+                _ => Expression.Constant(defaultValue.ToObject<dynamic>(), typeof(object)),
+            };
+
+            return new DynamicGetMemberBinder(name, fallback);
+        }
+
+        private sealed class DynamicGetMemberBinder : GetMemberBinder
+        {
+            private static readonly ConstructorInfo MissingMemberExceptionConstructor =
+                typeof(MissingMemberException)
+                    .GetConstructor(new[] { typeof(string), typeof(string) })!;
+
+            public DynamicGetMemberBinder(string name, Expression? fallback)
+                : base(name, ignoreCase: false)
+            {
+                Fallback = fallback;
+            }
+
+            public Expression? Fallback { get; }
+
+            public override DynamicMetaObject FallbackGetMember(
+                DynamicMetaObject target,
+                DynamicMetaObject? errorSuggestion)
+            {
+                if (errorSuggestion is not null)
+                {
+                    return errorSuggestion;
+                }
+
+                // eventually allow configurable binding flags/matching logic here?
+                var match = target.RuntimeType.GetMember(Name)
+                    .Where(m => m.MemberType is MemberTypes.Field or MemberTypes.Property)
+                    .SingleOrDefault();
+
+                return new DynamicMetaObject(
+                    match switch
+                    {
+                        FieldInfo field => Expression.TypeAs(
+                            Expression.Field(Expression.Constant(target.Value), field),
+                            ReturnType),
+                        PropertyInfo property => Expression.TypeAs(
+                            Expression.Property(Expression.Constant(target.Value), property),
+                            ReturnType),
+                        _ => Fallback ?? Expression.Throw(
+                            Expression.New(
+                                MissingMemberExceptionConstructor,
+                                Expression.Constant(target.RuntimeType.Name),
+                                Expression.Constant(Name)),
+                            ReturnType),
+                    },
+                    BindingRestrictions.Empty);
+            }
+        }
+    }
+}

--- a/src/Chr.Avro/Infrastructure/ReflectionExtensions.cs
+++ b/src/Chr.Avro/Infrastructure/ReflectionExtensions.cs
@@ -272,28 +272,6 @@ namespace Chr.Avro.Infrastructure
         }
 
         /// <summary>
-        /// Gets the value of a member.
-        /// </summary>
-        /// <param name="member">
-        /// A <see cref="MemberInfo" /> object to get the value from.
-        /// </param>
-        /// <param name="object">
-        /// An object instance.
-        /// </param>
-        /// <returns>
-        /// The value of <paramref name="member" /> on <paramref name="object" />.
-        /// </returns>
-        public static object GetValue(this MemberInfo member, object @object)
-        {
-            return member switch
-            {
-                FieldInfo field => field.GetValue(@object),
-                PropertyInfo property => property.GetValue(@object),
-                _ => throw new ArgumentException($"Unable to get a value from {member.Name}."),
-            };
-        }
-
-        /// <summary>
         /// Determines whether <see cref="MemberInfo" /> has <typeparamref name="T" /> as an
         /// attribute.
         /// </summary>

--- a/tests/Chr.Avro.Binary.Tests/RecordSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/RecordSerializationTests.cs
@@ -50,32 +50,38 @@ namespace Chr.Avro.Serialization.Tests
                     new RecordField("Sixth", map),
                     new RecordField("Seventh", @enum),
                     new RecordField("Eighth", @enum),
+                    new RecordField("Ninth", boolean)
+                    {
+                        Default = new ObjectDefaultValue<bool>(true, boolean),
+                    },
                 },
             };
 
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            var value = new
-            {
-                First = new List<bool>() { false },
-                Second = new List<bool>() { false, false },
-                Third = new List<bool>() { false, false, false },
-                Fourth = new List<bool>() { false },
-                Fifth = new Dictionary<string, int>() { { "first", 1 } },
-                Sixth = new Dictionary<string, int>() { { "first", 1 }, { "second", 2 } },
-                Seventh = ImplicitEnum.First,
-                Eighth = ImplicitEnum.None,
-            };
-
             using (stream)
             {
-                serialize(value, new BinaryWriter(stream));
+                serialize(
+                    new
+                    {
+                        First = new List<bool>() { false },
+                        Second = new List<bool>() { false, false },
+                        Third = new List<bool>() { false, false, false },
+                        Fourth = new List<bool>() { false },
+                        Fifth = new Dictionary<string, int>() { { "first", 1 } },
+                        Sixth = new Dictionary<string, int>() { { "first", 1 }, { "second", 2 } },
+                        Seventh = ImplicitEnum.First,
+                        Eighth = ImplicitEnum.None,
+                    },
+                    new BinaryWriter(stream));
             }
 
             var reader = new BinaryReader(stream.ToArray());
+            var value = deserialize(ref reader);
 
-            Assert.Equal(value.Seventh.ToString(), deserialize(ref reader).Seventh);
+            Assert.Equal(nameof(ImplicitEnum.First), value.Seventh);
+            Assert.Equal(true, value.Ninth);
         }
 
         [Fact]

--- a/tests/Chr.Avro.Json.Tests/RecordSerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/RecordSerializationTests.cs
@@ -48,32 +48,38 @@ namespace Chr.Avro.Serialization.Tests
                     new RecordField("Sixth", map),
                     new RecordField("Seventh", @enum),
                     new RecordField("Eighth", @enum),
+                    new RecordField("Ninth", boolean)
+                    {
+                        Default = new ObjectDefaultValue<bool>(true, boolean),
+                    },
                 },
             };
 
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            var value = new
-            {
-                First = new List<bool>() { false },
-                Second = new List<bool>() { false, false },
-                Third = new List<bool>() { false, false, false },
-                Fourth = new List<bool>() { false },
-                Fifth = new Dictionary<string, int>() { { "first", 1 } },
-                Sixth = new Dictionary<string, int>() { { "first", 1 }, { "second", 2 } },
-                Seventh = ImplicitEnum.First,
-                Eighth = ImplicitEnum.None,
-            };
-
             using (stream)
             {
-                serialize(value, new Utf8JsonWriter(stream));
+                serialize(
+                    new
+                    {
+                        First = new List<bool>() { false },
+                        Second = new List<bool>() { false, false },
+                        Third = new List<bool>() { false, false, false },
+                        Fourth = new List<bool>() { false },
+                        Fifth = new Dictionary<string, int>() { { "first", 1 } },
+                        Sixth = new Dictionary<string, int>() { { "first", 1 }, { "second", 2 } },
+                        Seventh = ImplicitEnum.First,
+                        Eighth = ImplicitEnum.None,
+                    },
+                    new Utf8JsonWriter(stream));
             }
 
             var reader = new Utf8JsonReader(stream.ToArray());
+            var value = deserialize(ref reader);
 
-            Assert.Equal(value.Seventh.ToString(), deserialize(ref reader).Seventh);
+            Assert.Equal(nameof(ImplicitEnum.First), value.Seventh);
+            Assert.Equal(true, value.Ninth);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #339. Catching `RuntimeBinderException` isn't ideal, but as long as we're using Microsoft.CSharp.RuntimeBinder I don't think we have much of a choice.