### PR TITLE
perf: Implement DecimalEncoder that used 256-bit math to encode decimal values to the avro binary representation

### DIFF
--- a/src/Chr.Avro.Binary/Chr.Avro.Binary.csproj
+++ b/src/Chr.Avro.Binary/Chr.Avro.Binary.csproj
@@ -4,7 +4,7 @@
     <Description>Avro binary serialization and deserialization</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Chr.Avro.Binary/Serialization/BinaryDateDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryDateDeserializerBuilderCase.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization
 {
     using System;

--- a/src/Chr.Avro.Binary/Serialization/BinaryDateSerializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryDateSerializerBuilderCase.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization
 {
     using System;

--- a/src/Chr.Avro.Binary/Serialization/BinaryDecimalCodec.256bit.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryDecimalCodec.256bit.cs
@@ -1,0 +1,331 @@
+#if NET8_0_OR_GREATER
+namespace Chr.Avro.Serialization
+{
+    using System;
+    using System.Buffers.Binary;
+    using System.Runtime.InteropServices;
+    using System.Runtime.Intrinsics;
+
+    /// <summary>
+    /// Methods to encode and decode decimals using 256-bit integer math for intermediate calculations,
+    /// avoiding heap allocations that occur with <see cref="System.Numerics.BigInteger"/>.
+    /// This supports encoding/decoding of decimals with magnitudes up to 2^256,
+    /// which is more than sufficient for decimal's 96-bit mantissa and maximum scale of 28.
+    /// </summary>
+    internal static partial class BinaryDecimalCodec
+    {
+        private static ReadOnlySpan<ulong> PowersOfTen => new ulong[]
+        {
+            1UL,
+            10UL,
+            100UL,
+            1_000UL,
+            10_000UL,
+            100_000UL,
+            1_000_000UL,
+            10_000_000UL,
+            100_000_000UL,
+            1_000_000_000UL,
+            10_000_000_000UL,
+            100_000_000_000UL,
+            1_000_000_000_000UL,
+            10_000_000_000_000UL,
+            100_000_000_000_000UL,
+            1_000_000_000_000_000UL,
+            10_000_000_000_000_000UL,
+            100_000_000_000_000_000UL,
+            1_000_000_000_000_000_000UL,
+            10_000_000_000_000_000_000UL, // 10^19
+        };
+
+        private static decimal DecodeDecimalWith256BitMath(ReadOnlySpan<byte> bytes, int scale)
+        {
+            const int BufferLength = 4;
+
+            // stackalloc is zero-initialized; no Clear() needed.
+            Span<ulong> buffer = stackalloc ulong[BufferLength];
+
+            bool isNegative = (bytes[0] & 0x80) != 0;
+
+            // Parse big-endian two's complement bytes into a little-endian 256-bit buffer.
+            // Copy then reverse is faster than the equivalent byte-by-byte indexed loop.
+            Span<byte> bufferBytes = MemoryMarshal.AsBytes(buffer);
+            int copyLen = Math.Min(bytes.Length, bufferBytes.Length);
+            bytes.Slice(0, copyLen).CopyTo(bufferBytes);
+            bufferBytes.Slice(0, copyLen).Reverse();
+
+            // Sign-extend when the input is shorter than 32 bytes.
+            if (isNegative && bytes.Length < bufferBytes.Length)
+            {
+                bufferBytes.Slice(bytes.Length).Fill(0xFF);
+            }
+
+            if (isNegative)
+            {
+                Negate256(buffer);
+            }
+
+            // Reduce scale to fit within decimal's maximum of 28.
+            if (scale > 28)
+            {
+                DivideByPowerOfTen(buffer, scale - 28);
+                scale = 28;
+            }
+
+            // Fast path: if the magnitude fits in 96 bits (decimal's mantissa size),
+            // construct the decimal directly without any division.
+            if (buffer[2] == 0 && buffer[3] == 0 && (buffer[1] >> 32) == 0)
+            {
+                return new decimal(
+                    (int)(uint)buffer[0],
+                    (int)(uint)(buffer[0] >> 32),
+                    (int)(uint)buffer[1],
+                    isNegative,
+                    (byte)scale);
+            }
+
+            // Slow path: the magnitude exceeds 96 bits (e.g. decimal.MaxValue encoded with
+            // a non-zero scale). Split into integer and fractional parts via DivRem.
+            var (fracLo, fracMid, fracHi) = DivRemByPowerOfTen(buffer, scale);
+
+            if (buffer[2] != 0 || buffer[3] != 0 || (buffer[1] >> 32) != 0)
+            {
+                throw new OverflowException("Decimal value is too large to fit in System.Decimal.");
+            }
+
+            var integerPart = new decimal(
+                (int)(uint)buffer[0],
+                (int)(uint)(buffer[0] >> 32),
+                (int)(uint)buffer[1],
+                isNegative,
+                0);
+
+            var fractionalPart = new decimal(
+                (int)fracLo,
+                (int)fracMid,
+                (int)fracHi,
+                isNegative,
+                (byte)scale);
+
+            return integerPart + fractionalPart;
+        }
+
+        private static int EncodeDecimalWith256BitMath(decimal value, int schemaScale, Span<byte> destination)
+        {
+            // 4 ulongs = 256 bits.
+            const int BufferLength = 4;
+
+            Span<int> bits = stackalloc int[4];
+            decimal.GetBits(value, bits);
+
+            var isNegative = (bits[3] & 0x80000000) != 0;
+            var sourceScale = (byte)((bits[3] >> 16) & 0x7F);
+
+            // Load magnitude into a 256-bit stack buffer (little-endian ulongs).
+            // Decimal magnitude is 96 bits; pack into two ulongs.
+            // stackalloc is zero-initialized; buffer[2] and buffer[3] start at 0.
+            Span<ulong> buffer = stackalloc ulong[BufferLength];
+            buffer[0] = (uint)bits[0] | ((ulong)(uint)bits[1] << 32);
+            buffer[1] = (uint)bits[2];
+
+            var scaleDiff = schemaScale - sourceScale;
+            if (scaleDiff > 0)
+            {
+                if (!TryMultiplyByPowerOfTen(buffer, scaleDiff))
+                {
+                    throw new OverflowException();
+                }
+            }
+            else if (scaleDiff < 0)
+            {
+                DivideByPowerOfTen(buffer, Math.Abs(scaleDiff));
+            }
+
+            if (isNegative)
+            {
+                Negate256(buffer);
+            }
+
+            // Serialize to big-endian bytes.
+            Span<byte> fullBytes = stackalloc byte[BufferLength * 8];
+            WriteBigEndian(buffer, fullBytes);
+
+            // Trim leading padding bytes based on two's complement sign.
+            int startIndex = 0;
+            if (!isNegative)
+            {
+                while (startIndex < fullBytes.Length && fullBytes[startIndex] == 0)
+                {
+                    startIndex++;
+                }
+
+                if (startIndex == fullBytes.Length)
+                {
+                    // Value is 0
+                    startIndex--;
+                }
+                else if ((fullBytes[startIndex] & 0x80) != 0)
+                {
+                    // Must prepend 0x00 so it isn't interpreted as negative
+                    startIndex--;
+                }
+            }
+            else
+            {
+                while (startIndex < fullBytes.Length && fullBytes[startIndex] == 0xFF)
+                {
+                    startIndex++;
+                }
+
+                if (startIndex == fullBytes.Length)
+                {
+                    // Value is -1
+                    startIndex--;
+                }
+                else if ((fullBytes[startIndex] & 0x80) == 0)
+                {
+                    // Must prepend 0xFF so it remains negative
+                    startIndex--;
+                }
+            }
+
+            var contentLen = fullBytes.Length - startIndex;
+            fullBytes.Slice(startIndex, contentLen).CopyTo(destination);
+            return contentLen;
+        }
+
+        private static bool TryMultiplyByPowerOfTen(Span<ulong> buffer, int power)
+        {
+            while (power >= 19)
+            {
+                if (!TryMultiplyByInt(buffer, PowersOfTen[19]))
+                {
+                    return false;
+                }
+
+                power -= 19;
+            }
+
+            return power == 0 || TryMultiplyByInt(buffer, PowersOfTen[power]);
+        }
+
+        private static bool TryMultiplyByInt(Span<ulong> buffer, ulong factor)
+        {
+            // Find the highest non-zero word to avoid pointless multiplications.
+            int len = buffer.Length;
+            while (len > 1 && buffer[len - 1] == 0)
+            {
+                len--;
+            }
+
+            ulong carry = 0;
+            for (int i = 0; i < len; i++)
+            {
+                UInt128 product = ((UInt128)buffer[i] * factor) + carry;
+                buffer[i] = (ulong)product;
+                carry = (ulong)(product >> 64);
+            }
+
+            if (carry == 0)
+            {
+                return true;
+            }
+
+            if (len >= buffer.Length)
+            {
+                // overflow
+                return false;
+            }
+
+            buffer[len] = carry;
+            return true;
+        }
+
+        private static void WriteBigEndian(Span<ulong> source, Span<byte> destination)
+        {
+            BinaryPrimitives.WriteUInt64BigEndian(destination, source[3]);
+            BinaryPrimitives.WriteUInt64BigEndian(destination.Slice(8), source[2]);
+            BinaryPrimitives.WriteUInt64BigEndian(destination.Slice(16), source[1]);
+            BinaryPrimitives.WriteUInt64BigEndian(destination.Slice(24), source[0]);
+        }
+
+        // Divides buffer by 10^scale in-place and returns the fractional component as (Lo, Mid, Hi).
+        // The remainder satisfies: rem < 10^scale ≤ 10^28 < 2^93, so it always fits in 96 bits.
+        private static (uint Lo, uint Mid, uint Hi) DivRemByPowerOfTen(Span<ulong> buffer, int scale)
+        {
+            if (scale == 0)
+            {
+                return (0, 0, 0);
+            }
+
+            // For scale ≤ 19, a single 64-bit division suffices.
+            int step1 = Math.Min(scale, 19);
+            ulong rem1 = DivRemByInt(buffer, PowersOfTen[step1]);
+
+            int step2 = scale - step1;
+            if (step2 == 0)
+            {
+                return ((uint)rem1, (uint)(rem1 >> 32), 0);
+            }
+
+            // For scale > 19, divide by 10^(scale-19) in a second step.
+            // Full remainder = rem2 * 10^step1 + rem1, fits in 96 bits since scale ≤ 28.
+            ulong rem2 = DivRemByInt(buffer, PowersOfTen[step2]);
+            UInt128 fullRemainder = (UInt128)(rem2 * PowersOfTen[step1]) + rem1;
+            return ((uint)fullRemainder, (uint)(fullRemainder >> 32), (uint)(fullRemainder >> 64));
+        }
+
+        // Divides buffer by divisor in-place, returning the remainder.
+        // Only processes words up to the highest non-zero one, skipping useless UInt128 divisions.
+        private static ulong DivRemByInt(Span<ulong> buffer, ulong divisor)
+        {
+            // Skip leading zero words (buffer is little-endian, so scan from the top down).
+            int start = buffer.Length - 1;
+            while (start > 0 && buffer[start] == 0)
+            {
+                start--;
+            }
+
+            ulong remainder = 0;
+            for (int i = start; i >= 0; i--)
+            {
+                UInt128 current = ((UInt128)remainder << 64) | buffer[i];
+                buffer[i] = (ulong)(current / divisor);
+                remainder = (ulong)(current % divisor);
+            }
+
+            return remainder;
+        }
+
+        private static void DivideByPowerOfTen(Span<ulong> buffer, int power)
+        {
+            while (power >= 19)
+            {
+                DivRemByInt(buffer, PowersOfTen[19]);
+                power -= 19;
+            }
+
+            if (power > 0)
+            {
+                DivRemByInt(buffer, PowersOfTen[power]);
+            }
+        }
+
+        private static void Negate256(Span<ulong> buffer)
+        {
+            ref byte bufferBytes = ref MemoryMarshal.GetReference(MemoryMarshal.AsBytes(buffer));
+            var vec = Vector256.LoadUnsafe(ref bufferBytes);
+            (~vec).StoreUnsafe(ref bufferBytes);
+
+            // Add 1 for Two's Complement
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                if (++buffer[i] != 0)
+                {
+                    break;
+                }
+            }
+        }
+    }
+}
+#endif

--- a/src/Chr.Avro.Binary/Serialization/BinaryDecimalCodec.BigInteger.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryDecimalCodec.BigInteger.cs
@@ -1,0 +1,29 @@
+namespace Chr.Avro.Serialization
+{
+    using System;
+    using System.Numerics;
+
+    /// <summary>
+    /// Methods to encode and decode decimals using <see cref="BigInteger"/> for intermediate calculations.
+    /// </summary>
+    internal static partial class BinaryDecimalCodec
+    {
+        private static byte[] EncodeWithBigInteger(decimal value, int scale)
+        {
+            var fraction = new BigInteger(value) * BigInteger.Pow(10, scale);
+            var whole = new BigInteger((value % 1m) * (decimal)Math.Pow(10, scale));
+            var bytes = (fraction + whole).ToByteArray();
+            Array.Reverse(bytes);
+            return bytes;
+        }
+
+        private static decimal DecodeDecimalWithBigInteger(byte[] bytes, int scale)
+        {
+            Array.Reverse(bytes);
+            var bigInteger = new BigInteger(bytes);
+            var divisor = BigInteger.Pow(10, scale);
+            var whole = BigInteger.DivRem(bigInteger, divisor, out var remainder);
+            return (decimal)whole + (decimal)remainder / (decimal)Math.Pow(10, scale);
+        }
+    }
+}

--- a/src/Chr.Avro.Binary/Serialization/BinaryDecimalCodec.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryDecimalCodec.cs
@@ -1,0 +1,91 @@
+namespace Chr.Avro.Serialization
+{
+    using System;
+    using Chr.Avro.Abstract;
+
+    /// <summary>
+    /// Provides static encode and decode methods for Avro decimal binary representation,
+    /// shared by <see cref="BinaryDecimalSerializerBuilderCase" /> and
+    /// <see cref="BinaryDecimalDeserializerBuilderCase" />.
+    /// </summary>
+    internal static partial class BinaryDecimalCodec
+    {
+        /// <summary>
+        /// Writes a <see cref="decimal"/> value to the specified <see cref="BinaryWriter"/> as a fixed-size byte array.
+        /// </summary>
+        /// <param name="writer">The <see cref="BinaryWriter"/> to which the fixed-length decimal bytes will be written.</param>
+        /// <param name="value">The <see cref="decimal"/> value to encode and write.</param>
+        /// <param name="precision">The total number of digits (precision) of the decimal value.</param>
+        /// <param name="scale">The number of fractional digits (scale) of the decimal value.</param>
+        /// <param name="schema">The <see cref="FixedSchema"/> defining the expected size of the encoded value.</param>
+        /// <exception cref="OverflowException">
+        /// Thrown when the size of the encoded byte array does not match the <see cref="FixedSchema.Size"/> defined by the schema.
+        /// </exception>
+        public static void WriteDecimalFixed(BinaryWriter writer, decimal value, int precision, int scale, FixedSchema schema)
+        {
+#if NET8_0_OR_GREATER
+            // A decimal's 96-bit mantissa fits in at most 13 bytes (12 + sign byte).
+            Span<byte> buffer = stackalloc byte[32];
+            var length = EncodeDecimalWith256BitMath(value, scale, buffer);
+            if (length != schema.Size)
+            {
+                ThrowOverflow(precision, scale, schema);
+                return;
+            }
+
+            writer.WriteFixed(buffer.Slice(0, length));
+#else
+            var bytes = EncodeWithBigInteger(value, scale);
+            if (bytes.Length != schema.Size)
+            {
+                ThrowOverflow(precision, scale, schema);
+            }
+
+            writer.WriteFixed(bytes);
+#endif
+        }
+
+        /// <summary>
+        /// Writes a <see cref="decimal"/> value to the specified <see cref="BinaryWriter"/> as a variable-length byte array.
+        /// </summary>
+        /// <param name="writer">The <see cref="BinaryWriter"/> to which the encoded decimal bytes will be written.</param>
+        /// <param name="value">The <see cref="decimal"/> value to encode and write.</param>
+        /// <param name="precision">The total number of digits (precision) of the decimal value.</param>
+        /// <param name="scale">The number of fractional digits (scale) of the decimal value.</param>
+        public static void WriteDecimalBytes(BinaryWriter writer, decimal value, int precision, int scale)
+        {
+#if NET8_0_OR_GREATER
+            // A decimal's 96-bit mantissa fits in at most 13 bytes (12 + sign byte).
+            Span<byte> buffer = stackalloc byte[32];
+            var length = EncodeDecimalWith256BitMath(value, scale, buffer);
+            writer.WriteBytes(buffer.Slice(0, length));
+#else
+            var bytes = EncodeWithBigInteger(value, scale);
+            writer.WriteBytes(bytes);
+#endif
+        }
+
+        /// <summary>
+        /// Decodes a byte array back into a <see cref="decimal"/> value using the specified scale.
+        /// </summary>
+        /// <param name="bytes">The byte array containing the encoded decimal data.</param>
+        /// <param name="scale">The number of fractional digits (scale) to apply to the decoded value.</param>
+        /// <returns>The decoded <see cref="decimal"/> value.</returns>
+        public static decimal DecodeDecimal(ReadOnlySpan<byte> bytes, int scale)
+        {
+#if NET8_0_OR_GREATER
+            return DecodeDecimalWith256BitMath(bytes, scale);
+#else
+            return DecodeDecimalWithBigInteger(bytes.ToArray(), scale);
+#endif
+        }
+
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+#endif
+        private static void ThrowOverflow(int precision, int scale, FixedSchema schema)
+        {
+            throw new OverflowException($"Size mismatch between {schema} (size {schema.Size}) and decimal with precision {precision} and scale {scale}.");
+        }
+    }
+}

--- a/src/Chr.Avro.Binary/Serialization/BinaryDecimalDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryDecimalDeserializerBuilderCase.cs
@@ -2,7 +2,7 @@ namespace Chr.Avro.Serialization
 {
     using System;
     using System.Linq.Expressions;
-    using System.Numerics;
+    using System.Reflection;
     using Chr.Avro.Abstract;
 
     /// <summary>
@@ -31,69 +31,40 @@ namespace Chr.Avro.Serialization
         {
             if (schema.LogicalType is DecimalLogicalType decimalLogicalType)
             {
-                var precision = decimalLogicalType.Precision;
                 var scale = decimalLogicalType.Scale;
 
                 Expression expression;
+
+                var decodeDecimal = typeof(BinaryDecimalCodec)
+                    .GetMethod(nameof(BinaryDecimalCodec.DecodeDecimal), BindingFlags.Static | BindingFlags.Public)!;
 
                 // figure out the size:
                 if (schema is BytesSchema)
                 {
                     var readBytes = typeof(BinaryReader)
-                        .GetMethod(nameof(BinaryReader.ReadBytes), Type.EmptyTypes);
+                        .GetMethod(nameof(BinaryReader.ReadBytesSpan), Type.EmptyTypes)!;
 
-                    expression = Expression.Call(context.Reader, readBytes);
+                    expression = Expression.Call(
+                        null,
+                        decodeDecimal,
+                        Expression.Call(context.Reader, readBytes),
+                        Expression.Constant(scale));
                 }
                 else if (schema is FixedSchema fixedSchema)
                 {
                     var readFixed = typeof(BinaryReader)
-                        .GetMethod(nameof(BinaryReader.ReadFixed), new[] { typeof(long) });
+                        .GetMethod(nameof(BinaryReader.ReadFixedSpan), new[] { typeof(int) })!;
 
-                    expression = Expression.Call(context.Reader, readFixed, Expression.Constant((long)fixedSchema.Size));
+                    expression = Expression.Call(
+                        null,
+                        decodeDecimal,
+                        Expression.Call(context.Reader, readFixed, Expression.Constant(fixedSchema.Size)),
+                        Expression.Constant(scale));
                 }
                 else
                 {
                     throw new UnsupportedSchemaException(schema);
                 }
-
-                // declare variables for in-place transformation:
-                var bytes = Expression.Variable(typeof(byte[]));
-                var remainder = Expression.Variable(typeof(BigInteger));
-
-                var divide = typeof(BigInteger)
-                    .GetMethod(nameof(BigInteger.DivRem), new[] { typeof(BigInteger), typeof(BigInteger), typeof(BigInteger).MakeByRefType() });
-
-                var integerConstructor = typeof(BigInteger)
-                    .GetConstructor(new[] { typeof(byte[]) });
-
-                var reverse = typeof(Array)
-                    .GetMethod(nameof(Array.Reverse), new[] { typeof(Array) });
-
-                // var bytes = ...;
-                //
-                // // BigInteger is little-endian, so reverse:
-                // Array.Reverse(bytes);
-                //
-                // var whole = BigInteger.DivRem(new BigInteger(bytes), BigInteger.Pow(10, scale), out var remainder);
-                // var fraction = (decimal)remainder / (decimal)Math.Pow(10, scale);
-                //
-                // return whole + fraction;
-                expression = Expression.Block(
-                    new[] { bytes, remainder },
-                    Expression.Assign(bytes, expression),
-                    Expression.Call(null, reverse, bytes),
-                    Expression.Add(
-                        Expression.ConvertChecked(
-                            Expression.Call(
-                                null,
-                                divide,
-                                Expression.New(integerConstructor, bytes),
-                                Expression.Constant(BigInteger.Pow(10, scale)),
-                                remainder),
-                            typeof(decimal)),
-                        Expression.Divide(
-                            Expression.ConvertChecked(remainder, typeof(decimal)),
-                            Expression.Constant((decimal)Math.Pow(10, scale)))));
 
                 try
                 {

--- a/src/Chr.Avro.Binary/Serialization/BinaryDecimalSerializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryDecimalSerializerBuilderCase.cs
@@ -2,7 +2,7 @@ namespace Chr.Avro.Serialization
 {
     using System;
     using System.Linq.Expressions;
-    using System.Numerics;
+    using System.Reflection;
     using Chr.Avro.Abstract;
 
     /// <summary>
@@ -31,8 +31,8 @@ namespace Chr.Avro.Serialization
         {
             if (schema.LogicalType is DecimalLogicalType decimalLogicalType)
             {
-                var precision = decimalLogicalType.Precision;
-                var scale = decimalLogicalType.Scale;
+                var precision = Expression.Constant(decimalLogicalType.Precision);
+                var scale = Expression.Constant(decimalLogicalType.Scale);
 
                 Expression expression;
 
@@ -45,71 +45,24 @@ namespace Chr.Avro.Serialization
                     throw new UnsupportedTypeException(type, $"Failed to map {schema} to {type}.", exception);
                 }
 
-                // declare variables for in-place transformation:
-                var bytes = Expression.Variable(typeof(byte[]));
-
-                var integerConstructor = typeof(BigInteger)
-                    .GetConstructor(new[] { typeof(decimal) });
-
-                var reverse = typeof(Array)
-                    .GetMethod(nameof(Array.Reverse), new[] { typeof(Array) });
-
-                var toByteArray = typeof(BigInteger)
-                    .GetMethod(nameof(BigInteger.ToByteArray), Type.EmptyTypes);
-
-                // var fraction = new BigInteger(...) * BigInteger.Pow(10, scale);
-                // var whole = new BigInteger((... % 1m) * (decimal)Math.Pow(10, scale));
-                // var bytes = (fraction + whole).ToByteArray();
-                //
-                // // BigInteger is little-endian, so reverse:
-                // Array.Reverse(bytes);
-                //
-                // return bytes;
-                expression = Expression.Block(
-                    Expression.Assign(
-                        bytes,
-                        Expression.Call(
-                            Expression.Add(
-                                Expression.Multiply(
-                                    Expression.New(
-                                        integerConstructor,
-                                        expression),
-                                    Expression.Constant(BigInteger.Pow(10, scale))),
-                                Expression.New(
-                                    integerConstructor,
-                                    Expression.Multiply(
-                                        Expression.Modulo(expression, Expression.Constant(1m)),
-                                        Expression.Constant((decimal)Math.Pow(10, scale))))),
-                            toByteArray)),
-                    Expression.Call(null, reverse, bytes),
-                    bytes);
-
                 // figure out how to write:
                 if (schema is BytesSchema)
                 {
-                    var writeBytes = typeof(BinaryWriter)
-                        .GetMethod(nameof(BinaryWriter.WriteBytes), new[] { typeof(byte[]) });
+                    var writeBytes = typeof(BinaryDecimalCodec)
+                        .GetMethod(nameof(BinaryDecimalCodec.WriteDecimalBytes), BindingFlags.Static | BindingFlags.Public)!;
 
                     expression = Expression.Block(
-                        new[] { bytes },
                         expression,
-                        Expression.Call(context.Writer, writeBytes, bytes));
+                        Expression.Call(writeBytes, context.Writer, expression, precision, scale));
                 }
                 else if (schema is FixedSchema fixedSchema)
                 {
-                    var exceptionConstructor = typeof(OverflowException)
-                        .GetConstructor(new[] { typeof(string) });
-
-                    var writeFixed = typeof(BinaryWriter)
-                        .GetMethod(nameof(BinaryWriter.WriteFixed), new[] { typeof(byte[]) });
+                    var writeFixed = typeof(BinaryDecimalCodec)
+                        .GetMethod(nameof(BinaryDecimalCodec.WriteDecimalFixed), BindingFlags.Static | BindingFlags.Public)!;
 
                     expression = Expression.Block(
-                        new[] { bytes },
                         expression,
-                        Expression.IfThen(
-                            Expression.NotEqual(Expression.ArrayLength(bytes), Expression.Constant(fixedSchema.Size)),
-                            Expression.Throw(Expression.New(exceptionConstructor, Expression.Constant($"Size mismatch between {fixedSchema} (size {fixedSchema.Size}) and decimal with precision {precision} and scale {scale}.")))),
-                        Expression.Call(context.Writer, writeFixed, bytes));
+                        Expression.Call(writeFixed, context.Writer, expression, precision, scale, Expression.Constant(fixedSchema)));
                 }
                 else
                 {

--- a/src/Chr.Avro.Binary/Serialization/BinaryDeserializerBuilder.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryDeserializerBuilder.cs
@@ -71,12 +71,12 @@ namespace Chr.Avro.Serialization
             return new Func<IBinaryDeserializerBuilder, IBinaryDeserializerBuilderCase>[]
             {
                 // logical types:
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 builder => new BinaryDateDeserializerBuilderCase(),
 #endif
                 builder => new BinaryDecimalDeserializerBuilderCase(),
                 builder => new BinaryDurationDeserializerBuilderCase(),
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 builder => new BinaryTimeDeserializerBuilderCase(),
 #endif
                 builder => new BinaryTimestampDeserializerBuilderCase(),

--- a/src/Chr.Avro.Binary/Serialization/BinaryReader.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryReader.cs
@@ -1,7 +1,7 @@
 namespace Chr.Avro.Serialization
 {
     using System;
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     using System.Buffers.Binary;
 #endif
     using System.Text;
@@ -76,7 +76,7 @@ namespace Chr.Avro.Serialization
         /// </returns>
         public double ReadDouble()
         {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             return BinaryPrimitives.ReadDoubleLittleEndian(ReadFixedSpan(8));
 #else
             var bytes = ReadFixed(8);
@@ -157,7 +157,7 @@ namespace Chr.Avro.Serialization
         /// </returns>
         public float ReadSingle()
         {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             return BinaryPrimitives.ReadSingleLittleEndian(ReadFixedSpan(4));
 #else
             var bytes = ReadFixed(4);
@@ -180,7 +180,7 @@ namespace Chr.Avro.Serialization
         /// </returns>
         public string ReadString()
         {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             return Encoding.UTF8.GetString(ReadBytesSpan());
 #else
             return Encoding.UTF8.GetString(ReadBytes());

--- a/src/Chr.Avro.Binary/Serialization/BinarySerializerBuilder.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinarySerializerBuilder.cs
@@ -67,12 +67,12 @@ namespace Chr.Avro.Serialization
             return new Func<IBinarySerializerBuilder, IBinarySerializerBuilderCase>[]
             {
                 // logical types:
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 builder => new BinaryDateSerializerBuilderCase(),
 #endif
                 builder => new BinaryDecimalSerializerBuilderCase(),
                 builder => new BinaryDurationSerializerBuilderCase(),
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 builder => new BinaryTimeSerializerBuilderCase(),
 #endif
                 builder => new BinaryTimestampSerializerBuilderCase(),

--- a/src/Chr.Avro.Binary/Serialization/BinaryTimeDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryTimeDeserializerBuilderCase.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization
 {
     using System;

--- a/src/Chr.Avro.Binary/Serialization/BinaryTimeSerializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryTimeSerializerBuilderCase.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization
 {
     using System;

--- a/src/Chr.Avro.Binary/Serialization/BinaryWriter.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryWriter.cs
@@ -1,7 +1,7 @@
 namespace Chr.Avro.Serialization
 {
     using System;
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     using System.Buffers.Binary;
 #endif
     using System.IO;
@@ -63,7 +63,7 @@ namespace Chr.Avro.Serialization
             WriteInteger(value.Length);
             WriteFixed(value);
         }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         /// <summary>
         /// Writes fixed-length binary data to the current position and advances the writer.
@@ -87,7 +87,7 @@ namespace Chr.Avro.Serialization
         /// </param>
         public void WriteDouble(double value)
         {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             Span<byte> bytes = stackalloc byte[sizeof(double)];
             BinaryPrimitives.WriteDoubleLittleEndian(bytes, value);
 #else
@@ -112,7 +112,7 @@ namespace Chr.Avro.Serialization
         {
             stream.Write(value, 0, value.Length);
         }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         /// <summary>
         /// Writes fixed-length binary data to the current position and advances the writer.
@@ -134,7 +134,7 @@ namespace Chr.Avro.Serialization
         /// </param>
         public void WriteInteger(int value)
         {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             var index = 0;
 
             // Max 5 bytes for 32-bit varint
@@ -153,7 +153,7 @@ namespace Chr.Avro.Serialization
                     current |= 0x80U;
                 }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 buffer[index++] = (byte)current;
 #else
                 stream.WriteByte((byte)current);
@@ -161,7 +161,7 @@ namespace Chr.Avro.Serialization
             }
             while (encoded != 0U);
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             stream.Write(buffer.Slice(0, index));
 #endif
         }
@@ -174,7 +174,7 @@ namespace Chr.Avro.Serialization
         /// </param>
         public void WriteInteger(long value)
         {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             var index = 0;
 
             // Max 10 bytes for 64-bit varint
@@ -193,7 +193,7 @@ namespace Chr.Avro.Serialization
                     current |= 0x80UL;
                 }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 buffer[index++] = (byte)current;
 #else
                 stream.WriteByte((byte)current);
@@ -201,7 +201,7 @@ namespace Chr.Avro.Serialization
             }
             while (encoded != 0UL);
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             stream.Write(buffer.Slice(0, index));
 #endif
         }
@@ -215,7 +215,7 @@ namespace Chr.Avro.Serialization
         /// </param>
         public void WriteSingle(float value)
         {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             Span<byte> bytes = stackalloc byte[sizeof(float)];
             BinaryPrimitives.WriteSingleLittleEndian(bytes, value);
 #else
@@ -238,7 +238,7 @@ namespace Chr.Avro.Serialization
         /// </param>
         public void WriteString(string value)
         {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             WriteInteger(Encoding.UTF8.GetByteCount(value));
 
             // UTF8 is Unicode encoding that represents each code point as a sequence of 1 to 4 bytes.

--- a/src/Chr.Avro.Cli/Chr.Avro.Cli.csproj
+++ b/src/Chr.Avro.Cli/Chr.Avro.Cli.csproj
@@ -5,7 +5,7 @@
     <IsPackable>true</IsPackable>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <ToolCommandName>dotnet-avro</ToolCommandName>
   </PropertyGroup>
 

--- a/src/Chr.Avro.Codegen/Chr.Avro.Codegen.csproj
+++ b/src/Chr.Avro.Codegen/Chr.Avro.Codegen.csproj
@@ -4,7 +4,7 @@
     <Description>Experimental utilities to generate code from Avro schemas</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Chr.Avro.Codegen/Codegen/CSharpCodeGenerator.cs
+++ b/src/Chr.Avro.Codegen/Codegen/CSharpCodeGenerator.cs
@@ -304,7 +304,7 @@ namespace Chr.Avro.Codegen
                     value = true;
                     break;
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 case IntSchema i when i.LogicalType is DateLogicalType t:
                     type = SyntaxFactory.ParseTypeName("global::System.DateOnly");
                     value = true;

--- a/src/Chr.Avro.Confluent/Chr.Avro.Confluent.csproj
+++ b/src/Chr.Avro.Confluent/Chr.Avro.Confluent.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Integration tools for the Confluent Kafka and Schema Registry clients</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Chr.Avro.Confluent/Confluent/AsyncSchemaRegistryDeserializer.cs
+++ b/src/Chr.Avro.Confluent/Confluent/AsyncSchemaRegistryDeserializer.cs
@@ -222,7 +222,7 @@ namespace Chr.Avro.Confluent
                 throw new InvalidEncodingException(0, "The encoded data does not include a Confluent wire format header.");
             }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             var header = data.Span[..5];
 
             if (header[0] != 0x00)

--- a/src/Chr.Avro.Fixtures/Fixtures/RangeAnnotatedPropertiesClass.cs
+++ b/src/Chr.Avro.Fixtures/Fixtures/RangeAnnotatedPropertiesClass.cs
@@ -4,21 +4,21 @@ namespace Chr.Avro.Fixtures
 
     public class RangeAnnotatedPropertiesClass
     {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         [Range(typeof(decimal), "0.00", "999999.99", ConvertValueInInvariantCulture = true)]
 #else
         [Range(typeof(decimal), "0.00", "999999.99")]
 #endif
         public decimal Currency { get; set; }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         [Range(typeof(decimal?), "0.00", "999999.99", ConvertValueInInvariantCulture = true)]
 #else
         [Range(typeof(decimal?), "0.00", "999999.99")]
 #endif
         public decimal? NullableCurrency { get; set; }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         [Range(typeof(decimal), "-.500", ".500", ConvertValueInInvariantCulture = true)]
 #else
         [Range(typeof(decimal), "-.500", ".500")]

--- a/src/Chr.Avro.Json/Chr.Avro.Json.csproj
+++ b/src/Chr.Avro.Json/Chr.Avro.Json.csproj
@@ -4,7 +4,7 @@
     <Description>Avro JSON serialization and deserialization</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Chr.Avro.Json/Serialization/JsonDateDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonDateDeserializerBuilderCase.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization
 {
     using System;

--- a/src/Chr.Avro.Json/Serialization/JsonDateSerializerBuilderCase.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonDateSerializerBuilderCase.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization
 {
     using System;

--- a/src/Chr.Avro.Json/Serialization/JsonDeserializerBuilder.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonDeserializerBuilder.cs
@@ -72,12 +72,12 @@ namespace Chr.Avro.Serialization
             return new Func<IJsonDeserializerBuilder, IJsonDeserializerBuilderCase>[]
             {
                 // logical types:
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 builder => new JsonDateDeserializerBuilderCase(),
 #endif
                 builder => new JsonDecimalDeserializerBuilderCase(),
                 builder => new JsonDurationDeserializerBuilderCase(),
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 builder => new JsonTimeDeserializerBuilderCase(),
 #endif
                 builder => new JsonTimestampDeserializerBuilderCase(),

--- a/src/Chr.Avro.Json/Serialization/JsonSerializerBuilder.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonSerializerBuilder.cs
@@ -68,12 +68,12 @@ namespace Chr.Avro.Serialization
             return new Func<IJsonSerializerBuilder, IJsonSerializerBuilderCase>[]
             {
                 // logical types:
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 builder => new JsonDateSerializerBuilderCase(),
 #endif
                 builder => new JsonDecimalSerializerBuilderCase(),
                 builder => new JsonDurationSerializerBuilderCase(),
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 builder => new JsonTimeSerializerBuilderCase(),
 #endif
                 builder => new JsonTimestampSerializerBuilderCase(),

--- a/src/Chr.Avro.Json/Serialization/JsonTimeDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonTimeDeserializerBuilderCase.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization
 {
     using System;

--- a/src/Chr.Avro.Json/Serialization/JsonTimeSerializerBuilderCase.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonTimeSerializerBuilderCase.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization
 {
     using System;

--- a/src/Chr.Avro/Abstract/DateSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/DateSchemaBuilderCase.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Abstract
 {
     using System;

--- a/src/Chr.Avro/Abstract/RecordSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/RecordSchemaBuilderCase.cs
@@ -9,7 +9,7 @@ namespace Chr.Avro.Abstract
     using System.Runtime.Serialization;
     using System.Text.RegularExpressions;
     using Chr.Avro.Infrastructure;
-    #if !NET6_0_OR_GREATER
+    #if !NET8_0_OR_GREATER
     using NullabilityInfo = Chr.Avro.Infrastructure.NullabilityInfo;
     using NullabilityInfoContext = Chr.Avro.Infrastructure.NullabilityInfoContext;
     using NullabilityState = Chr.Avro.Infrastructure.NullabilityState;

--- a/src/Chr.Avro/Abstract/SchemaBuilder.cs
+++ b/src/Chr.Avro/Abstract/SchemaBuilder.cs
@@ -112,11 +112,11 @@ namespace Chr.Avro.Abstract
                 builder => new ArraySchemaBuilderCase(nullableReferenceTypeBehavior, builder),
 
                 // built-ins:
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 builder => new DateSchemaBuilderCase(temporalBehavior),
 #endif
                 builder => new DurationSchemaBuilderCase(),
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 builder => new TimeSchemaBuilderCase(temporalBehavior),
 #endif
                 builder => new TimestampSchemaBuilderCase(temporalBehavior),

--- a/src/Chr.Avro/Abstract/TimeSchemaBuilderCase.cs
+++ b/src/Chr.Avro/Abstract/TimeSchemaBuilderCase.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Abstract
 {
     using System;

--- a/src/Chr.Avro/Chr.Avro.csproj
+++ b/src/Chr.Avro/Chr.Avro.csproj
@@ -4,7 +4,7 @@
     <Description>Avro schema models</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Chr.Avro/Infrastructure/NullabilityInfo.cs
+++ b/src/Chr.Avro/Infrastructure/NullabilityInfo.cs
@@ -1,4 +1,4 @@
-#if !NET6_0_OR_GREATER
+#if !NET8_0_OR_GREATER
 namespace Chr.Avro.Infrastructure
 {
     using System;

--- a/src/Chr.Avro/Infrastructure/NullabilityInfoContext.cs
+++ b/src/Chr.Avro/Infrastructure/NullabilityInfoContext.cs
@@ -1,4 +1,4 @@
-#if !NET6_0_OR_GREATER
+#if !NET8_0_OR_GREATER
 namespace Chr.Avro.Infrastructure
 {
     using System;

--- a/src/Chr.Avro/Infrastructure/NullabilityState.cs
+++ b/src/Chr.Avro/Infrastructure/NullabilityState.cs
@@ -1,4 +1,4 @@
-#if !NET6_0_OR_GREATER
+#if !NET8_0_OR_GREATER
 namespace Chr.Avro.Infrastructure
 {
     /// <summary>

--- a/src/Chr.Avro/Infrastructure/ReflectionExtensions.cs
+++ b/src/Chr.Avro/Infrastructure/ReflectionExtensions.cs
@@ -4,7 +4,7 @@ namespace Chr.Avro.Infrastructure
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     using System.Runtime.CompilerServices;
 #endif
     using System.Runtime.Serialization;
@@ -264,7 +264,7 @@ namespace Chr.Avro.Infrastructure
         public static T GetUninitializedInstance<T>()
             where T : notnull
         {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             return (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
 #else
             return (T)FormatterServices.GetUninitializedObject(typeof(T));

--- a/src/Chr.Avro/Serialization/ArrayDeserializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/ArrayDeserializerBuilderCase.cs
@@ -33,7 +33,7 @@ namespace Chr.Avro.Serialization
                     .GetMethod("ToArray", Type.EmptyTypes);
 
                 value = Expression.Call(value, toArray);
-#if !NET6_0_OR_GREATER
+#if !NET8_0_OR_GREATER
 
                 // no implicit conversion from T[] to ArraySegment<T> exists on .NET Framework, so
                 // generate a constructor explicitly:

--- a/src/Chr.Avro/Serialization/DateDeserializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/DateDeserializerBuilderCase.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization
 {
     using System;

--- a/src/Chr.Avro/Serialization/DateSerializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/DateSerializerBuilderCase.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization
 {
     using System;

--- a/src/Chr.Avro/Serialization/StringDeserializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/StringDeserializerBuilderCase.cs
@@ -50,7 +50,7 @@ namespace Chr.Avro.Serialization
                         Expression.Constant(DateTimeStyles.RoundtripKind)),
                     target);
             }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             else if (underlying == typeof(DateOnly))
             {
                 var parseDateOnly = typeof(DateOnly)

--- a/src/Chr.Avro/Serialization/StringSerializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/StringSerializerBuilderCase.cs
@@ -27,7 +27,7 @@ namespace Chr.Avro.Serialization
 
                 var convertDateTimeOffset = typeof(DateTimeOffset)
                     .GetMethod(nameof(DateTimeOffset.ToString), new[] { typeof(string), typeof(IFormatProvider) });
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
                 var convertDateOnly = typeof(DateOnly)
                     .GetMethod(nameof(DateOnly.ToString), new[] { typeof(string), typeof(IFormatProvider) });
@@ -78,7 +78,7 @@ namespace Chr.Avro.Serialization
                                 convertDateTimeOffset,
                                 Expression.Constant("O"),
                                 Expression.Constant(CultureInfo.InvariantCulture)))),
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                     Expression.IfThen(
                         Expression.TypeIs(intermediate, typeof(DateOnly)),
                         Expression.Return(
@@ -161,7 +161,7 @@ namespace Chr.Avro.Serialization
                         Expression.Constant("O"),
                         Expression.Constant(CultureInfo.InvariantCulture));
                 }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 else if (value.Type == typeof(DateOnly))
                 {
                     var convertDateOnly = typeof(DateOnly)

--- a/src/Chr.Avro/Serialization/TimeDeserializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/TimeDeserializerBuilderCase.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization
 {
     using System;

--- a/src/Chr.Avro/Serialization/TimeSerializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/TimeSerializerBuilderCase.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization
 {
     using System;

--- a/src/Chr.Avro/Serialization/TimestampDeserializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/TimestampDeserializerBuilderCase.cs
@@ -13,7 +13,7 @@ namespace Chr.Avro.Serialization
         /// <summary>
         /// A <see cref="DateTime" /> representing the Unix epoch (1970-01-01T00:00:00.000Z).
         /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         protected static readonly DateTime Epoch = DateTime.UnixEpoch;
 #else
         protected static readonly DateTime Epoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);

--- a/src/Chr.Avro/Serialization/TimestampSerializerBuilderCase.cs
+++ b/src/Chr.Avro/Serialization/TimestampSerializerBuilderCase.cs
@@ -13,7 +13,7 @@ namespace Chr.Avro.Serialization
         /// <summary>
         /// A <see cref="DateTime" /> representing the Unix epoch (1970-01-01T00:00:00.000Z).
         /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         protected static readonly DateTime Epoch = DateTime.UnixEpoch;
 #else
         protected static readonly DateTime Epoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);

--- a/tests/Chr.Avro.Binary.Tests/DateSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/DateSerializationTests.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization.Tests
 {
     using System;

--- a/tests/Chr.Avro.Binary.Tests/StringSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/StringSerializationTests.cs
@@ -24,7 +24,7 @@ namespace Chr.Avro.Serialization.Tests
             serializerBuilder = new BinarySerializerBuilder();
             stream = new MemoryStream();
         }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         public static IEnumerable<object[]> DateOnlys => new List<object[]>
         {
@@ -66,7 +66,7 @@ namespace Chr.Avro.Serialization.Tests
             new object[] { "wizard" },
             new object[] { "🧙" },
         };
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         public static IEnumerable<object[]> TimeOnlys => new List<object[]>
         {
@@ -91,7 +91,7 @@ namespace Chr.Avro.Serialization.Tests
             new object[] { new Uri("https://host/path") },
             new object[] { new Uri("https://host/path?a=query") },
         };
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         [Theory]
         [MemberData(nameof(DateOnlys))]
@@ -152,7 +152,7 @@ namespace Chr.Avro.Serialization.Tests
 
             Assert.Equal(value.ToString(), deserialize(ref reader));
         }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         [Theory]
         [MemberData(nameof(TimeOnlys))]
@@ -192,7 +192,7 @@ namespace Chr.Avro.Serialization.Tests
 
             Assert.Equal(XmlConvert.ToString(value), deserialize(ref reader));
         }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         [Theory]
         [MemberData(nameof(DateOnlys))]
@@ -409,7 +409,7 @@ namespace Chr.Avro.Serialization.Tests
 
             Assert.Equal(value, deserialize(ref reader));
         }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         [Theory]
         [MemberData(nameof(TimeOnlys))]

--- a/tests/Chr.Avro.Binary.Tests/TimeSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/TimeSerializationTests.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization.Tests
 {
     using System;

--- a/tests/Chr.Avro.Codegen.Tests/CSharpCodeCompiler.cs
+++ b/tests/Chr.Avro.Codegen.Tests/CSharpCodeCompiler.cs
@@ -29,7 +29,7 @@ namespace Chr.Avro.Codegen.Tests
 
             var refPaths = new[]
             {
-#if !NET6_0_OR_GREATER
+#if !NET8_0_OR_GREATER
                 Path.Combine(runtimePath, "netstandard.dll"),
 #endif
                 typeof(object).GetTypeInfo().Assembly.Location, // mscorlib

--- a/tests/Chr.Avro.Json.Tests/DateSerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/DateSerializationTests.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization.Tests
 {
     using System;

--- a/tests/Chr.Avro.Json.Tests/StringSerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/StringSerializationTests.cs
@@ -22,7 +22,7 @@ namespace Chr.Avro.Serialization.Tests
             serializerBuilder = new JsonSerializerBuilder();
             stream = new MemoryStream();
         }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         public static IEnumerable<object[]> DateOnlys => new List<object[]>
         {
@@ -64,7 +64,7 @@ namespace Chr.Avro.Serialization.Tests
             new object[] { "wizard" },
             new object[] { "🧙" },
         };
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         public static IEnumerable<object[]> TimeOnlys => new List<object[]>
         {
@@ -89,7 +89,7 @@ namespace Chr.Avro.Serialization.Tests
             new object[] { new Uri("https://host/path") },
             new object[] { new Uri("https://host/path?a=query") },
         };
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         [Theory]
         [MemberData(nameof(DateOnlys))]
@@ -149,7 +149,7 @@ namespace Chr.Avro.Serialization.Tests
 
             Assert.Equal(value.ToString(), deserialize(ref reader));
         }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         [Theory]
         [MemberData(nameof(TimeOnlys))]
@@ -189,7 +189,7 @@ namespace Chr.Avro.Serialization.Tests
 
             Assert.Equal(XmlConvert.ToString(value), deserialize(ref reader));
         }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         [Theory]
         [MemberData(nameof(DateOnlys))]
@@ -387,7 +387,7 @@ namespace Chr.Avro.Serialization.Tests
 
             Assert.Equal(value, deserialize(ref reader));
         }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         [Theory]
         [MemberData(nameof(TimeOnlys))]

--- a/tests/Chr.Avro.Json.Tests/TimeSerializationTests.cs
+++ b/tests/Chr.Avro.Json.Tests/TimeSerializationTests.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace Chr.Avro.Serialization.Tests
 {
     using System;

--- a/tests/Chr.Avro.Tests/Abstract/SchemaBuilderShould.cs
+++ b/tests/Chr.Avro.Tests/Abstract/SchemaBuilderShould.cs
@@ -545,7 +545,7 @@ namespace Chr.Avro.Tests
             Assert.Equal(typeof(CircularClass).Name, schema.Name);
             Assert.Equal(typeof(CircularClass).Namespace, schema.Namespace);
         }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         [Theory]
         [InlineData(typeof(DateOnly))]
@@ -843,7 +843,7 @@ namespace Chr.Avro.Tests
                 s => Assert.IsType<NullSchema>(s),
                 s => Assert.IsType(inner, s));
         }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         [Theory]
         [InlineData(typeof(TimeOnly))]


### PR DESCRIPTION
This is something I had on my fork because my application primarily works with decimal for its numbers. 
My objective was to reduce the allocations associated with the use of BigInteger to encode the decimal values, but the change also had a positive impact in throuput.


```
| Method   | Job                | Runtime            | Mean     | Error     | StdDev    | Median   | Ratio | RatioSD | Allocated | Alloc Ratio |
|--------- |------------------- |------------------- |---------:|----------:|----------:|---------:|------:|--------:|----------:|------------:|
| Baseline | .NET 8.0           | .NET 8.0           | 1.448 ms | 0.1946 ms | 0.5707 ms | 1.689 ms |  0.35 |    0.14 |      48 B |       0.000 |
| Baseline | .NET Framework 4.8 | .NET Framework 4.8 | 4.142 ms | 0.0903 ms | 0.2647 ms | 4.063 ms |  1.00 |    0.09 | 2727936 B |       1.000 |
```
1. I think this change could also be applied to the non NET6_0_OR_GREATER path, but i decided to keep netstandard2.0 as is.
2. The 48 bytes allocated are due to the allocation of the enumerator for the list. This is solved by #365 

I don't know, if the extra complexity of this change is worth to take, but decided to open the PR anyway, in case you think it is.


Benchmark code:
``` cs
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Jobs;
using Chr.Avro.Abstract;
using Chr.Avro.Serialization;

[SimpleJob(RuntimeMoniker.Net48, baseline: true)]
[SimpleJob(RuntimeMoniker.Net80)]
[MemoryDiagnoser]
public class AvroSerializeListOfObjects {
    private ObjectWithCollection _toSerialize;
    private MemoryStream _memoryStream;
    private Chr.Avro.Serialization.BinaryWriter _writer;
    private BinarySerializer<ObjectWithCollection> _serializer;

    [GlobalSetup]
    public void GlobalSetup() {
        // Large enough to fit the serialized value
        _memoryStream = new MemoryStream(500 * 1024 * 1024);
        _writer = new Chr.Avro.Serialization.BinaryWriter(_memoryStream);
        var rnd = new Random();
        _toSerialize = new ObjectWithCollection() {
            Numbers = Enumerable.Range(0, 10000).Select(i => (decimal)rnd.NextDouble()).ToList(),
        };

        var serializerBuilder = new BinarySerializerBuilder();
        var schemaBuilder = new SchemaBuilder();
        var schema = schemaBuilder.BuildSchema<ObjectWithCollection>();
        _serializer = serializerBuilder.BuildDelegate<ObjectWithCollection>(schema);
    }

    [IterationSetup]
    public void IterationSetup() => _memoryStream.Position = 0;


    [Benchmark]
    public void Baseline() => _serializer(_toSerialize, _writer);
}

public class ObjectWithCollection {
    public List<decimal> Numbers { get; set; }
}
```