### PR TITLE
fix: escape C# reserved keywords in generated identifiers

### DIFF
--- a/src/Chr.Avro.Codegen/Codegen/CSharpCodeGenerator.cs
+++ b/src/Chr.Avro.Codegen/Codegen/CSharpCodeGenerator.cs
@@ -55,13 +55,13 @@ namespace Chr.Avro.Codegen
         /// </throws>
         public virtual ClassDeclarationSyntax GenerateClass(RecordSchema schema)
         {
-            var declaration = SyntaxFactory.ClassDeclaration(schema.Name)
+            var declaration = SyntaxFactory.ClassDeclaration(EscapeIdentifier(schema.Name))
                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
                 .AddMembers(schema.Fields
                     .Select(field =>
                     {
                         var child = SyntaxFactory
-                            .PropertyDeclaration(GetPropertyType(field.Type), field.Name)
+                            .PropertyDeclaration(GetPropertyType(field.Type), EscapeIdentifier(field.Name))
                             .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
                             .AddAccessorListAccessors(
                                 SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
@@ -107,10 +107,10 @@ namespace Chr.Avro.Codegen
         /// </returns>
         public virtual EnumDeclarationSyntax GenerateEnum(EnumSchema schema)
         {
-            var declaration = SyntaxFactory.EnumDeclaration(schema.Name)
+            var declaration = SyntaxFactory.EnumDeclaration(EscapeIdentifier(schema.Name))
                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
                 .AddMembers(schema.Symbols
-                    .Select(symbol => SyntaxFactory.EnumMemberDeclaration(symbol))
+                    .Select(symbol => SyntaxFactory.EnumMemberDeclaration(EscapeIdentifier(symbol)))
                     .ToArray())
                 .AddAttributeLists(GetDescriptionAttribute(schema.Documentation));
 
@@ -185,7 +185,7 @@ namespace Chr.Avro.Codegen
                         SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("Chr.Avro.Serialization")),
                     });
 
-                    var declaration = SyntaxFactory.NamespaceDeclaration(SyntaxFactory.ParseName(commonNamespace))
+                    var declaration = SyntaxFactory.NamespaceDeclaration(SyntaxFactory.ParseName(EscapeDottedName(commonNamespace)))
                         .WithUsings(usings)
                         .AddMembers(commonInterfaces);
 
@@ -210,7 +210,7 @@ namespace Chr.Avro.Codegen
                     // If the group has a namespace, wrap the members in a namespace declaration
                     members = new[]
                     {
-                        SyntaxFactory.NamespaceDeclaration(SyntaxFactory.ParseName(group.Key)).AddMembers(members),
+                        SyntaxFactory.NamespaceDeclaration(SyntaxFactory.ParseName(EscapeDottedName(group.Key))).AddMembers(members),
                     };
                 }
 
@@ -346,7 +346,7 @@ namespace Chr.Avro.Codegen
                     break;
 
                 case EnumSchema e:
-                    type = SyntaxFactory.ParseTypeName($"global::{e.FullName}");
+                    type = SyntaxFactory.ParseTypeName($"global::{EscapeDottedName(e.FullName)}");
                     value = true;
                     break;
 
@@ -373,7 +373,7 @@ namespace Chr.Avro.Codegen
                     break;
 
                 case RecordSchema r:
-                    type = SyntaxFactory.ParseTypeName($"global::{r.FullName}");
+                    type = SyntaxFactory.ParseTypeName($"global::{EscapeDottedName(r.FullName)}");
                     break;
 
                 case StringSchema s:
@@ -434,6 +434,23 @@ namespace Chr.Avro.Codegen
                         .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed)));
 
             return node.WithLeadingTrivia(trivia);
+        }
+
+        private static string EscapeIdentifier(string name)
+        {
+            return SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None
+                ? "@" + name
+                : name;
+        }
+
+        private static string EscapeDottedName(string dottedName)
+        {
+            if (string.IsNullOrEmpty(dottedName) || dottedName.IndexOf('.') < 0)
+            {
+                return EscapeIdentifier(dottedName);
+            }
+
+            return string.Join(".", dottedName.Split('.').Select(EscapeIdentifier));
         }
 
         private static string GetCommonNamespace(IEnumerable<string?> sources)
@@ -531,7 +548,8 @@ namespace Chr.Avro.Codegen
                 Environment.NewLine,
                 interfaceDefinition.RecordSchemaNames.Select(schemaName =>
                 {
-                    return $"                nameof({schemaName}) => typeof({schemaName}),";
+                    var escaped = EscapeDottedName(schemaName);
+                    return $"                nameof({escaped}) => typeof({escaped}),";
                 }));
 
             // Create the class template with non-global namespace references
@@ -704,7 +722,7 @@ namespace Chr.Avro.Codegen
             var interfaceDeclaration = SyntaxFactory.InterfaceDeclaration(name)
                 .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword)))
                 .WithMembers(SyntaxFactory.List<MemberDeclarationSyntax>(commonFields.Select(field =>
-                    SyntaxFactory.PropertyDeclaration(GetPropertyType(field.Type), field.Name)
+                    SyntaxFactory.PropertyDeclaration(GetPropertyType(field.Type), EscapeIdentifier(field.Name))
                         .AddAccessorListAccessors(
                             SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
                                 .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)),

--- a/tests/Chr.Avro.Codegen.Tests/Codegen/CSharpKeywordEscapingTests.cs
+++ b/tests/Chr.Avro.Codegen.Tests/Codegen/CSharpKeywordEscapingTests.cs
@@ -1,0 +1,90 @@
+namespace Chr.Avro.Codegen.Tests.Codegen
+{
+    using System.Linq;
+    using Chr.Avro.Abstract;
+    using Xunit;
+
+    public class CSharpKeywordEscapingTests
+    {
+        [Fact]
+        public void GivenRecordFieldsNamedLikeCSharpKeywords_WhenGeneratingCode_ShouldCompileAndExposeMatchingProperties()
+        {
+            var schema = new RecordSchema("TestEvent", new[]
+            {
+                new RecordField("event", new StringSchema()),
+                new RecordField("do", new BooleanSchema()),
+                new RecordField("class", new IntSchema()),
+            });
+
+            var sourceCode = new CSharpCodeGenerator().WriteCompilationUnit(schema);
+            var compiledTypes = CSharpCodeCompiler.GetTypesDefinedInSourceCode(sourceCode);
+            var generatedType = compiledTypes.Single(t => t.Name == "TestEvent");
+
+            Assert.NotNull(generatedType.GetProperty("event"));
+            Assert.NotNull(generatedType.GetProperty("do"));
+            Assert.NotNull(generatedType.GetProperty("class"));
+        }
+
+        [Fact]
+        public void GivenRecordSchemaNamedLikeCSharpKeyword_WhenGeneratingCode_ShouldCompile()
+        {
+            var schema = new RecordSchema("event", new[]
+            {
+                new RecordField("id", new IntSchema()),
+            });
+
+            var sourceCode = new CSharpCodeGenerator().WriteCompilationUnit(schema);
+            var compiledTypes = CSharpCodeCompiler.GetTypesDefinedInSourceCode(sourceCode);
+
+            Assert.Contains(compiledTypes, t => t.Name == "event");
+        }
+
+        [Fact]
+        public void GivenEnumSymbolsNamedLikeCSharpKeywords_WhenGeneratingCode_ShouldCompileAndExposeMatchingMembers()
+        {
+            var schema = new EnumSchema("Verb", new[] { "do", "class", "namespace" });
+
+            var sourceCode = new CSharpCodeGenerator().WriteCompilationUnit(schema);
+            var compiledTypes = CSharpCodeCompiler.GetTypesDefinedInSourceCode(sourceCode);
+            var generatedType = compiledTypes.Single(t => t.Name == "Verb");
+
+            var memberNames = generatedType.GetEnumNames();
+            Assert.Contains("do", memberNames);
+            Assert.Contains("class", memberNames);
+            Assert.Contains("namespace", memberNames);
+        }
+
+        [Fact]
+        public void GivenSchemaWithNamespaceSegmentNamedLikeCSharpKeyword_WhenGeneratingCode_ShouldCompile()
+        {
+            var schema = new RecordSchema("Payload", new[]
+            {
+                new RecordField("value", new StringSchema()),
+            })
+            {
+                Namespace = "com.example.event",
+            };
+
+            var sourceCode = new CSharpCodeGenerator().WriteCompilationUnit(schema);
+            var compiledTypes = CSharpCodeCompiler.GetTypesDefinedInSourceCode(sourceCode);
+
+            Assert.Contains(compiledTypes, t => t.FullName == "com.example.@event.Payload" || t.FullName == "com.example.event.Payload");
+        }
+
+        [Fact]
+        public void GivenEnumReferencedByRecordField_WhenEnumNameIsCSharpKeyword_ShouldCompile()
+        {
+            var enumSchema = new EnumSchema("class", new[] { "A", "B" });
+            var recordSchema = new RecordSchema("Holder", new[]
+            {
+                new RecordField("category", enumSchema),
+            });
+
+            var sourceCode = new CSharpCodeGenerator().WriteCompilationUnit(recordSchema);
+            var compiledTypes = CSharpCodeCompiler.GetTypesDefinedInSourceCode(sourceCode);
+
+            Assert.Contains(compiledTypes, t => t.Name == "Holder");
+            Assert.Contains(compiledTypes, t => t.Name == "class" && t.IsEnum);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Avro field, schema, enum, and namespace names that happen to equal C# reserved keywords (e.g. `event`, `do`, `class`, `namespace`) were emitted verbatim by `CSharpCodeGenerator`, producing source that does not compile (CS1041/CS1519).
- Adds two small helpers in `CSharpCodeGenerator` — `EscapeIdentifier` (single name) and `EscapeDottedName` (per-segment for namespaces / full names) — using `SyntaxFacts.GetKeywordKind` to decide when to prepend `@`.
- Applied at every Avro-derived identifier site: record class name, record property names, enum type name, enum member names, enum/record type references, namespace declarations (both the common-interface wrapper and per-group), `nameof(...)` / `typeof(...)` in the generated union deserializer builder case template, and interface member names.
- Contextual keywords (`var`, `record`, `yield`, `async`, ...) are left unchanged because they are valid identifiers in C#.

Closes #370

## Test plan

- [x] New xUnit test class `CSharpKeywordEscapingTests` covering:
  - Record with fields named `event`, `do`, `class`
  - Record schema named `event`
  - Enum with symbols `do`, `class`, `namespace`
  - Record with namespace segment `com.example.event`
  - Record referencing an enum named `class`
- [x] All five new tests fail before the fix with the expected C# compiler diagnostics (CS1041 / CS1519) and pass after it.
- [x] All pre-existing Codegen tests still pass (10/10 green on `net8.0`).