### PR TITLE
perf: Allow fields to be skipped when the schema defines an member that is not found on the target type

### DIFF
--- a/src/Chr.Avro.Binary/Serialization/BinaryDeserializerBuilder.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryDeserializerBuilder.cs
@@ -66,6 +66,9 @@ namespace Chr.Avro.Serialization
         {
             return new Func<IBinaryDeserializerBuilder, IBinaryDeserializerBuilderCase>[]
             {
+                // field skipping (must be first):
+                builder => new BinarySkipFieldDeserializerBuilderCase(builder),
+
                 // logical types:
 #if NET6_0_OR_GREATER
                 builder => new BinaryDateDeserializerBuilderCase(),

--- a/src/Chr.Avro.Binary/Serialization/BinaryRecordDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryRecordDeserializerBuilderCase.cs
@@ -144,16 +144,19 @@ namespace Chr.Avro.Serialization
 
                                         if (match == null)
                                         {
-                                            // always deserialize fields to advance the reader:
-                                            expression = DeserializerBuilder.BuildExpression(typeof(object), field.Type, context);
-
                                             // fall back to a dynamic setter if the value supports it:
                                             if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(value.Type))
                                             {
+                                                expression = DeserializerBuilder.BuildExpression(typeof(object), field.Type, context);
                                                 var flags = CSharpBinderFlags.None;
                                                 var infos = new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) };
                                                 var binder = Binder.SetMember(flags, field.Name, value.Type, infos);
                                                 expression = Expression.Dynamic(binder, typeof(void), value, expression);
+                                            }
+                                            else
+                                            {
+                                                // always deserialize fields to advance the reader:
+                                                expression = DeserializerBuilder.BuildExpression(typeof(SkipField), field.Type, context);
                                             }
                                         }
                                         else

--- a/src/Chr.Avro.Binary/Serialization/BinarySkipFieldDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinarySkipFieldDeserializerBuilderCase.cs
@@ -1,0 +1,263 @@
+namespace Chr.Avro.Serialization
+{
+    using System;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using Chr.Avro.Abstract;
+
+    /// <summary>
+    /// Implements a <see cref="BinaryDeserializerBuilder" /> case that skips over binary-encoded
+    /// fields without deserializing them.
+    /// </summary>
+    internal class BinarySkipFieldDeserializerBuilderCase : DeserializerBuilderCase, IBinaryDeserializerBuilderCase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BinarySkipFieldDeserializerBuilderCase" /> class.
+        /// </summary>
+        /// <param name="deserializerBuilder">
+        /// A deserializer builder instance that will be used to build expressions for skipping nested structures.
+        /// </param>
+        public BinarySkipFieldDeserializerBuilderCase(IBinaryDeserializerBuilder deserializerBuilder)
+        {
+            DeserializerBuilder = deserializerBuilder ?? throw new ArgumentNullException(nameof(deserializerBuilder), "Binary deserializer builder cannot be null.");
+        }
+
+        /// <summary>
+        /// Gets the deserializer builder instance that will be used to build expressions for skipping nested structures.
+        /// </summary>
+        public IBinaryDeserializerBuilder DeserializerBuilder { get; }
+
+        /// <summary>
+        /// Builds a <see cref="BinaryDeserializer{T}" /> that skips the field.
+        /// </summary>
+        /// <returns>
+        /// A successful <see cref="BinaryDeserializerBuilderCaseResult" /> if <paramref name="type" />
+        /// is <see cref="SkipField" />; an unsuccessful <see cref="BinaryDeserializerBuilderCaseResult" />
+        /// otherwise.
+        /// </returns>
+        /// <inheritdoc />
+        public virtual BinaryDeserializerBuilderCaseResult BuildExpression(Type type, Schema schema, BinaryDeserializerBuilderContext context)
+        {
+            if (type != typeof(SkipField))
+            {
+                return BinaryDeserializerBuilderCaseResult.FromException(new UnsupportedTypeException(type, $"{nameof(BinarySkipFieldDeserializerBuilderCase)} only supports {nameof(SkipField)}."));
+            }
+
+            try
+            {
+                return BinaryDeserializerBuilderCaseResult.FromExpression(BuildSkipExpression(schema, context));
+            }
+            catch (InvalidOperationException exception)
+            {
+                throw new UnsupportedSchemaException(schema, $"Unable to skip {schema}.", exception);
+            }
+        }
+
+        private Expression BuildSkipExpression(Schema schema, BinaryDeserializerBuilderContext context)
+        {
+            return schema switch
+            {
+                NullSchema => Expression.Empty(),
+                BooleanSchema => SkipBytes(context, 1),
+                IntSchema or LongSchema => ReadInteger(context),
+                FloatSchema => SkipBytes(context, 4),
+                DoubleSchema => SkipBytes(context, 8),
+                BytesSchema => SkipBytes(context, ReadInteger(context)),
+                StringSchema => SkipBytes(context, ReadInteger(context)),
+                FixedSchema fixedSchema => SkipBytes(context, fixedSchema.Size),
+                RecordSchema recordSchema => SkipRecord(context, recordSchema),
+                EnumSchema => ReadInteger(context),
+                ArraySchema arraySchema => SkipArray(context, arraySchema),
+                MapSchema mapSchema => SkipMap(context, mapSchema),
+                UnionSchema unionSchema => SkipUnion(context, unionSchema),
+                _ => throw new InvalidOperationException($"Unknown schema type: {schema.GetType().Name}"),
+            };
+        }
+
+        private Expression ReadInteger(BinaryDeserializerBuilderContext context)
+        {
+            var readInteger = typeof(BinaryReader).GetMethod(nameof(BinaryReader.ReadInteger))!;
+            return Expression.Call(context.Reader, readInteger);
+        }
+
+        private Expression SkipBytes(BinaryDeserializerBuilderContext context, int count)
+        {
+            var readFixedSpan = typeof(BinaryReader).GetMethod(nameof(BinaryReader.ReadFixedSpan))!;
+            return Expression.Call(context.Reader, readFixedSpan, Expression.Constant(count));
+        }
+
+        private Expression SkipBytes(BinaryDeserializerBuilderContext context, Expression lengthExpression)
+        {
+            var readFixedSpan = typeof(BinaryReader).GetMethod(nameof(BinaryReader.ReadFixedSpan))!;
+            return Expression.Call(context.Reader, readFixedSpan, Expression.Convert(lengthExpression, typeof(int)));
+        }
+
+        private Expression SkipRecord(BinaryDeserializerBuilderContext context, RecordSchema recordSchema)
+        {
+            var expressions = recordSchema.Fields
+                .Select(field => DeserializerBuilder.BuildExpression(typeof(SkipField), field.Type, context))
+                .ToList();
+
+            if (expressions.Count == 0)
+            {
+                return Expression.Empty();
+            }
+
+            return Expression.Block(expressions);
+        }
+
+        private Expression SkipArray(BinaryDeserializerBuilderContext context, ArraySchema arraySchema)
+        {
+            var readInteger = typeof(BinaryReader).GetMethod(nameof(BinaryReader.ReadInteger))!;
+
+            var skipItem = DeserializerBuilder.BuildExpression(typeof(SkipField), arraySchema.Item, context);
+
+            var size = Expression.Variable(typeof(long));
+            var index = Expression.Variable(typeof(long));
+            var outer = Expression.Label();
+            var inner = Expression.Label();
+
+            // outer: while (true)
+            // {
+            //     var size = reader.ReadInteger();
+            //
+            //     if (size == 0L) break outer;
+            //
+            //     if (size < 0L)
+            //     {
+            //         size *= -1L;
+            //         reader.ReadInteger();
+            //     }
+            //
+            //     var index = 0L;
+            //
+            //     inner: while (true)
+            //     {
+            //         if (index++ == size) break inner;
+            //         skipItem();
+            //     }
+            // }
+            return Expression.Block(
+                new[] { size, index },
+                Expression.Loop(
+                    Expression.Block(
+                        Expression.Assign(size, Expression.Call(context.Reader, readInteger)),
+                        Expression.IfThen(
+                            Expression.Equal(size, Expression.Constant(0L)),
+                            Expression.Break(outer)),
+                        Expression.IfThen(
+                            Expression.LessThan(size, Expression.Constant(0L)),
+                            Expression.Block(
+                                Expression.MultiplyAssign(size, Expression.Constant(-1L)),
+                                Expression.Call(context.Reader, readInteger))),
+                        Expression.Assign(index, Expression.Constant(0L)),
+                        Expression.Loop(
+                            Expression.Block(
+                                Expression.IfThen(
+                                    Expression.Equal(Expression.PostIncrementAssign(index), size),
+                                    Expression.Break(inner)),
+                                skipItem),
+                            inner)),
+                    outer));
+        }
+
+        private Expression SkipMap(BinaryDeserializerBuilderContext context, MapSchema mapSchema)
+        {
+            var readInteger = typeof(BinaryReader).GetMethod(nameof(BinaryReader.ReadInteger))!;
+
+            var skipKey = DeserializerBuilder.BuildExpression(typeof(SkipField), new StringSchema(), context);
+            var skipValue = DeserializerBuilder.BuildExpression(typeof(SkipField), mapSchema.Value, context);
+
+            var size = Expression.Variable(typeof(long));
+            var index = Expression.Variable(typeof(long));
+            var outer = Expression.Label();
+            var inner = Expression.Label();
+
+            // outer: while (true)
+            // {
+            //     var size = reader.ReadInteger();
+            //
+            //     if (size == 0L) break outer;
+            //
+            //     if (size < 0L)
+            //     {
+            //         size *= -1L;
+            //         reader.ReadInteger();
+            //     }
+            //
+            //     var index = 0L;
+            //
+            //     inner: while (true)
+            //     {
+            //         if (index++ == size) break inner;
+            //         skipKey();
+            //         skipValue();
+            //     }
+            // }
+            return Expression.Block(
+                new[] { size, index },
+                Expression.Loop(
+                    Expression.Block(
+                        Expression.Assign(size, Expression.Call(context.Reader, readInteger)),
+                        Expression.IfThen(
+                            Expression.Equal(size, Expression.Constant(0L)),
+                            Expression.Break(outer)),
+                        Expression.IfThen(
+                            Expression.LessThan(size, Expression.Constant(0L)),
+                            Expression.Block(
+                                Expression.MultiplyAssign(size, Expression.Constant(-1L)),
+                                Expression.Call(context.Reader, readInteger))),
+                        Expression.Assign(index, Expression.Constant(0L)),
+                        Expression.Loop(
+                            Expression.Block(
+                                Expression.IfThen(
+                                    Expression.Equal(Expression.PostIncrementAssign(index), size),
+                                    Expression.Break(inner)),
+                                skipKey,
+                                skipValue),
+                            inner)),
+                    outer));
+        }
+
+        private Expression SkipUnion(BinaryDeserializerBuilderContext context, UnionSchema unionSchema)
+        {
+            var position = typeof(BinaryReader).GetProperty(nameof(BinaryReader.Index))!;
+            var readInteger = typeof(BinaryReader).GetMethod(nameof(BinaryReader.ReadInteger))!;
+            var exceptionConstructor = typeof(InvalidEncodingException)
+                .GetConstructor(new[] { typeof(long), typeof(string), typeof(Exception) })!;
+
+            var cases = unionSchema.Schemas.Select((schema, i) =>
+            {
+                var skipExpression = DeserializerBuilder.BuildExpression(typeof(SkipField), schema, context);
+
+                // Convert expression to void by wrapping in an expression block that discards the result
+                Expression voidExpression;
+                if (skipExpression.Type == typeof(void))
+                {
+                    voidExpression = skipExpression;
+                }
+                else
+                {
+                    voidExpression = Expression.Block(typeof(void), skipExpression);
+                }
+
+                return Expression.SwitchCase(voidExpression, Expression.Constant((long)i));
+            }).ToArray();
+
+            var index = Expression.Variable(typeof(long));
+            return Expression.Block(
+                new[] { index },
+                Expression.Assign(index, Expression.Call(context.Reader, readInteger)),
+                Expression.Switch(
+                    index,
+                    Expression.Throw(
+                        Expression.New(
+                            exceptionConstructor,
+                            Expression.Property(context.Reader, position),
+                            Expression.Constant($"Invalid union index; expected a value in [0-{unionSchema.Schemas.Count}). This may indicate invalid encoding earlier in the stream."),
+                            Expression.Constant(null, typeof(Exception))),
+                        typeof(void)),
+                    cases));
+        }
+    }
+}

--- a/src/Chr.Avro.Json/Serialization/JsonDeserializerBuilder.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonDeserializerBuilder.cs
@@ -13,6 +13,8 @@ namespace Chr.Avro.Serialization
     /// </summary>
     public class JsonDeserializerBuilder : ExpressionBuilder, IJsonDeserializerBuilder
     {
+        private readonly JsonSkipFieldDeserializerBuilderCase skipFieldDeserializerBuilderCase;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonDeserializerBuilder" /> class
         /// configured with the default list of cases.
@@ -44,6 +46,8 @@ namespace Chr.Avro.Serialization
             {
                 cases.Add(builder(this));
             }
+
+            skipFieldDeserializerBuilderCase = new(this);
         }
 
         /// <summary>
@@ -67,9 +71,6 @@ namespace Chr.Avro.Serialization
         {
             return new Func<IJsonDeserializerBuilder, IJsonDeserializerBuilderCase>[]
             {
-                // field skipping (must be first):
-                builder => new JsonSkipFieldDeserializerBuilderCase(builder),
-
                 // logical types:
 #if NET6_0_OR_GREATER
                 builder => new JsonDateDeserializerBuilderCase(),
@@ -147,9 +148,19 @@ namespace Chr.Avro.Serialization
         {
             var exceptions = new List<Exception>();
 
+            // Special case for the skip field case since it must be called before all the others we can't simply put
+            // it in CreateDefaultCaseBuilders, because custom case builders usually are prepended to the default ones
+            var result = skipFieldDeserializerBuilderCase.BuildExpression(type, schema, context);
+            if (result.Expression != null)
+            {
+                return result.Expression;
+            }
+
+            exceptions.AddRange(result.Exceptions);
+
             foreach (var @case in Cases)
             {
-                var result = @case.BuildExpression(type, schema, context);
+                result = @case.BuildExpression(type, schema, context);
 
                 if (result.Expression != null)
                 {

--- a/src/Chr.Avro.Json/Serialization/JsonDeserializerBuilder.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonDeserializerBuilder.cs
@@ -67,6 +67,9 @@ namespace Chr.Avro.Serialization
         {
             return new Func<IJsonDeserializerBuilder, IJsonDeserializerBuilderCase>[]
             {
+                // field skipping (must be first):
+                builder => new JsonSkipFieldDeserializerBuilderCase(builder),
+
                 // logical types:
 #if NET6_0_OR_GREATER
                 builder => new JsonDateDeserializerBuilderCase(),

--- a/src/Chr.Avro.Json/Serialization/JsonDeserializerBuilder.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonDeserializerBuilder.cs
@@ -47,7 +47,7 @@ namespace Chr.Avro.Serialization
                 cases.Add(builder(this));
             }
 
-            skipFieldDeserializerBuilderCase = new(this);
+            skipFieldDeserializerBuilderCase = new();
         }
 
         /// <summary>

--- a/src/Chr.Avro.Json/Serialization/JsonRecordDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonRecordDeserializerBuilderCase.cs
@@ -219,16 +219,19 @@ namespace Chr.Avro.Serialization
 
                                                     if (match == null)
                                                     {
-                                                        // always deserialize fields to advance the reader:
-                                                        expression = DeserializerBuilder.BuildExpression(typeof(object), field.Type, context);
-
                                                         // fall back to a dynamic setter if the value supports it:
                                                         if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(value.Type))
                                                         {
+                                                            expression = DeserializerBuilder.BuildExpression(typeof(object), field.Type, context);
                                                             var flags = CSharpBinderFlags.None;
                                                             var infos = new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) };
                                                             var binder = Binder.SetMember(flags, field.Name, value.Type, infos);
                                                             expression = Expression.Dynamic(binder, typeof(void), value, expression);
+                                                        }
+                                                        else
+                                                        {
+                                                            // always deserialize fields to advance the reader:
+                                                            expression = DeserializerBuilder.BuildExpression(typeof(SkipField), field.Type, context);
                                                         }
                                                     }
                                                     else

--- a/src/Chr.Avro.Json/Serialization/JsonSkipFieldDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonSkipFieldDeserializerBuilderCase.cs
@@ -1,0 +1,181 @@
+namespace Chr.Avro.Serialization
+{
+    using System;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Text.Json;
+    using Chr.Avro.Abstract;
+
+    /// <summary>
+    /// Implements a <see cref="JsonDeserializerBuilder" /> case that skips over JSON-encoded
+    /// fields without deserializing them.
+    /// </summary>
+    internal class JsonSkipFieldDeserializerBuilderCase : DeserializerBuilderCase, IJsonDeserializerBuilderCase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonSkipFieldDeserializerBuilderCase" /> class.
+        /// </summary>
+        /// <param name="deserializerBuilder">
+        /// A deserializer builder instance that will be used to build expressions for skipping nested structures.
+        /// </param>
+        public JsonSkipFieldDeserializerBuilderCase(IJsonDeserializerBuilder deserializerBuilder)
+        {
+            DeserializerBuilder = deserializerBuilder ?? throw new ArgumentNullException(nameof(deserializerBuilder), "JSON deserializer builder cannot be null.");
+        }
+
+        /// <summary>
+        /// Gets the deserializer builder instance that will be used to build expressions for skipping nested structures.
+        /// </summary>
+        public IJsonDeserializerBuilder DeserializerBuilder { get; }
+
+        /// <summary>
+        /// Builds a <see cref="JsonDeserializer{T}" /> that skips the field.
+        /// </summary>
+        /// <returns>
+        /// A successful <see cref="JsonDeserializerBuilderCaseResult" /> if <paramref name="type" />
+        /// is <see cref="SkipField" />; an unsuccessful <see cref="JsonDeserializerBuilderCaseResult" />
+        /// otherwise.
+        /// </returns>
+        /// <inheritdoc />
+        public virtual JsonDeserializerBuilderCaseResult BuildExpression(Type type, Schema schema, JsonDeserializerBuilderContext context)
+        {
+            if (type != typeof(SkipField))
+            {
+                return JsonDeserializerBuilderCaseResult.FromException(new UnsupportedTypeException(type, $"{nameof(JsonSkipFieldDeserializerBuilderCase)} only supports {nameof(SkipField)}."));
+            }
+
+            try
+            {
+                return JsonDeserializerBuilderCaseResult.FromExpression(BuildSkipExpression(schema, context));
+            }
+            catch (InvalidOperationException exception)
+            {
+                throw new UnsupportedSchemaException(schema, $"Unable to skip {schema}.", exception);
+            }
+        }
+
+        private Expression BuildSkipExpression(Schema schema, JsonDeserializerBuilderContext context)
+        {
+            return schema switch
+            {
+                NullSchema => SkipValue(context),
+                BooleanSchema => SkipValue(context),
+                IntSchema or LongSchema => SkipValue(context),
+                FloatSchema => SkipValue(context),
+                DoubleSchema => SkipValue(context),
+                BytesSchema => SkipValue(context),
+                StringSchema => SkipValue(context),
+                FixedSchema => SkipValue(context),
+                RecordSchema recordSchema => SkipRecord(context, recordSchema),
+                EnumSchema => SkipValue(context),
+                ArraySchema arraySchema => SkipArray(context, arraySchema),
+                MapSchema mapSchema => SkipMap(context, mapSchema),
+                UnionSchema unionSchema => SkipUnion(context, unionSchema),
+                _ => throw new InvalidOperationException($"Unknown schema type: {schema.GetType().Name}"),
+            };
+        }
+
+        private Expression SkipValue(JsonDeserializerBuilderContext context)
+        {
+            var skip = typeof(Utf8JsonReader).GetMethod(nameof(Utf8JsonReader.Skip))!;
+            return Expression.Call(context.Reader, skip);
+        }
+
+        private Expression SkipRecord(JsonDeserializerBuilderContext context, RecordSchema recordSchema)
+        {
+            var expressions = recordSchema.Fields
+                .Select(field => DeserializerBuilder.BuildExpression(typeof(SkipField), field.Type, context))
+                .ToList();
+
+            if (expressions.Count == 0)
+            {
+                return Expression.Empty();
+            }
+
+            return Expression.Block(expressions);
+        }
+
+        private Expression SkipArray(JsonDeserializerBuilderContext context, ArraySchema arraySchema)
+        {
+            var read = typeof(Utf8JsonReader).GetMethod(nameof(Utf8JsonReader.Read))!;
+            var getTokenType = typeof(Utf8JsonReader).GetProperty(nameof(Utf8JsonReader.TokenType))!;
+
+            var skipItem = DeserializerBuilder.BuildExpression(typeof(SkipField), arraySchema.Item, context);
+
+            var loopLabel = Expression.Label();
+
+            // while (reader.Read())
+            // {
+            //     if (reader.TokenType == JsonTokenType.EndArray)
+            //         break;
+            //     skipItem();
+            // }
+            return Expression.Loop(
+                Expression.Block(
+                    Expression.IfThen(
+                        Expression.Not(Expression.Call(context.Reader, read)),
+                        Expression.Break(loopLabel)),
+                    Expression.IfThen(
+                        Expression.Equal(
+                            Expression.Property(context.Reader, getTokenType),
+                            Expression.Constant(JsonTokenType.EndArray)),
+                        Expression.Break(loopLabel)),
+                    skipItem),
+                loopLabel);
+        }
+
+        private Expression SkipMap(JsonDeserializerBuilderContext context, MapSchema mapSchema)
+        {
+            var read = typeof(Utf8JsonReader).GetMethod(nameof(Utf8JsonReader.Read))!;
+            var getTokenType = typeof(Utf8JsonReader).GetProperty(nameof(Utf8JsonReader.TokenType))!;
+
+            var skipValue = DeserializerBuilder.BuildExpression(typeof(SkipField), mapSchema.Value, context);
+
+            var loopLabel = Expression.Label();
+
+            // while (reader.Read())
+            // {
+            //     if (reader.TokenType == JsonTokenType.EndObject)
+            //         break;
+            //     reader.Read(); // skip the value (we already read the key)
+            //     skipValue();
+            // }
+            return Expression.Loop(
+                Expression.Block(
+                    Expression.IfThen(
+                        Expression.Not(Expression.Call(context.Reader, read)),
+                        Expression.Break(loopLabel)),
+                    Expression.IfThen(
+                        Expression.Equal(
+                            Expression.Property(context.Reader, getTokenType),
+                            Expression.Constant(JsonTokenType.EndObject)),
+                        Expression.Break(loopLabel)),
+                    Expression.Call(context.Reader, read),
+                    skipValue),
+                loopLabel);
+        }
+
+        private Expression SkipUnion(JsonDeserializerBuilderContext context, UnionSchema unionSchema)
+        {
+            var read = typeof(Utf8JsonReader).GetMethod(nameof(Utf8JsonReader.Read))!;
+            var getTokenType = typeof(Utf8JsonReader).GetProperty(nameof(Utf8JsonReader.TokenType))!;
+
+            // For unions, we need to determine which schema is encoded
+            // In JSON, unions are typically encoded as objects with a single key (the schema name)
+            // or as the value directly if it's nullable
+            var cases = unionSchema.Schemas.Select((schema, i) =>
+                Expression.SwitchCase(
+                    DeserializerBuilder.BuildExpression(typeof(SkipField), schema, context),
+                    Expression.Constant(i)))
+                .ToList();
+
+            if (cases.Count == 0)
+            {
+                return SkipValue(context);
+            }
+
+            // Simple approach: skip the value directly
+            return SkipValue(context);
+        }
+    }
+}

--- a/src/Chr.Avro.Json/Serialization/JsonSkipFieldDeserializerBuilderCase.cs
+++ b/src/Chr.Avro.Json/Serialization/JsonSkipFieldDeserializerBuilderCase.cs
@@ -1,7 +1,6 @@
 namespace Chr.Avro.Serialization
 {
     using System;
-    using System.Linq;
     using System.Linq.Expressions;
     using System.Text.Json;
     using Chr.Avro.Abstract;
@@ -12,22 +11,6 @@ namespace Chr.Avro.Serialization
     /// </summary>
     internal class JsonSkipFieldDeserializerBuilderCase : DeserializerBuilderCase, IJsonDeserializerBuilderCase
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="JsonSkipFieldDeserializerBuilderCase" /> class.
-        /// </summary>
-        /// <param name="deserializerBuilder">
-        /// A deserializer builder instance that will be used to build expressions for skipping nested structures.
-        /// </param>
-        public JsonSkipFieldDeserializerBuilderCase(IJsonDeserializerBuilder deserializerBuilder)
-        {
-            DeserializerBuilder = deserializerBuilder ?? throw new ArgumentNullException(nameof(deserializerBuilder), "JSON deserializer builder cannot be null.");
-        }
-
-        /// <summary>
-        /// Gets the deserializer builder instance that will be used to build expressions for skipping nested structures.
-        /// </summary>
-        public IJsonDeserializerBuilder DeserializerBuilder { get; }
-
         /// <summary>
         /// Builds a <see cref="JsonDeserializer{T}" /> that skips the field.
         /// </summary>
@@ -44,138 +27,10 @@ namespace Chr.Avro.Serialization
                 return JsonDeserializerBuilderCaseResult.FromException(new UnsupportedTypeException(type, $"{nameof(JsonSkipFieldDeserializerBuilderCase)} only supports {nameof(SkipField)}."));
             }
 
-            try
-            {
-                return JsonDeserializerBuilderCaseResult.FromExpression(BuildSkipExpression(schema, context));
-            }
-            catch (InvalidOperationException exception)
-            {
-                throw new UnsupportedSchemaException(schema, $"Unable to skip {schema}.", exception);
-            }
-        }
-
-        private Expression BuildSkipExpression(Schema schema, JsonDeserializerBuilderContext context)
-        {
-            return schema switch
-            {
-                NullSchema => SkipValue(context),
-                BooleanSchema => SkipValue(context),
-                IntSchema or LongSchema => SkipValue(context),
-                FloatSchema => SkipValue(context),
-                DoubleSchema => SkipValue(context),
-                BytesSchema => SkipValue(context),
-                StringSchema => SkipValue(context),
-                FixedSchema => SkipValue(context),
-                RecordSchema recordSchema => SkipRecord(context, recordSchema),
-                EnumSchema => SkipValue(context),
-                ArraySchema arraySchema => SkipArray(context, arraySchema),
-                MapSchema mapSchema => SkipMap(context, mapSchema),
-                UnionSchema unionSchema => SkipUnion(context, unionSchema),
-                _ => throw new InvalidOperationException($"Unknown schema type: {schema.GetType().Name}"),
-            };
-        }
-
-        private Expression SkipValue(JsonDeserializerBuilderContext context)
-        {
+            // Utf8JsonReader.Skip() handles all JSON token types: it advances past simple values,
+            // and recursively skips from StartObject/StartArray to their matching End* token.
             var skip = typeof(Utf8JsonReader).GetMethod(nameof(Utf8JsonReader.Skip))!;
-            return Expression.Call(context.Reader, skip);
-        }
-
-        private Expression SkipRecord(JsonDeserializerBuilderContext context, RecordSchema recordSchema)
-        {
-            var expressions = recordSchema.Fields
-                .Select(field => DeserializerBuilder.BuildExpression(typeof(SkipField), field.Type, context))
-                .ToList();
-
-            if (expressions.Count == 0)
-            {
-                return Expression.Empty();
-            }
-
-            return Expression.Block(expressions);
-        }
-
-        private Expression SkipArray(JsonDeserializerBuilderContext context, ArraySchema arraySchema)
-        {
-            var read = typeof(Utf8JsonReader).GetMethod(nameof(Utf8JsonReader.Read))!;
-            var getTokenType = typeof(Utf8JsonReader).GetProperty(nameof(Utf8JsonReader.TokenType))!;
-
-            var skipItem = DeserializerBuilder.BuildExpression(typeof(SkipField), arraySchema.Item, context);
-
-            var loopLabel = Expression.Label();
-
-            // while (reader.Read())
-            // {
-            //     if (reader.TokenType == JsonTokenType.EndArray)
-            //         break;
-            //     skipItem();
-            // }
-            return Expression.Loop(
-                Expression.Block(
-                    Expression.IfThen(
-                        Expression.Not(Expression.Call(context.Reader, read)),
-                        Expression.Break(loopLabel)),
-                    Expression.IfThen(
-                        Expression.Equal(
-                            Expression.Property(context.Reader, getTokenType),
-                            Expression.Constant(JsonTokenType.EndArray)),
-                        Expression.Break(loopLabel)),
-                    skipItem),
-                loopLabel);
-        }
-
-        private Expression SkipMap(JsonDeserializerBuilderContext context, MapSchema mapSchema)
-        {
-            var read = typeof(Utf8JsonReader).GetMethod(nameof(Utf8JsonReader.Read))!;
-            var getTokenType = typeof(Utf8JsonReader).GetProperty(nameof(Utf8JsonReader.TokenType))!;
-
-            var skipValue = DeserializerBuilder.BuildExpression(typeof(SkipField), mapSchema.Value, context);
-
-            var loopLabel = Expression.Label();
-
-            // while (reader.Read())
-            // {
-            //     if (reader.TokenType == JsonTokenType.EndObject)
-            //         break;
-            //     reader.Read(); // skip the value (we already read the key)
-            //     skipValue();
-            // }
-            return Expression.Loop(
-                Expression.Block(
-                    Expression.IfThen(
-                        Expression.Not(Expression.Call(context.Reader, read)),
-                        Expression.Break(loopLabel)),
-                    Expression.IfThen(
-                        Expression.Equal(
-                            Expression.Property(context.Reader, getTokenType),
-                            Expression.Constant(JsonTokenType.EndObject)),
-                        Expression.Break(loopLabel)),
-                    Expression.Call(context.Reader, read),
-                    skipValue),
-                loopLabel);
-        }
-
-        private Expression SkipUnion(JsonDeserializerBuilderContext context, UnionSchema unionSchema)
-        {
-            var read = typeof(Utf8JsonReader).GetMethod(nameof(Utf8JsonReader.Read))!;
-            var getTokenType = typeof(Utf8JsonReader).GetProperty(nameof(Utf8JsonReader.TokenType))!;
-
-            // For unions, we need to determine which schema is encoded
-            // In JSON, unions are typically encoded as objects with a single key (the schema name)
-            // or as the value directly if it's nullable
-            var cases = unionSchema.Schemas.Select((schema, i) =>
-                Expression.SwitchCase(
-                    DeserializerBuilder.BuildExpression(typeof(SkipField), schema, context),
-                    Expression.Constant(i)))
-                .ToList();
-
-            if (cases.Count == 0)
-            {
-                return SkipValue(context);
-            }
-
-            // Simple approach: skip the value directly
-            return SkipValue(context);
+            return JsonDeserializerBuilderCaseResult.FromExpression(Expression.Call(context.Reader, skip));
         }
     }
 }

--- a/src/Chr.Avro/Serialization/SkipField.cs
+++ b/src/Chr.Avro/Serialization/SkipField.cs
@@ -1,0 +1,4 @@
+namespace Chr.Avro.Serialization
+{
+    internal readonly struct SkipField { }
+}

--- a/tests/Chr.Avro.Binary.Tests/BinarySkipFieldDeserializerBuilderCaseTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/BinarySkipFieldDeserializerBuilderCaseTests.cs
@@ -1,0 +1,523 @@
+namespace Chr.Avro.Serialization.Tests
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using Chr.Avro.Abstract;
+    using Xunit;
+
+    using BinaryReader = Chr.Avro.Serialization.BinaryReader;
+    using BinaryWriter = Chr.Avro.Serialization.BinaryWriter;
+
+    public class BinarySkipFieldDeserializerBuilderCaseTests
+    {
+        private readonly IBinaryDeserializerBuilder deserializerBuilder;
+
+        private readonly IBinarySerializerBuilder serializerBuilder;
+
+        private readonly MemoryStream stream;
+
+        public BinarySkipFieldDeserializerBuilderCaseTests()
+        {
+            deserializerBuilder = new BinaryDeserializerBuilder();
+            serializerBuilder = new BinarySerializerBuilder();
+            stream = new MemoryStream();
+        }
+
+        [Fact]
+        public void Can_skip_int_field()
+        {
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new IntSchema()),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "hello", SkippedField = 12345, KeptField2 = "world" },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("hello", result.KeptField);
+            Assert.Equal("world", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_long_field()
+        {
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new LongSchema()),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, long>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "world", SkippedField = 9876543210, KeptField2 = "test" },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("world", result.KeptField);
+            Assert.Equal("test", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_float_field()
+        {
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new FloatSchema()),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, float>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "pi", SkippedField = 3.14f, KeptField2 = "math" },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("pi", result.KeptField);
+            Assert.Equal("math", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_double_field()
+        {
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new DoubleSchema()),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, double>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "e", SkippedField = 2.71828, KeptField2 = "euler" },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("e", result.KeptField);
+            Assert.Equal("euler", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_boolean_field()
+        {
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new BooleanSchema()),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, bool>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "flag", SkippedField = true, KeptField2 = "value" },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("flag", result.KeptField);
+            Assert.Equal("value", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_bytes_field()
+        {
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new BytesSchema()),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, byte[]>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "data", SkippedField = new byte[] { 0xAA, 0xBB, 0xCC }, KeptField2 = "binary" },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("data", result.KeptField);
+            Assert.Equal("binary", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_string_field()
+        {
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new StringSchema()),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, string>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "kept", SkippedField = "this_should_be_skipped", KeptField2 = "also_kept" },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("kept", result.KeptField);
+            Assert.Equal("also_kept", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_fixed_field()
+        {
+            var fixedSchema = new FixedSchema("FixedData", 4);
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", fixedSchema),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, byte[]>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "fixed", SkippedField = new byte[] { 0x01, 0x02, 0x03, 0x04 }, KeptField2 = "size4" },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("fixed", result.KeptField);
+            Assert.Equal("size4", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_enum_field_with_symbolic_behavior()
+        {
+            var enumSchema = new EnumSchema("CustomEnum", new[] { "A", "B", "C" });
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", enumSchema),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, CustomEnum>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "status", SkippedField = CustomEnum.C, KeptField2 = "enum_type" },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("status", result.KeptField);
+            Assert.Equal("enum_type", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_enum_field_with_integral_behavior()
+        {
+            // Integral behavior: enum is serialized as int
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new IntSchema()),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "status", SkippedField = 1, KeptField2 = "value" },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("status", result.KeptField);
+            Assert.Equal("value", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_enum_field_with_nominal_behavior()
+        {
+            // Nominal behavior: enum is serialized as string
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new StringSchema()),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, string>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "status", SkippedField = "A", KeptField2 = "value" },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("status", result.KeptField);
+            Assert.Equal("value", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_array_field()
+        {
+            var arraySchema = new ArraySchema(new IntSchema());
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", arraySchema),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, int[]>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "array", SkippedField = new[] { 1, 2, 3, 4, 5 }, KeptField2 = "sequence" },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("array", result.KeptField);
+            Assert.Equal("sequence", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_map_field()
+        {
+            var mapSchema = new MapSchema(new IntSchema());
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", mapSchema),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, Dictionary<string, int>>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            var data = new Dictionary<string, int> { { "a", 1 }, { "b", 2 } };
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "map", SkippedField = data, KeptField2 = "dictionary" },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("map", result.KeptField);
+            Assert.Equal("dictionary", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_nested_record_field()
+        {
+            var nestedSchema = new RecordSchema("NestedRecord", new RecordField[]
+            {
+                new("nested_field", new IntSchema()),
+            });
+
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", nestedSchema),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, NestedRecord>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new()
+                    {
+                        KeptField = "outer",
+                        SkippedField = new NestedRecord { NestedField = 999 },
+                        KeptField2 = "nested",
+                    },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("outer", result.KeptField);
+            Assert.Equal("nested", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_union_field()
+        {
+            var unionSchema = new UnionSchema(new Schema[] { new NullSchema(), new StringSchema() });
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", unionSchema),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, string>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "union", SkippedField = "union_value", KeptField2 = "variant" },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("union", result.KeptField);
+            Assert.Equal("variant", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_multiple_fields()
+        {
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new IntSchema()),
+                new("KeptField2", new StringSchema()),
+                new("SkippedField2", new LongSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<MultiFieldRecord>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new()
+                    {
+                        KeptField = "first",
+                        SkippedField = 100,
+                        KeptField2 = "second",
+                        SkippedField2 = 200,
+                    },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("first", result.KeptField);
+            Assert.Equal("second", result.KeptField2);
+        }
+
+        private enum CustomEnum
+        {
+            A,
+            B,
+            C,
+        }
+
+        public class Record<TKept>
+        {
+            public TKept KeptField { get; set; }
+
+            public TKept KeptField2 { get; set; }
+        }
+
+        public class Record<TKept, TSkipped>
+        {
+            public TKept KeptField { get; set; }
+
+            public TSkipped SkippedField { get; set; }
+
+            public TKept KeptField2 { get; set; }
+        }
+
+        public class NestedRecord
+        {
+            public int NestedField { get; set; }
+        }
+
+        public class MultiFieldRecord
+        {
+            public string KeptField { get; set; }
+
+            public int SkippedField { get; set; }
+
+            public string KeptField2 { get; set; }
+
+            public long SkippedField2 { get; set; }
+        }
+    }
+}

--- a/tests/Chr.Avro.Binary.Tests/BinarySkipFieldDeserializerBuilderCaseTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/BinarySkipFieldDeserializerBuilderCaseTests.cs
@@ -383,6 +383,40 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Fact]
+        public void Can_skip_empty_nested_record_field()
+        {
+            var emptySchema = new RecordSchema("EmptyRecord");
+
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", emptySchema),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, EmptyRecord>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new()
+                    {
+                        KeptField = "before",
+                        SkippedField = new EmptyRecord(),
+                        KeptField2 = "after",
+                    },
+                    new(stream));
+            }
+
+            var reader = new BinaryReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("before", result.KeptField);
+            Assert.Equal("after", result.KeptField2);
+        }
+
+        [Fact]
         public void Can_skip_nested_record_field()
         {
             var nestedSchema = new RecordSchema("NestedRecord", new RecordField[]
@@ -503,6 +537,8 @@ namespace Chr.Avro.Serialization.Tests
 
             public TKept KeptField2 { get; set; }
         }
+
+        public class EmptyRecord { }
 
         public class NestedRecord
         {

--- a/tests/Chr.Avro.Json.Tests/JsonSkipFieldDeserializerBuilderCaseTests.cs
+++ b/tests/Chr.Avro.Json.Tests/JsonSkipFieldDeserializerBuilderCaseTests.cs
@@ -1,0 +1,384 @@
+namespace Chr.Avro.Serialization.Tests
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text.Json;
+    using Chr.Avro.Abstract;
+    using Xunit;
+
+    public class JsonSkipFieldDeserializerBuilderCaseTests
+    {
+        private readonly IJsonDeserializerBuilder deserializerBuilder;
+
+        private readonly IJsonSerializerBuilder serializerBuilder;
+
+        private readonly MemoryStream stream;
+
+        public JsonSkipFieldDeserializerBuilderCaseTests()
+        {
+            deserializerBuilder = new JsonDeserializerBuilder();
+            serializerBuilder = new JsonSerializerBuilder();
+            stream = new MemoryStream();
+        }
+
+        [Fact]
+        public void Can_skip_int_field()
+        {
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new IntSchema()),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, int>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "hello", SkippedField = 12345, KeptField2 = "world" },
+                    new(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("hello", result.KeptField);
+            Assert.Equal("world", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_string_field()
+        {
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new StringSchema()),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, string>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "kept", SkippedField = "this_should_be_skipped", KeptField2 = "also_kept" },
+                    new(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("kept", result.KeptField);
+            Assert.Equal("also_kept", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_boolean_field()
+        {
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new BooleanSchema()),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, bool>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "flag", SkippedField = true, KeptField2 = "value" },
+                    new(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("flag", result.KeptField);
+            Assert.Equal("value", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_double_field()
+        {
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new DoubleSchema()),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, double>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "e", SkippedField = 2.71828, KeptField2 = "euler" },
+                    new(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("e", result.KeptField);
+            Assert.Equal("euler", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_array_field()
+        {
+            var arraySchema = new ArraySchema(new IntSchema());
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", arraySchema),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, int[]>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "array", SkippedField = new[] { 1, 2, 3, 4, 5 }, KeptField2 = "sequence" },
+                    new(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("array", result.KeptField);
+            Assert.Equal("sequence", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_map_field()
+        {
+            var mapSchema = new MapSchema(new IntSchema());
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", mapSchema),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, Dictionary<string, int>>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            var data = new Dictionary<string, int> { { "a", 1 }, { "b", 2 } };
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "map", SkippedField = data, KeptField2 = "dictionary" },
+                    new(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("map", result.KeptField);
+            Assert.Equal("dictionary", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_nested_record_field()
+        {
+            var nestedSchema = new RecordSchema("NestedRecord", new RecordField[]
+            {
+                new("nested_field", new IntSchema()),
+            });
+
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", nestedSchema),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, NestedRecord>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new()
+                    {
+                        KeptField = "outer",
+                        SkippedField = new NestedRecord { NestedField = 999 },
+                        KeptField2 = "nested",
+                    },
+                    new(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("outer", result.KeptField);
+            Assert.Equal("nested", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_multiple_fields()
+        {
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new IntSchema()),
+                new("KeptField2", new StringSchema()),
+                new("SkippedField2", new LongSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<MultiFieldRecord>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new()
+                    {
+                        KeptField = "first",
+                        SkippedField = 100,
+                        KeptField2 = "second",
+                        SkippedField2 = 200,
+                    },
+                    new(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("first", result.KeptField);
+            Assert.Equal("second", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_enum_field_with_symbolic_behavior()
+        {
+            var enumSchema = new EnumSchema("CustomEnum", new[] { "A", "B", "C" });
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", enumSchema),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, CustomEnum>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "status", SkippedField = CustomEnum.C, KeptField2 = "enum_type" },
+                    new(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("status", result.KeptField);
+            Assert.Equal("enum_type", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_enum_field_with_integral_behavior()
+        {
+            // Integral behavior: enum is serialized as int
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new IntSchema()),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, CustomEnum>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "status", SkippedField = CustomEnum.C, KeptField2 = "value" },
+                    new(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("status", result.KeptField);
+            Assert.Equal("value", result.KeptField2);
+        }
+
+        [Fact]
+        public void Can_skip_enum_field_with_nominal_behavior()
+        {
+            // Nominal behavior: enum is serialized as string
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", new StringSchema()),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, CustomEnum>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new() { KeptField = "status", SkippedField = CustomEnum.C, KeptField2 = "value" },
+                    new(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("status", result.KeptField);
+            Assert.Equal("value", result.KeptField2);
+        }
+
+        public class Record<TKept>
+        {
+            public TKept KeptField { get; set; }
+
+            public TKept KeptField2 { get; set; }
+        }
+
+        public class Record<TKept, TSkipped>
+        {
+            public TKept KeptField { get; set; }
+
+            public TSkipped SkippedField { get; set; }
+
+            public TKept KeptField2 { get; set; }
+        }
+
+        public class NestedRecord
+        {
+            public int NestedField { get; set; }
+        }
+
+        public class MultiFieldRecord
+        {
+            public string KeptField { get; set; }
+
+            public int SkippedField { get; set; }
+
+            public string KeptField2 { get; set; }
+
+            public long SkippedField2 { get; set; }
+        }
+
+        private enum CustomEnum
+        {
+            A,
+            B,
+            C,
+        }
+    }
+}

--- a/tests/Chr.Avro.Json.Tests/JsonSkipFieldDeserializerBuilderCaseTests.cs
+++ b/tests/Chr.Avro.Json.Tests/JsonSkipFieldDeserializerBuilderCaseTests.cs
@@ -188,6 +188,40 @@ namespace Chr.Avro.Serialization.Tests
         }
 
         [Fact]
+        public void Can_skip_empty_nested_record_field()
+        {
+            var emptySchema = new RecordSchema("EmptyRecord");
+
+            var schema = new RecordSchema("TestRecord", new RecordField[]
+            {
+                new("KeptField", new StringSchema()),
+                new("SkippedField", emptySchema),
+                new("KeptField2", new StringSchema()),
+            });
+
+            var serialize = serializerBuilder.BuildDelegate<Record<string, EmptyRecord>>(schema);
+            var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
+
+            using (stream)
+            {
+                serialize(
+                    new()
+                    {
+                        KeptField = "before",
+                        SkippedField = new EmptyRecord(),
+                        KeptField2 = "after",
+                    },
+                    new(stream));
+            }
+
+            var reader = new Utf8JsonReader(stream.ToArray());
+            var result = deserialize(ref reader);
+
+            Assert.Equal("before", result.KeptField);
+            Assert.Equal("after", result.KeptField2);
+        }
+
+        [Fact]
         public void Can_skip_nested_record_field()
         {
             var nestedSchema = new RecordSchema("NestedRecord", new RecordField[]
@@ -357,6 +391,8 @@ namespace Chr.Avro.Serialization.Tests
 
             public TKept KeptField2 { get; set; }
         }
+
+        public class EmptyRecord { }
 
         public class NestedRecord
         {


### PR DESCRIPTION
Implements the approach suggested in https://github.com/ch-robinson/dotnet-avro/issues/342#issuecomment-3476752517
 to optimize deserialization when the schema contains more fields than the target type.

I couldn’t think of a reasonable way to write tests that ensure the skip-field code path is executed. If you have any suggestions, I’m all ears.

If I’m missing something, please let me know and I’ll address it right away.

Closes #342