### PR TITLE
perf: Avoid enumerator boxing and virtual calls during array serialization

### DIFF
--- a/src/Chr.Avro.Binary/Serialization/BinaryArraySerializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryArraySerializerBuilderCase.cs
@@ -2,6 +2,7 @@ namespace Chr.Avro.Serialization
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq.Expressions;
     using Chr.Avro.Abstract;
 
@@ -49,14 +50,13 @@ namespace Chr.Avro.Serialization
                 {
                     // support dynamic mapping:
                     itemType ??= typeof(object);
-                    var readOnlyCollectionType = typeof(IReadOnlyCollection<>).MakeGenericType(itemType);
-                    var enumerableType = typeof(IEnumerable<>).MakeGenericType(itemType);
-                    var enumeratorType = typeof(IEnumerator<>).MakeGenericType(itemType);
 
+                    var collectionType = typeof(ICollection<>).MakeGenericType(itemType);
+                    var enumerableType = typeof(IEnumerable<>).MakeGenericType(itemType);
                     Expression expression;
                     try
                     {
-                        if (readOnlyCollectionType.IsAssignableFrom(type))
+                        if (collectionType.IsAssignableFrom(type))
                         {
                             // NOTE: Not casting the expression to allow us to get the specific enumerator of `type`
                             // This way we can avoid the allocation of an IEnumerator<T> and the overhead of
@@ -65,7 +65,23 @@ namespace Chr.Avro.Serialization
                         }
                         else
                         {
-                            expression = BuildConversion(value, readOnlyCollectionType);
+                            var readOnlyCollectionType = typeof(IReadOnlyCollection<>).MakeGenericType(itemType);
+                            if (readOnlyCollectionType.IsAssignableFrom(type))
+                            {
+                                // NOTE: If the type is assignable to IReadOnlyCollection<T> (like ImmutableCollections)
+                                // we can use that instead of ICollection<T> to get the count of items in the collection
+                                expression = value;
+                                collectionType = readOnlyCollectionType;
+                            }
+                            else
+                            {
+                                // If the type is not assignable to either IReadOnlyCollection<T> or ICollection<T> we
+                                // convert to an ICollection<T> to be able to get the count of items in the collection.
+                                //
+                                // This will likely result in a materialization of the IEnumerable<T> which is not ideal
+                                // but we need the count of items in the collection to write the length prefix of the array.
+                                expression = BuildConversion(value, collectionType);
+                            }
                         }
                     }
                     catch (Exception exception)
@@ -74,12 +90,13 @@ namespace Chr.Avro.Serialization
                     }
 
                     var collection = Expression.Variable(expression.Type);
-                    var enumerationReflection = EnumerationReflection.Create(collection, readOnlyCollectionType, enumerableType);
+                    var enumerationReflection = EnumerationReflection.Create(collection, collectionType, enumerableType);
+                    Debug.Assert(enumerationReflection.GetCount is not null, "For binary serialization we must have a valid GetCount method.");
 
                     var loopLabel = Expression.Label();
 
                     var writeInteger = typeof(BinaryWriter)
-                        .GetMethod(nameof(BinaryWriter.WriteInteger), new[] { typeof(long) });
+                        .GetMethod(nameof(BinaryWriter.WriteInteger), new[] { typeof(long) })!;
 
                     var writeItem = SerializerBuilder
                         .BuildExpression(Expression.Property(enumerationReflection.Enumerator, enumerationReflection.GetCurrent), arraySchema.Item, context);
@@ -113,8 +130,6 @@ namespace Chr.Avro.Serialization
                     //
                     // // write closing block:
                     // writer.WriteInteger(0L);
-
-
                     Expression loop = Expression.Loop(
                         Expression.IfThenElse(
                             Expression.Call(enumerationReflection.Enumerator, enumerationReflection.MoveNext),
@@ -161,5 +176,7 @@ namespace Chr.Avro.Serialization
                 return BinarySerializerBuilderCaseResult.FromException(new UnsupportedSchemaException(schema, $"{nameof(BinaryArraySerializerBuilderCase)} can only be applied to {nameof(ArraySchema)}s."));
             }
         }
+
+
     }
 }

--- a/src/Chr.Avro.Json/Serialization/JsonArraySerializerBuilderCase.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonArraySerializerBuilderCase.cs
@@ -50,14 +50,12 @@ namespace Chr.Avro.Serialization
                 {
                     // support dynamic mapping:
                     itemType ??= typeof(object);
-                    var readOnlyCollectionType = typeof(IReadOnlyCollection<>).MakeGenericType(itemType);
                     var enumerableType = typeof(IEnumerable<>).MakeGenericType(itemType);
-                    var enumeratorType = typeof(IEnumerator<>).MakeGenericType(itemType);
 
                     Expression expression;
                     try
                     {
-                        if (readOnlyCollectionType.IsAssignableFrom(type))
+                        if (enumerableType.IsAssignableFrom(type))
                         {
                             // NOTE: Not casting the expression to allow us to get the specific enumerator of `type`
                             // This way we can avoid the allocation of an IEnumerator<T> and the overhead of
@@ -66,7 +64,7 @@ namespace Chr.Avro.Serialization
                         }
                         else
                         {
-                            expression = BuildConversion(value, readOnlyCollectionType);
+                            expression = BuildConversion(value, enumerableType);
                         }
                     }
                     catch (Exception exception)
@@ -75,7 +73,7 @@ namespace Chr.Avro.Serialization
                     }
 
                     var collection = Expression.Variable(expression.Type);
-                    var enumerationReflection = EnumerationReflection.Create(collection, readOnlyCollectionType, enumerableType);
+                    var enumerationReflection = EnumerationReflection.Create(collection, enumerableType, enumerableType);
 
                     var loopLabel = Expression.Label();
 

--- a/src/Chr.Avro/Serialization/ArraySerializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/ArraySerializerBuilderCase.cs
@@ -1,12 +1,16 @@
 namespace Chr.Avro.Serialization
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using System.Linq.Expressions;
+    using System.Reflection;
     using Chr.Avro.Abstract;
     using Chr.Avro.Infrastructure;
     using Microsoft.CSharp.RuntimeBinder;
+    using Binder = Microsoft.CSharp.RuntimeBinder.Binder;
 
     /// <summary>
     /// Provides a base implementation for serializer builder cases that match <see cref="ArraySchema" />.
@@ -18,7 +22,7 @@ namespace Chr.Avro.Serialization
         {
             if (target.GetEnumerableType() is Type itemType)
             {
-                var collectionType = typeof(ICollection<>).MakeGenericType(itemType);
+                var collectionType = typeof(IReadOnlyCollection<>).MakeGenericType(itemType);
                 var enumerableType = typeof(IEnumerable<>).MakeGenericType(itemType);
 
                 var toList = typeof(Enumerable)
@@ -58,7 +62,7 @@ namespace Chr.Avro.Serialization
         {
             if (target.GetEnumerableType() is Type itemType)
             {
-                var collectionType = typeof(ICollection<>).MakeGenericType(itemType);
+                var collectionType = typeof(IReadOnlyCollection<>).MakeGenericType(itemType);
                 var enumerableType = typeof(IEnumerable<>).MakeGenericType(itemType);
 
                 if (!collectionType.IsAssignableFrom(value.Type))
@@ -110,6 +114,140 @@ namespace Chr.Avro.Serialization
             foreach (object? item in enumerable)
             {
                 yield return item;
+            }
+        }
+
+        /// <summary>
+        /// A helper class meant to facilitate the runtime generation of code that iterates over collections.
+        /// It resolves and caches the necessary MethodInfo and PropertyInfo metadata required to build
+        /// a "foreach" loop using Expression Trees.
+        /// </summary>
+        internal class EnumerationReflection
+        {
+            private EnumerationReflection(
+                ParameterExpression enumerator,
+                PropertyInfo getCount,
+                PropertyInfo getCurrent,
+                MethodInfo getEnumerator,
+                MethodInfo moveNext,
+                MethodCallExpression? disposeCall)
+            {
+                Enumerator = enumerator;
+                GetCount = getCount;
+                GetCurrent = getCurrent;
+                GetEnumerator = getEnumerator;
+                MoveNext = moveNext;
+                DisposeCall = disposeCall;
+            }
+
+            /// <summary>
+            /// Gets the expression variable that holds the Enumerator instance (e.g., the 'var enum' in a foreach).
+            /// </summary>
+            public ParameterExpression Enumerator { get; }
+
+            /// <summary>
+            /// Gets the <see cref="PropertyInfo"/> for the collection's Count or Length property.
+            /// </summary>
+            public PropertyInfo GetCount { get; }
+
+            /// <summary>
+            /// Gets the <see cref="PropertyInfo"/> for the <c>Current</c> property of the enumerator.
+            /// </summary>
+            public PropertyInfo GetCurrent { get; }
+
+            /// <summary>
+            /// Gets the <see cref="MethodInfo"/> for the <c>GetEnumerator()</c> method.
+            /// </summary>
+            public MethodInfo GetEnumerator { get; }
+
+            /// <summary>
+            /// Gets the <see cref="MethodInfo"/> for the <c>MoveNext()</c> method.
+            /// </summary>
+            public MethodInfo MoveNext { get; }
+
+            /// <summary>
+            /// Gets the <see cref="MethodCallExpression"/> representing the <c>Dispose()</c> call.
+            /// This may be null if the enumerator does not implement <see cref="IDisposable"/>
+            /// (common in some struct enumerators for performance).
+            /// </summary>
+            public MethodCallExpression? DisposeCall { get; }
+
+            /// <summary>
+            /// Analyzes the provided collection type and resolves the reflection metadata needed to iterate it.
+            /// </summary>
+            /// <param name="collection">The expression representing the collection instance.</param>
+            /// <param name="readOnlyCollectionType">The fallback type for read-only collections (usually <see cref="IReadOnlyCollection{T}"/>).</param>
+            /// <param name="enumerableType">The fallback type for enumerables (usually <see cref="IEnumerable{T}"/> or <see cref="IEnumerable"/>).</param>
+            /// <returns>A populated <see cref="EnumerationReflection"/> instance.</returns>
+            public static EnumerationReflection Create(ParameterExpression collection, Type readOnlyCollectionType, Type enumerableType)
+            {
+                // Try to get the Count property from the actual concrete type first.
+                // If not found (e.g., explicit interface impl), fallback to looking up ICollection or IReadOnlyCollection.
+                var getCount = GetCountProperty(collection.Type, readOnlyCollectionType);
+
+                // Similarly, look on the concrete type (to avoid boxing struct enumerators like List<T>.Enumerator),
+                // falling back to the generic IEnumerable<T> interface if needed.
+                var getEnumerator = GetMethodWithFallback(collection.Type, nameof(IEnumerable.GetEnumerator), enumerableType)!;
+
+                // CRITICAL: IEnumerator<T> inherits from IEnumerator (non-generic).
+                // The MoveNext method is defined on the non-generic base interface.
+                // If the return type of GetEnumerator is strictly IEnumerator<T>, standard reflection might not
+                // see MoveNext immediately without checking the interface hierarchy.
+                var moveNext = GetMethodWithFallback(getEnumerator.ReturnType, nameof(IEnumerator.MoveNext), typeof(IEnumerator))!;
+
+                // Creates a variable expression that will hold the result of calling getEnumerator
+                var enumerator = Expression.Variable(getEnumerator.ReturnType);
+
+                // Look for the 'Current' property on the enumerator type returned from the getEnumerator resolved earlier.
+                var getCurrent = enumerator.Type.GetProperty(nameof(IEnumerator.Current))!;
+
+                // Check if the specific enumerator type implements IDisposable.
+                var dispose = GetMethodWithFallback(enumerator.Type, nameof(IDisposable.Dispose), typeof(IDisposable));
+                var disposeCall = default(MethodCallExpression);
+                if (dispose is not null)
+                {
+                    // Some Enumerator implementations (like ImmutableArray<T>.Enumerator and internal ArrayEnumerator)
+                    // do NOT implement IDisposable.
+                    // By checking for null here, the generated code can skip the overhead of a try/finally block
+                    // if it is not strictly necessary.
+                    disposeCall = Expression.Call(enumerator, dispose);
+                }
+
+                return new EnumerationReflection(enumerator, getCount, getCurrent, getEnumerator, moveNext, disposeCall);
+            }
+
+            private static PropertyInfo GetCountProperty(Type type, Type fallback)
+            {
+                // Try to get the property from the concrete type (e.g., List<int>)
+                var property = type.GetProperty(nameof(ICollection.Count));
+                if (property is not null)
+                {
+                    return property;
+                }
+
+                // If not found, get from the fallback type
+                Debug.Assert(fallback.IsAssignableFrom(type), "Fallback should aways be IReadOnlyCollection and BuildConversion will result in an IReadOnlyCollection");
+                property = fallback.GetProperty(nameof(ICollection.Count))!;
+                return property;
+            }
+
+            private static MethodInfo? GetMethodWithFallback(Type type, string name, Type fallback)
+            {
+                // Try to get the method from the concrete type (e.g., List<int>)
+                var method = type.GetMethod(name);
+                if (method is not null)
+                {
+                    return method;
+                }
+
+                // If not found, and the type implements the fallback interface (IReadOnlyCollection, IEnumerable, IDisposable),
+                // get the method from that interface.
+                if (fallback.IsAssignableFrom(type))
+                {
+                    method = fallback.GetMethod(name);
+                }
+
+                return method;
             }
         }
     }

--- a/src/Chr.Avro/Serialization/ArraySerializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/ArraySerializerBuilderCase.cs
@@ -3,7 +3,6 @@ namespace Chr.Avro.Serialization
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
@@ -22,7 +21,7 @@ namespace Chr.Avro.Serialization
         {
             if (target.GetEnumerableType() is Type itemType)
             {
-                var collectionType = typeof(IReadOnlyCollection<>).MakeGenericType(itemType);
+                var collectionType = typeof(ICollection<>).MakeGenericType(itemType);
                 var enumerableType = typeof(IEnumerable<>).MakeGenericType(itemType);
 
                 var toList = typeof(Enumerable)
@@ -62,7 +61,7 @@ namespace Chr.Avro.Serialization
         {
             if (target.GetEnumerableType() is Type itemType)
             {
-                var collectionType = typeof(IReadOnlyCollection<>).MakeGenericType(itemType);
+                var collectionType = typeof(ICollection<>).MakeGenericType(itemType);
                 var enumerableType = typeof(IEnumerable<>).MakeGenericType(itemType);
 
                 if (!collectionType.IsAssignableFrom(value.Type))
@@ -126,7 +125,7 @@ namespace Chr.Avro.Serialization
         {
             private EnumerationReflection(
                 ParameterExpression enumerator,
-                PropertyInfo getCount,
+                PropertyInfo? getCount,
                 PropertyInfo getCurrent,
                 MethodInfo getEnumerator,
                 MethodInfo moveNext,
@@ -147,8 +146,9 @@ namespace Chr.Avro.Serialization
 
             /// <summary>
             /// Gets the <see cref="PropertyInfo"/> for the collection's Count or Length property.
+            /// May be null when count is not needed (e.g., JSON serialization).
             /// </summary>
-            public PropertyInfo GetCount { get; }
+            public PropertyInfo? GetCount { get; }
 
             /// <summary>
             /// Gets the <see cref="PropertyInfo"/> for the <c>Current</c> property of the enumerator.
@@ -176,14 +176,18 @@ namespace Chr.Avro.Serialization
             /// Analyzes the provided collection type and resolves the reflection metadata needed to iterate it.
             /// </summary>
             /// <param name="collection">The expression representing the collection instance.</param>
-            /// <param name="readOnlyCollectionType">The fallback type for read-only collections (usually <see cref="IReadOnlyCollection{T}"/>).</param>
-            /// <param name="enumerableType">The fallback type for enumerables (usually <see cref="IEnumerable{T}"/> or <see cref="IEnumerable"/>).</param>
+            /// <param name="collectionType">
+            /// The fallback type for collections (can be <see cref="IReadOnlyCollection{T}"/> or <see cref="ICollection{T}"/>).
+            /// </param>
+            /// <param name="enumerableType">
+            /// The fallback type for enumerables (usually <see cref="IEnumerable{T}"/> or <see cref="IEnumerable"/>).
+            /// </param>
             /// <returns>A populated <see cref="EnumerationReflection"/> instance.</returns>
-            public static EnumerationReflection Create(ParameterExpression collection, Type readOnlyCollectionType, Type enumerableType)
+            public static EnumerationReflection Create(ParameterExpression collection, Type collectionType, Type enumerableType)
             {
                 // Try to get the Count property from the actual concrete type first.
                 // If not found (e.g., explicit interface impl), fallback to looking up ICollection or IReadOnlyCollection.
-                var getCount = GetCountProperty(collection.Type, readOnlyCollectionType);
+                var getCount = GetCountProperty(collection.Type, collectionType);
 
                 // Similarly, look on the concrete type (to avoid boxing struct enumerators like List<T>.Enumerator),
                 // falling back to the generic IEnumerable<T> interface if needed.
@@ -216,7 +220,7 @@ namespace Chr.Avro.Serialization
                 return new EnumerationReflection(enumerator, getCount, getCurrent, getEnumerator, moveNext, disposeCall);
             }
 
-            private static PropertyInfo GetCountProperty(Type type, Type fallback)
+            private static PropertyInfo? GetCountProperty(Type type, Type fallback)
             {
                 // Try to get the property from the concrete type (e.g., List<int>)
                 var property = type.GetProperty(nameof(ICollection.Count));
@@ -225,9 +229,12 @@ namespace Chr.Avro.Serialization
                     return property;
                 }
 
-                // If not found, get from the fallback type
-                Debug.Assert(fallback.IsAssignableFrom(type), "Fallback should aways be IReadOnlyCollection and BuildConversion will result in an IReadOnlyCollection");
-                property = fallback.GetProperty(nameof(ICollection.Count))!;
+                // If not found, get from the fallback type if applicable.
+                if (fallback.IsAssignableFrom(type))
+                {
+                    property = fallback.GetProperty(nameof(ICollection.Count));
+                }
+
                 return property;
             }
 


### PR DESCRIPTION
My application primally serializes collections of items.
I noticed a large number of allocated objects due to boxing happening in the generated code for the serialization. This is my attempt to resolve this.

I ran a basic benchmark in main and in this PR:
```
| Method   | Mean     | Error    | StdDev   | Allocated |
|--------- |---------:|---------:|---------:|----------:|
| main     | 311.3 us | 20.90 us | 61.62 us |      40 B |
| PR       | 247.8 us |  4.35 us |  7.50 us |         - |
```

The benchmark I used:
```cs
using BenchmarkDotNet.Attributes;
using Chr.Avro.Abstract;
using Chr.Avro.Serialization;

[MemoryDiagnoser]
public class AvroSerializeListOfObjects {
    private ObjectWithCollection _toSerialize;
    private MemoryStream _memoryStream;
    private Chr.Avro.Serialization.BinaryWriter _writer;
    private BinarySerializer<ObjectWithCollection> _serializer;

    [GlobalSetup]
    public void GlobalSetup() {
        // Large enough to fit the serialized value
        _memoryStream = new MemoryStream(500 * 1024 * 1024);
        _writer = new Chr.Avro.Serialization.BinaryWriter(_memoryStream);

        _toSerialize = new ObjectWithCollection() {
            Numbers = Enumerable.Range(0, 10000).ToList(),
        };

        var serializerBuilder = new BinarySerializerBuilder();
        var schemaBuilder = new SchemaBuilder();
        var schema = schemaBuilder.BuildSchema<ObjectWithCollection>();
        _serializer = serializerBuilder.BuildDelegate<ObjectWithCollection>(schema);
    }

    [IterationSetup]
    public void IterationSetup() => _memoryStream.Position = 0;


    [Benchmark]
    public void Baseline() => _serializer(_toSerialize, _writer);
}

public class ObjectWithCollection {
    public List<int> Numbers { get; set; }
}
```