### PR TITLE
refactor: Migrate BinaryWriter to IBufferWriter<byte>

### DIFF
--- a/benchmarks/dotnet/Program.cs
+++ b/benchmarks/dotnet/Program.cs
@@ -301,52 +301,46 @@ namespace Chr.Avro.Benchmarks.Chr
 
         public override IEnumerable<(string, TimeSpan)> Run()
         {
-            var stream = new MemoryStream();
-            var writer = new BinaryWriter(stream);
+            var bufferWriter = new System.Buffers.ArrayBufferWriter<byte>();
+            var writer = new BinaryWriter(bufferWriter);
 
             var deserialize = new BinaryDeserializerBuilder().BuildDelegate<T>(Schema);
             var serialize = new BinarySerializerBuilder().BuildDelegate<T>(Schema);
 
-            using (stream)
+            foreach (var value in Values)
             {
-                foreach (var value in Values)
-                {
-                    serialize(value, writer);
-                }
+                serialize(value, writer);
             }
 
             var count = Values.Length;
-            var size = stream.ToArray().Length * Iterations / count;
+            var size = bufferWriter.WrittenCount * Iterations / count;
 
-            stream = new MemoryStream(size);
-            writer = new BinaryWriter(stream);
+            bufferWriter = new System.Buffers.ArrayBufferWriter<byte>(size);
+            writer = new BinaryWriter(bufferWriter);
 
-            using (stream)
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            for (int i = 0; i < Iterations; i++)
             {
-                var stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-                for (int i = 0; i < Iterations; i++)
-                {
-                    serialize(Values[i % count], writer);
-                }
-
-                stopwatch.Stop();
-                yield return ("serialization", stopwatch.Elapsed);
-                stopwatch.Reset();
-
-                var reader = new Serialization.BinaryReader(stream.ToArray());
-
-                stopwatch.Start();
-
-                for (int i = 0; i < Iterations; i++)
-                {
-                    deserialize(ref reader);
-                }
-
-                stopwatch.Stop();
-                yield return ("deserialization", stopwatch.Elapsed);
+                serialize(Values[i % count], writer);
             }
+
+            stopwatch.Stop();
+            yield return ("serialization", stopwatch.Elapsed);
+            stopwatch.Reset();
+
+            var reader = new Serialization.BinaryReader(bufferWriter.WrittenSpan);
+
+            stopwatch.Start();
+
+            for (int i = 0; i < Iterations; i++)
+            {
+                deserialize(ref reader);
+            }
+
+            stopwatch.Stop();
+            yield return ("deserialization", stopwatch.Elapsed);
         }
     }
 }

--- a/src/Chr.Avro.Binary/Chr.Avro.Binary.csproj
+++ b/src/Chr.Avro.Binary/Chr.Avro.Binary.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Buffers" Version="4.5.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Chr.Avro.Binary/Serialization/BinaryWriter.cs
+++ b/src/Chr.Avro.Binary/Serialization/BinaryWriter.cs
@@ -1,16 +1,16 @@
 namespace Chr.Avro.Serialization
 {
     using System;
+    using System.Buffers;
 #if NET6_0_OR_GREATER
     using System.Buffers.Binary;
 #endif
-    using System.IO;
     using System.Text;
 
     /// <summary>
     /// Writes primitive values to binary Avro data.
     /// </summary>
-    public sealed class BinaryWriter : IDisposable
+    public sealed class BinaryWriter
     {
         /// <summary>
         /// The maximum number of characters encoded per chunk when writing strings.
@@ -19,26 +19,17 @@ namespace Chr.Avro.Serialization
         /// </summary>
         internal const int MaxCharChunk = 64;
 
-        private readonly Stream stream;
+        private readonly IBufferWriter<byte> output;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BinaryWriter" /> class.
         /// </summary>
-        /// <param name="stream">
+        /// <param name="output">
         /// The binary Avro destination.
         /// </param>
-        public BinaryWriter(Stream stream)
+        public BinaryWriter(IBufferWriter<byte> output)
         {
-            this.stream = stream;
-        }
-
-        /// <summary>
-        /// Frees any resources used by the writer and flushes the <see cref="Stream" />. The
-        /// <see cref="Stream" /> is not disposed.
-        /// </summary>
-        public void Dispose()
-        {
-            stream.Flush();
+            this.output = output;
         }
 
         /// <summary>
@@ -49,7 +40,9 @@ namespace Chr.Avro.Serialization
         /// </param>
         public void WriteBoolean(bool value)
         {
-            stream.WriteByte(value ? (byte)0x01 : (byte)0x00);
+            var span = output.GetSpan(1);
+            span[0] = value ? (byte)0x01 : (byte)0x00;
+            output.Advance(1);
         }
 
         /// <summary>
@@ -110,7 +103,9 @@ namespace Chr.Avro.Serialization
         /// </param>
         public void WriteFixed(byte[] value)
         {
-            stream.Write(value, 0, value.Length);
+            var span = output.GetSpan(value.Length);
+            new ReadOnlySpan<byte>(value).CopyTo(span);
+            output.Advance(value.Length);
         }
 #if NET6_0_OR_GREATER
 
@@ -118,11 +113,13 @@ namespace Chr.Avro.Serialization
         /// Writes fixed-length binary data to the current position and advances the writer.
         /// </summary>
         /// <param name="value">
-        /// An array of <see cref="byte" />s.
+        /// A span of <see cref="byte" />s.
         /// </param>
         public void WriteFixed(ReadOnlySpan<byte> value)
         {
-            stream.Write(value);
+            var span = output.GetSpan(value.Length);
+            value.CopyTo(span);
+            output.Advance(value.Length);
         }
 #endif
 
@@ -134,12 +131,10 @@ namespace Chr.Avro.Serialization
         /// </param>
         public void WriteInteger(int value)
         {
-#if NET6_0_OR_GREATER
             var index = 0;
 
             // Max 5 bytes for 32-bit varint
             Span<byte> buffer = stackalloc byte[5];
-#endif
 
             var encoded = (uint)((value << 1) ^ (value >> 31));
 
@@ -153,17 +148,13 @@ namespace Chr.Avro.Serialization
                     current |= 0x80U;
                 }
 
-#if NET6_0_OR_GREATER
                 buffer[index++] = (byte)current;
-#else
-                stream.WriteByte((byte)current);
-#endif
             }
             while (encoded != 0U);
 
-#if NET6_0_OR_GREATER
-            stream.Write(buffer.Slice(0, index));
-#endif
+            var dest = output.GetSpan(index);
+            buffer.Slice(0, index).CopyTo(dest);
+            output.Advance(index);
         }
 
         /// <summary>
@@ -174,12 +165,10 @@ namespace Chr.Avro.Serialization
         /// </param>
         public void WriteInteger(long value)
         {
-#if NET6_0_OR_GREATER
             var index = 0;
 
             // Max 10 bytes for 64-bit varint
             Span<byte> buffer = stackalloc byte[10];
-#endif
 
             var encoded = (ulong)((value << 1) ^ (value >> 63));
 
@@ -193,21 +182,17 @@ namespace Chr.Avro.Serialization
                     current |= 0x80UL;
                 }
 
-#if NET6_0_OR_GREATER
                 buffer[index++] = (byte)current;
-#else
-                stream.WriteByte((byte)current);
-#endif
             }
             while (encoded != 0UL);
 
-#if NET6_0_OR_GREATER
-            stream.Write(buffer.Slice(0, index));
-#endif
+            var dest = output.GetSpan(index);
+            buffer.Slice(0, index).CopyTo(dest);
+            output.Advance(index);
         }
 
         /// <summary>
-        /// Writes a double-precision floating point number to the current position and advances
+        /// Writes a single-precision floating point number to the current position and advances
         /// the writer.
         /// </summary>
         /// <param name="value">
@@ -260,7 +245,7 @@ namespace Chr.Avro.Serialization
 
                 var chunk = value.AsSpan(pos, sliceLength);
                 var written = Encoding.UTF8.GetBytes(chunk, buffer);
-                stream.Write(buffer.Slice(0, written));
+                WriteFixed(buffer.Slice(0, written));
                 pos += sliceLength;
             }
 #else

--- a/src/Chr.Avro.Confluent/Confluent/AsyncSchemaRegistrySerializer.cs
+++ b/src/Chr.Avro.Confluent/Confluent/AsyncSchemaRegistrySerializer.cs
@@ -1,8 +1,9 @@
 namespace Chr.Avro.Confluent
 {
     using System;
+    using System.Buffers;
     using System.Collections.Generic;
-    using System.IO;
+    using System.Linq;
     using System.Linq.Expressions;
     using System.Threading.Tasks;
     using Chr.Avro.Representation;
@@ -319,47 +320,45 @@ namespace Chr.Avro.Confluent
             }
 
             var inner = SerializerBuilder.BuildDelegateExpression<T>(schema);
-            var stream = Expression.Parameter(typeof(MemoryStream));
+            var buffer = Expression.Variable(typeof(SimpleBufferWriter));
             var value = inner.Parameters[0];
 
-            var streamConstructor = typeof(MemoryStream)
+            var bufferConstructor = typeof(SimpleBufferWriter)
                 .GetConstructor(Type.EmptyTypes);
 
+            // Use GetConstructors().Single() to avoid type-identity issues with System.Buffers
+            // across assembly contexts (e.g., net462 vs netstandard2.0).
             var writerConstructor = inner.Parameters[1].Type
-                .GetConstructor(new[] { typeof(Stream) });
+                .GetConstructors()
+                .Single();
 
-            var dispose = typeof(IDisposable)
-                .GetMethod(nameof(IDisposable.Dispose), Type.EmptyTypes);
+            var writeHeader = typeof(SimpleBufferWriter)
+                .GetMethod(nameof(SimpleBufferWriter.WriteBytes), new[] { typeof(byte[]), typeof(int), typeof(int) });
 
-            var toArray = typeof(MemoryStream)
-                .GetMethod(nameof(MemoryStream.ToArray), Type.EmptyTypes);
-
-            var write = typeof(Stream)
-                .GetMethod(nameof(Stream.Write), new[] { typeof(byte[]), typeof(int), typeof(int) });
+            var toArray = typeof(SimpleBufferWriter)
+                .GetMethod(nameof(SimpleBufferWriter.ToArray), Type.EmptyTypes);
 
             if (schema is BytesSchema)
             {
-                inner = new WireFormatBytesSerializerRewriter(stream)
+                inner = new WireFormatBytesSerializerRewriter(buffer)
                     .VisitAndConvert(inner, GetType().Name);
             }
 
             var writer = Expression.Block(
-                new[] { stream },
-                Expression.Assign(stream, Expression.New(streamConstructor)),
-                Expression.TryFinally(
-                    Expression.Block(
-                        Expression.Call(
-                            stream,
-                            write,
-                            Expression.Constant(header),
-                            Expression.Constant(0),
-                            Expression.Constant(header.Length)),
-                        Expression.Invoke(
-                            inner,
-                            value,
-                            Expression.New(writerConstructor, stream))),
-                    Expression.Call(stream, dispose)),
-                Expression.Call(stream, toArray));
+                new[] { buffer },
+                Expression.Assign(buffer, Expression.New(bufferConstructor)),
+                Expression.Call(
+                    buffer,
+                    writeHeader,
+                    Expression.Constant(header),
+                    Expression.Constant(0),
+                    Expression.Constant(header.Length)),
+                Expression.Invoke(
+                    inner,
+                    value,
+                    Expression.New(writerConstructor,
+                        Expression.Convert(buffer, writerConstructor.GetParameters()[0].ParameterType))),
+                Expression.Call(buffer, toArray));
 
             return Expression.Lambda<Func<T, byte[]>>(writer, value).Compile();
         }

--- a/src/Chr.Avro.Confluent/Confluent/DelegateSerializer.cs
+++ b/src/Chr.Avro.Confluent/Confluent/DelegateSerializer.cs
@@ -1,7 +1,7 @@
 namespace Chr.Avro.Confluent
 {
     using System;
-    using System.IO;
+    using System.Buffers;
     using Chr.Avro.Serialization;
     using global::Confluent.Kafka;
 
@@ -36,15 +36,15 @@ namespace Chr.Avro.Confluent
         }
 
         /// <summary>
-        /// A function that provides the core deserializer implementation.
+        /// A function that provides the core serializer implementation.
         /// </summary>
         /// <param name="value">
         /// The object to be serialized.
         /// </param>
-        /// <param name="stream">
-        /// A <see cref="Stream" /> to write the serialized data to.
+        /// <param name="output">
+        /// An <see cref="IBufferWriter{T}" /> to write the serialized data to.
         /// </param>
-        public delegate void Implementation(T value, Stream stream);
+        public delegate void Implementation(T value, IBufferWriter<byte> output);
 
         /// <summary>
         /// Gets the ID of the schema that the serializer was built against.
@@ -75,15 +75,11 @@ namespace Chr.Avro.Confluent
                 Array.Reverse(header, 1, 4);
             }
 
-            var stream = new MemoryStream();
+            var buffer = new SimpleBufferWriter();
+            buffer.WriteBytes(header, 0, header.Length);
+            @delegate(data, buffer);
 
-            using (stream)
-            {
-                stream.Write(header, 0, header.Length);
-                @delegate(data, stream);
-            }
-
-            return stream.ToArray();
+            return buffer.ToArray();
         }
     }
 }

--- a/src/Chr.Avro.Confluent/Confluent/SchemaRegistrySerializerBuilder.cs
+++ b/src/Chr.Avro.Confluent/Confluent/SchemaRegistrySerializerBuilder.cs
@@ -2,7 +2,6 @@ namespace Chr.Avro.Confluent
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Linq.Expressions;
     using System.Threading.Tasks;
@@ -259,16 +258,17 @@ namespace Chr.Avro.Confluent
             }
 
             var inner = SerializerBuilder.BuildDelegateExpression<T>(schema);
-            var stream = Expression.Parameter(typeof(Stream));
+            var output = Expression.Parameter(typeof(System.Buffers.IBufferWriter<byte>));
             var value = inner.Parameters[0];
             var writer = inner.Parameters[1];
 
             var writerConstructor = writer.Type
-                .GetConstructor(new[] { stream.Type });
+                .GetConstructors()
+                .Single();
 
             if (schema is Abstract.BytesSchema)
             {
-                inner = new WireFormatBytesSerializerRewriter(stream)
+                inner = new WireFormatBytesSerializerRewriter(output)
                     .VisitAndConvert(inner, GetType().Name);
             }
 
@@ -279,9 +279,10 @@ namespace Chr.Avro.Confluent
                             new[] { writer },
                             Expression.Assign(
                                 writer,
-                                Expression.New(writerConstructor, stream)),
+                                Expression.New(writerConstructor,
+                                    Expression.Convert(output, writerConstructor.GetParameters()[0].ParameterType))),
                             inner.Body),
-                        new[] { value, stream })
+                        new[] { value, output })
                     .Compile(),
                 id,
                 tombstoneBehavior);

--- a/src/Chr.Avro.Confluent/Confluent/SimpleBufferWriter.cs
+++ b/src/Chr.Avro.Confluent/Confluent/SimpleBufferWriter.cs
@@ -1,0 +1,77 @@
+namespace Chr.Avro.Confluent
+{
+    using System;
+    using System.Buffers;
+
+    /// <summary>
+    /// A simple <see cref="IBufferWriter{T}" /> implementation backed by a resizable array.
+    /// </summary>
+    internal sealed class SimpleBufferWriter : IBufferWriter<byte>
+    {
+        private byte[] buffer;
+        private int written;
+
+        public SimpleBufferWriter()
+            : this(256)
+        {
+        }
+
+        public SimpleBufferWriter(int initialCapacity)
+        {
+            buffer = new byte[initialCapacity];
+            written = 0;
+        }
+
+        /// <summary>
+        /// Gets the number of bytes written so far.
+        /// </summary>
+        public int WrittenCount => written;
+
+        public void Advance(int count)
+        {
+            written += count;
+        }
+
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint > 0 ? sizeHint : 1);
+            return new Memory<byte>(buffer, written, buffer.Length - written);
+        }
+
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint > 0 ? sizeHint : 1);
+            return new Span<byte>(buffer, written, buffer.Length - written);
+        }
+
+        /// <summary>
+        /// Returns the written bytes as an array.
+        /// </summary>
+        public byte[] ToArray()
+        {
+            var result = new byte[written];
+            Array.Copy(buffer, 0, result, 0, written);
+            return result;
+        }
+
+        /// <summary>
+        /// Writes bytes directly to the buffer without going through <see cref="IBufferWriter{T}" />.
+        /// Useful for writing a fixed-size header before the main payload.
+        /// </summary>
+        public void WriteBytes(byte[] data, int offset, int count)
+        {
+            EnsureCapacity(count);
+            Array.Copy(data, offset, buffer, written, count);
+            written += count;
+        }
+
+        private void EnsureCapacity(int needed)
+        {
+            if (buffer.Length - written < needed)
+            {
+                var newSize = Math.Max(buffer.Length * 2, written + needed);
+                Array.Resize(ref buffer, newSize);
+            }
+        }
+    }
+}

--- a/src/Chr.Avro.Confluent/Confluent/WireFormatBytesSerializerRewriter.cs
+++ b/src/Chr.Avro.Confluent/Confluent/WireFormatBytesSerializerRewriter.cs
@@ -1,11 +1,10 @@
 namespace Chr.Avro.Confluent
 {
     using System;
+    using System.Buffers;
     using System.Linq.Expressions;
     using Chr.Avro.Abstract;
     using Chr.Avro.Serialization;
-
-    using Stream = System.IO.Stream;
 
     /// <summary>
     /// Rewrites generated serializers for <see cref="BytesSchema" />s to conform to the "raw
@@ -13,19 +12,31 @@ namespace Chr.Avro.Confluent
     /// </summary>
     internal class WireFormatBytesSerializerRewriter : ExpressionVisitor
     {
-        private readonly ParameterExpression stream;
+        private readonly ParameterExpression output;
         private bool isRewriteComplete;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WireFormatBytesSerializerRewriter" />
         /// class.
         /// </summary>
-        /// <param name="stream">
-        /// A <see cref="ParameterExpression" /> representing the stream being serialized to.
+        /// <param name="output">
+        /// A <see cref="ParameterExpression" /> representing the <see cref="IBufferWriter{T}" />
+        /// being serialized to.
         /// </param>
-        public WireFormatBytesSerializerRewriter(ParameterExpression stream)
+        public WireFormatBytesSerializerRewriter(ParameterExpression output)
         {
-            this.stream = stream;
+            this.output = output;
+        }
+
+        /// <summary>
+        /// Writes a byte array directly to an <see cref="IBufferWriter{T}" />.
+        /// Called via expression trees to avoid ref-struct limitations.
+        /// </summary>
+        public static void WriteToBufferWriter(IBufferWriter<byte> output, byte[] data)
+        {
+            var span = output.GetSpan(data.Length);
+            new ReadOnlySpan<byte>(data).CopyTo(span);
+            output.Advance(data.Length);
         }
 
         /// <inheritdoc />
@@ -42,22 +53,20 @@ namespace Chr.Avro.Confluent
         /// <inheritdoc />
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
-            var readBytes = typeof(BinaryWriter)
+            var writeBytes = typeof(BinaryWriter)
                 .GetMethod(nameof(BinaryWriter.WriteBytes), new[] { typeof(byte[]) });
 
-            if (node.Method == readBytes)
+            if (node.Method == writeBytes)
             {
                 isRewriteComplete = true;
 
-                var write = stream.Type
-                    .GetMethod(nameof(Stream.Write), new[] { typeof(byte[]), typeof(int), typeof(int) });
+                var writeToBufferWriter = typeof(WireFormatBytesSerializerRewriter)
+                    .GetMethod(nameof(WriteToBufferWriter), new[] { typeof(IBufferWriter<byte>), typeof(byte[]) });
 
                 return Expression.Call(
-                    stream,
-                    write,
-                    node.Arguments[0],
-                    Expression.Constant(0),
-                    Expression.ArrayLength(node.Arguments[0]));
+                    writeToBufferWriter,
+                    output,
+                    node.Arguments[0]);
             }
 
             return base.VisitMethodCall(node);

--- a/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/ArraySerializationTests.cs
@@ -4,7 +4,6 @@ namespace Chr.Avro.Serialization.Tests
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Collections.ObjectModel;
-    using System.IO;
     using System.Linq;
     using Chr.Avro.Abstract;
     using Xunit;
@@ -18,13 +17,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public ArraySerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         public static IEnumerable<object[]> ArrayData => new List<object[]>
@@ -62,12 +61,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<long[]>(schema);
             var serialize = serializerBuilder.BuildDelegate<long[]>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -81,12 +77,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ArraySegment<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<ArraySegment<long>>(schema);
 
-            using (stream)
-            {
-                serialize(new ArraySegment<long>(value), new BinaryWriter(stream));
-            }
+            serialize(new ArraySegment<long>(value), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -100,12 +93,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<Collection<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<Collection<long>>(schema);
 
-            using (stream)
-            {
-                serialize(new Collection<long>(value), new BinaryWriter(stream));
-            }
+            serialize(new Collection<long>(value), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -119,12 +109,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value.Cast<object>(), deserialize(ref reader));
         }
@@ -138,12 +125,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<HashSet<string>>(schema);
             var serialize = serializerBuilder.BuildDelegate<HashSet<string>>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -157,12 +141,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ICollection<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<ICollection<long>>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -176,12 +157,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<IEnumerable<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<IEnumerable<long>>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -195,12 +173,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<IImmutableList<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<IImmutableList<long>>(schema);
 
-            using (stream)
-            {
-                serialize(value.ToImmutableList(), new BinaryWriter(stream));
-            }
+            serialize(value.ToImmutableList(), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -214,12 +189,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<IImmutableQueue<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<IImmutableQueue<long>>(schema);
 
-            using (stream)
-            {
-                serialize(ImmutableQueue.CreateRange(value), new BinaryWriter(stream));
-            }
+            serialize(ImmutableQueue.CreateRange(value), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -233,12 +205,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<IImmutableSet<string>>(schema);
             var serialize = serializerBuilder.BuildDelegate<IImmutableSet<string>>(schema);
 
-            using (stream)
-            {
-                serialize(value.ToImmutableHashSet(), new BinaryWriter(stream));
-            }
+            serialize(value.ToImmutableHashSet(), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader).OrderBy(v => v));
         }
@@ -252,12 +221,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<IImmutableStack<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<IImmutableStack<long>>(schema);
 
-            using (stream)
-            {
-                serialize(ImmutableStack.CreateRange(value), new BinaryWriter(stream));
-            }
+            serialize(ImmutableStack.CreateRange(value), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -271,12 +237,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<IList<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<IList<long>>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -290,12 +253,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<IReadOnlyCollection<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<IReadOnlyCollection<long>>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -309,12 +269,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<IReadOnlyList<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<IReadOnlyList<long>>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -328,12 +285,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ISet<string>>(schema);
             var serialize = serializerBuilder.BuildDelegate<ISet<string>>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader).OrderBy(v => v));
         }
@@ -347,12 +301,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ImmutableArray<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<ImmutableArray<long>>(schema);
 
-            using (stream)
-            {
-                serialize(value.ToImmutableArray(), new BinaryWriter(stream));
-            }
+            serialize(value.ToImmutableArray(), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -366,12 +317,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ImmutableHashSet<string>>(schema);
             var serialize = serializerBuilder.BuildDelegate<ImmutableHashSet<string>>(schema);
 
-            using (stream)
-            {
-                serialize(value.ToImmutableHashSet(), new BinaryWriter(stream));
-            }
+            serialize(value.ToImmutableHashSet(), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader).OrderBy(v => v));
         }
@@ -385,12 +333,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ImmutableList<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<ImmutableList<long>>(schema);
 
-            using (stream)
-            {
-                serialize(value.ToImmutableList(), new BinaryWriter(stream));
-            }
+            serialize(value.ToImmutableList(), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -404,12 +349,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ImmutableQueue<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<ImmutableQueue<long>>(schema);
 
-            using (stream)
-            {
-                serialize(ImmutableQueue.CreateRange(value), new BinaryWriter(stream));
-            }
+            serialize(ImmutableQueue.CreateRange(value), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -423,12 +365,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ImmutableSortedSet<string>>(schema);
             var serialize = serializerBuilder.BuildDelegate<ImmutableSortedSet<string>>(schema);
 
-            using (stream)
-            {
-                serialize(value.ToImmutableSortedSet(), new BinaryWriter(stream));
-            }
+            serialize(value.ToImmutableSortedSet(), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -442,12 +381,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ImmutableStack<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<ImmutableStack<long>>(schema);
 
-            using (stream)
-            {
-                serialize(ImmutableStack.CreateRange(value), new BinaryWriter(stream));
-            }
+            serialize(ImmutableStack.CreateRange(value), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -461,12 +397,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<string[][]>(schema);
             var serialize = serializerBuilder.BuildDelegate<string[][]>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -480,12 +413,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<LinkedList<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<LinkedList<long>>(schema);
 
-            using (stream)
-            {
-                serialize(new LinkedList<long>(value), new BinaryWriter(stream));
-            }
+            serialize(new LinkedList<long>(value), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -499,12 +429,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<List<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<List<long>>(schema);
 
-            using (stream)
-            {
-                serialize(value.ToList(), new BinaryWriter(stream));
-            }
+            serialize(value.ToList(), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -518,12 +445,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ObservableCollection<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<ObservableCollection<long>>(schema);
 
-            using (stream)
-            {
-                serialize(new ObservableCollection<long>(value), new BinaryWriter(stream));
-            }
+            serialize(new ObservableCollection<long>(value), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -537,12 +461,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<Queue<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<Queue<long>>(schema);
 
-            using (stream)
-            {
-                serialize(new Queue<long>(value), new BinaryWriter(stream));
-            }
+            serialize(new Queue<long>(value), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -556,12 +477,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ReadOnlyCollection<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<ReadOnlyCollection<long>>(schema);
 
-            using (stream)
-            {
-                serialize(new ReadOnlyCollection<long>(value), new BinaryWriter(stream));
-            }
+            serialize(new ReadOnlyCollection<long>(value), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -575,12 +493,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ReadOnlyObservableCollection<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<ReadOnlyObservableCollection<long>>(schema);
 
-            using (stream)
-            {
-                serialize(new ReadOnlyObservableCollection<long>(new ObservableCollection<long>(value)), new BinaryWriter(stream));
-            }
+            serialize(new ReadOnlyObservableCollection<long>(new ObservableCollection<long>(value)), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -594,12 +509,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<SortedSet<string>>(schema);
             var serialize = serializerBuilder.BuildDelegate<SortedSet<string>>(schema);
 
-            using (stream)
-            {
-                serialize(new SortedSet<string>(value), new BinaryWriter(stream));
-            }
+            serialize(new SortedSet<string>(value), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -613,12 +525,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<Stack<long>>(schema);
             var serialize = serializerBuilder.BuildDelegate<Stack<long>>(schema);
 
-            using (stream)
-            {
-                serialize(new Stack<long>(value), new BinaryWriter(stream));
-            }
+            serialize(new Stack<long>(value), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }

--- a/tests/Chr.Avro.Binary.Tests/BinarySkipFieldDeserializerBuilderCaseTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/BinarySkipFieldDeserializerBuilderCaseTests.cs
@@ -1,7 +1,6 @@
 namespace Chr.Avro.Serialization.Tests
 {
     using System.Collections.Generic;
-    using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
 
@@ -14,13 +13,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public BinarySkipFieldDeserializerBuilderCaseTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         [Fact]
@@ -36,14 +35,11 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<Record<string, int>>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new() { KeptField = "hello", SkippedField = 12345, KeptField2 = "world" },
-                    new(stream));
-            }
+            serialize(
+                new() { KeptField = "hello", SkippedField = 12345, KeptField2 = "world" },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("hello", result.KeptField);
@@ -63,14 +59,11 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<Record<string, long>>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new() { KeptField = "world", SkippedField = 9876543210, KeptField2 = "test" },
-                    new(stream));
-            }
+            serialize(
+                new() { KeptField = "world", SkippedField = 9876543210, KeptField2 = "test" },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("world", result.KeptField);
@@ -90,14 +83,11 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<Record<string, float>>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new() { KeptField = "pi", SkippedField = 3.14f, KeptField2 = "math" },
-                    new(stream));
-            }
+            serialize(
+                new() { KeptField = "pi", SkippedField = 3.14f, KeptField2 = "math" },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("pi", result.KeptField);
@@ -117,14 +107,11 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<Record<string, double>>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new() { KeptField = "e", SkippedField = 2.71828, KeptField2 = "euler" },
-                    new(stream));
-            }
+            serialize(
+                new() { KeptField = "e", SkippedField = 2.71828, KeptField2 = "euler" },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("e", result.KeptField);
@@ -144,14 +131,11 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<Record<string, bool>>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new() { KeptField = "flag", SkippedField = true, KeptField2 = "value" },
-                    new(stream));
-            }
+            serialize(
+                new() { KeptField = "flag", SkippedField = true, KeptField2 = "value" },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("flag", result.KeptField);
@@ -171,14 +155,11 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<Record<string, byte[]>>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new() { KeptField = "data", SkippedField = new byte[] { 0xAA, 0xBB, 0xCC }, KeptField2 = "binary" },
-                    new(stream));
-            }
+            serialize(
+                new() { KeptField = "data", SkippedField = new byte[] { 0xAA, 0xBB, 0xCC }, KeptField2 = "binary" },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("data", result.KeptField);
@@ -198,14 +179,11 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<Record<string, string>>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new() { KeptField = "kept", SkippedField = "this_should_be_skipped", KeptField2 = "also_kept" },
-                    new(stream));
-            }
+            serialize(
+                new() { KeptField = "kept", SkippedField = "this_should_be_skipped", KeptField2 = "also_kept" },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("kept", result.KeptField);
@@ -226,14 +204,11 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<Record<string, byte[]>>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new() { KeptField = "fixed", SkippedField = new byte[] { 0x01, 0x02, 0x03, 0x04 }, KeptField2 = "size4" },
-                    new(stream));
-            }
+            serialize(
+                new() { KeptField = "fixed", SkippedField = new byte[] { 0x01, 0x02, 0x03, 0x04 }, KeptField2 = "size4" },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("fixed", result.KeptField);
@@ -254,14 +229,11 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<Record<string, CustomEnum>>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new() { KeptField = "status", SkippedField = CustomEnum.C, KeptField2 = "enum_type" },
-                    new(stream));
-            }
+            serialize(
+                new() { KeptField = "status", SkippedField = CustomEnum.C, KeptField2 = "enum_type" },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("status", result.KeptField);
@@ -282,14 +254,11 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<Record<string, int>>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new() { KeptField = "status", SkippedField = 1, KeptField2 = "value" },
-                    new(stream));
-            }
+            serialize(
+                new() { KeptField = "status", SkippedField = 1, KeptField2 = "value" },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("status", result.KeptField);
@@ -310,14 +279,11 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<Record<string, string>>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new() { KeptField = "status", SkippedField = "A", KeptField2 = "value" },
-                    new(stream));
-            }
+            serialize(
+                new() { KeptField = "status", SkippedField = "A", KeptField2 = "value" },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("status", result.KeptField);
@@ -338,14 +304,11 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<Record<string, int[]>>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new() { KeptField = "array", SkippedField = new[] { 1, 2, 3, 4, 5 }, KeptField2 = "sequence" },
-                    new(stream));
-            }
+            serialize(
+                new() { KeptField = "array", SkippedField = new[] { 1, 2, 3, 4, 5 }, KeptField2 = "sequence" },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("array", result.KeptField);
@@ -368,14 +331,11 @@ namespace Chr.Avro.Serialization.Tests
 
             var data = new Dictionary<string, int> { { "a", 1 }, { "b", 2 } };
 
-            using (stream)
-            {
-                serialize(
-                    new() { KeptField = "map", SkippedField = data, KeptField2 = "dictionary" },
-                    new(stream));
-            }
+            serialize(
+                new() { KeptField = "map", SkippedField = data, KeptField2 = "dictionary" },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("map", result.KeptField);
@@ -397,19 +357,16 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<Record<string, EmptyRecord>>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new()
-                    {
-                        KeptField = "before",
-                        SkippedField = new EmptyRecord(),
-                        KeptField2 = "after",
-                    },
-                    new(stream));
-            }
+            serialize(
+                new()
+                {
+                    KeptField = "before",
+                    SkippedField = new EmptyRecord(),
+                    KeptField2 = "after",
+                },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("before", result.KeptField);
@@ -434,19 +391,16 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<Record<string, NestedRecord>>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new()
-                    {
-                        KeptField = "outer",
-                        SkippedField = new NestedRecord { NestedField = 999 },
-                        KeptField2 = "nested",
-                    },
-                    new(stream));
-            }
+            serialize(
+                new()
+                {
+                    KeptField = "outer",
+                    SkippedField = new NestedRecord { NestedField = 999 },
+                    KeptField2 = "nested",
+                },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("outer", result.KeptField);
@@ -467,14 +421,11 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<Record<string, string>>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new() { KeptField = "union", SkippedField = "union_value", KeptField2 = "variant" },
-                    new(stream));
-            }
+            serialize(
+                new() { KeptField = "union", SkippedField = "union_value", KeptField2 = "variant" },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("union", result.KeptField);
@@ -495,20 +446,17 @@ namespace Chr.Avro.Serialization.Tests
             var serialize = serializerBuilder.BuildDelegate<MultiFieldRecord>(schema);
             var deserialize = deserializerBuilder.BuildDelegate<Record<string>>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new()
-                    {
-                        KeptField = "first",
-                        SkippedField = 100,
-                        KeptField2 = "second",
-                        SkippedField2 = 200,
-                    },
-                    new(stream));
-            }
+            serialize(
+                new()
+                {
+                    KeptField = "first",
+                    SkippedField = 100,
+                    KeptField2 = "second",
+                    SkippedField2 = 200,
+                },
+                new(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var result = deserialize(ref reader);
 
             Assert.Equal("first", result.KeptField);

--- a/tests/Chr.Avro.Binary.Tests/BinaryWriterTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/BinaryWriterTests.cs
@@ -2,7 +2,6 @@ namespace Chr.Avro.Serialization.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Text;
     using Xunit;
@@ -11,14 +10,14 @@ namespace Chr.Avro.Serialization.Tests
 
     public class BinaryWriterTests
     {
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         private readonly BinaryWriter writer;
 
         public BinaryWriterTests()
         {
-            stream = new MemoryStream();
-            writer = new BinaryWriter(stream);
+            bufferWriter = new TestBufferWriter();
+            writer = new BinaryWriter(bufferWriter);
         }
 
         public static IEnumerable<object[]> BlockEncodings => new List<object[]>
@@ -152,36 +151,27 @@ namespace Chr.Avro.Serialization.Tests
         [MemberData(nameof(BooleanEncodings))]
         public void WritesBooleans(bool value, byte[] encoding)
         {
-            using (stream)
-            {
-                writer.WriteBoolean(value);
-            }
+            writer.WriteBoolean(value);
 
-            Assert.Equal(encoding, stream.ToArray());
+            Assert.Equal(encoding, bufferWriter.WrittenSpan.ToArray());
         }
 
         [Theory]
         [MemberData(nameof(DoubleEncodings))]
         public void WritesDoubles(double value, byte[] encoding)
         {
-            using (stream)
-            {
-                writer.WriteDouble(value);
-            }
+            writer.WriteDouble(value);
 
-            Assert.Equal(encoding, stream.ToArray());
+            Assert.Equal(encoding, bufferWriter.WrittenSpan.ToArray());
         }
 
         [Theory]
         [MemberData(nameof(Int32Encodings))]
         public void WritesInt32s(int value, byte[] encoding)
         {
-            using (stream)
-            {
-                writer.WriteInteger(value);
-            }
+            writer.WriteInteger(value);
 
-            Assert.Equal(encoding, stream.ToArray());
+            Assert.Equal(encoding, bufferWriter.WrittenSpan.ToArray());
         }
 
         [Theory]
@@ -189,36 +179,27 @@ namespace Chr.Avro.Serialization.Tests
         [MemberData(nameof(Int64Encodings))]
         public void WritesInt64s(long value, byte[] encoding)
         {
-            using (stream)
-            {
-                writer.WriteInteger(value);
-            }
+            writer.WriteInteger(value);
 
-            Assert.Equal(encoding, stream.ToArray());
+            Assert.Equal(encoding, bufferWriter.WrittenSpan.ToArray());
         }
 
         [Theory]
         [MemberData(nameof(SingleEncodings))]
         public void WritesSingles(float value, byte[] encoding)
         {
-            using (stream)
-            {
-                writer.WriteSingle(value);
-            }
+            writer.WriteSingle(value);
 
-            Assert.Equal(encoding, stream.ToArray());
+            Assert.Equal(encoding, bufferWriter.WrittenSpan.ToArray());
         }
 
         [Theory]
         [MemberData(nameof(StringEncodings))]
         public void WritesStrings(string value, byte[] encoding)
         {
-            using (stream)
-            {
-                writer.WriteString(value);
-            }
+            writer.WriteString(value);
 
-            Assert.Equal(encoding, stream.ToArray());
+            Assert.Equal(encoding, bufferWriter.WrittenSpan.ToArray());
         }
     }
 }

--- a/tests/Chr.Avro.Binary.Tests/BooleanSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/BooleanSerializationTests.cs
@@ -1,6 +1,5 @@
 namespace Chr.Avro.Serialization.Tests
 {
-    using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
 
@@ -13,13 +12,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public BooleanSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         [Theory]
@@ -32,12 +31,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<bool>(schema);
             var serialize = serializerBuilder.BuildDelegate<bool>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -52,12 +48,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }

--- a/tests/Chr.Avro.Binary.Tests/BytesSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/BytesSerializationTests.cs
@@ -2,7 +2,6 @@ namespace Chr.Avro.Serialization.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
 
@@ -15,13 +14,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public BytesSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         public static IEnumerable<object[]> ByteArrays => new List<object[]>
@@ -46,12 +45,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<byte[]>(schema);
             var serialize = serializerBuilder.BuildDelegate<byte[]>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -65,12 +61,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -84,12 +77,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<Guid>(schema);
             var serialize = serializerBuilder.BuildDelegate<Guid>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -103,12 +93,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<Guid?>(schema);
             var serialize = serializerBuilder.BuildDelegate<Guid>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }

--- a/tests/Chr.Avro.Binary.Tests/DateSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/DateSerializationTests.cs
@@ -3,7 +3,6 @@ namespace Chr.Avro.Serialization.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
 
@@ -16,13 +15,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public DateSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         public static IEnumerable<object[]> DateEncodings => new List<object[]>
@@ -56,12 +55,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateOnly>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateOnly>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);

--- a/tests/Chr.Avro.Binary.Tests/DecimalSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/DecimalSerializationTests.cs
@@ -1,7 +1,6 @@
 namespace Chr.Avro.Serialization.Tests
 {
     using System.Collections.Generic;
-    using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
 
@@ -14,13 +13,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public DecimalSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         public static IEnumerable<object[]> BoundaryDecimals => new List<object[]>
@@ -57,12 +56,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<decimal>(schema);
             var serialize = serializerBuilder.BuildDelegate<decimal>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -79,12 +75,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -101,12 +94,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<decimal>(schema);
             var serialize = serializerBuilder.BuildDelegate<decimal>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);

--- a/tests/Chr.Avro.Binary.Tests/DoubleSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/DoubleSerializationTests.cs
@@ -1,7 +1,6 @@
 namespace Chr.Avro.Serialization.Tests
 {
     using System.Collections.Generic;
-    using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
 
@@ -14,13 +13,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public DoubleSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         public static IEnumerable<object[]> Doubles => new List<object[]>
@@ -49,12 +48,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<double>(schema);
             var serialize = serializerBuilder.BuildDelegate<double>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -69,12 +65,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal((double)value, deserialize(ref reader));
         }
@@ -88,12 +81,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<double>(schema);
             var serialize = serializerBuilder.BuildDelegate<int>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }

--- a/tests/Chr.Avro.Binary.Tests/DurationSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/DurationSerializationTests.cs
@@ -2,7 +2,6 @@ namespace Chr.Avro.Serialization.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
 
@@ -15,13 +14,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public DurationSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         public static IEnumerable<object[]> TimeSpanEncodings => new List<object[]>
@@ -79,10 +78,7 @@ namespace Chr.Avro.Serialization.Tests
 
             var serialize = serializerBuilder.BuildDelegate<TimeSpan>(schema);
 
-            using (stream)
-            {
-                Assert.Throws<OverflowException>(() => serialize(TimeSpan.FromMilliseconds(-1), new BinaryWriter(stream)));
-            }
+            Assert.Throws<OverflowException>(() => serialize(TimeSpan.FromMilliseconds(-1), new BinaryWriter(bufferWriter)));
         }
 
         [Theory]
@@ -97,12 +93,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<TimeSpan>(schema);
             var serialize = serializerBuilder.BuildDelegate<TimeSpan>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);
@@ -121,12 +114,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<TimeSpan?>(schema);
             var serialize = serializerBuilder.BuildDelegate<TimeSpan>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);

--- a/tests/Chr.Avro.Binary.Tests/EnumSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/EnumSerializationTests.cs
@@ -1,7 +1,6 @@
 namespace Chr.Avro.Serialization.Tests
 {
     using System;
-    using System.IO;
     using Chr.Avro.Abstract;
     using Chr.Avro.Fixtures;
     using Xunit;
@@ -15,13 +14,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public EnumSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         [Fact]
@@ -35,12 +34,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ImplicitEnum>(schema);
             var serialize = serializerBuilder.BuildDelegate<string>(schema);
 
-            using (stream)
-            {
-                serialize("FIFTH", new BinaryWriter(stream));
-            }
+            serialize("FIFTH", new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(ImplicitEnum.None, deserialize(ref reader));
         }
@@ -58,12 +54,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ImplicitEnum>(schema);
             var serialize = serializerBuilder.BuildDelegate<ImplicitEnum>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -80,10 +73,7 @@ namespace Chr.Avro.Serialization.Tests
             schema = new EnumSchema("ordinal", new[] { "NONE", "FIRST", "SECOND", "THIRD", "FOURTH" });
             var serialize = serializerBuilder.BuildDelegate<ImplicitEnum>(schema);
 
-            using (stream)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>(() => serialize((ImplicitEnum)(-1), new BinaryWriter(stream)));
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(() => serialize((ImplicitEnum)(-1), new BinaryWriter(bufferWriter)));
         }
 
         [Fact]
@@ -92,10 +82,7 @@ namespace Chr.Avro.Serialization.Tests
             var schema = new EnumSchema("ordinal", new[] { "NONE", "FIRST" });
             var serialize = serializerBuilder.BuildDelegate<string>(schema);
 
-            using (stream)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>(() => serialize("SECOND", new BinaryWriter(stream)));
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(() => serialize("SECOND", new BinaryWriter(bufferWriter)));
         }
 
         [Theory]
@@ -111,12 +98,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ImplicitEnum?>(schema);
             var serialize = serializerBuilder.BuildDelegate<ImplicitEnum>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -134,12 +118,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<string>(schema);
             var serialize = serializerBuilder.BuildDelegate<string>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }

--- a/tests/Chr.Avro.Binary.Tests/FixedSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/FixedSerializationTests.cs
@@ -2,7 +2,6 @@ namespace Chr.Avro.Serialization.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
 
@@ -15,13 +14,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public FixedSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         public static IEnumerable<object[]> ByteArrays => new List<object[]>
@@ -46,12 +45,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<byte[]>(schema);
             var serialize = serializerBuilder.BuildDelegate<byte[]>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -65,12 +61,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -84,12 +77,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<Guid>(schema);
             var serialize = serializerBuilder.BuildDelegate<Guid>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -103,12 +93,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<Guid?>(schema);
             var serialize = serializerBuilder.BuildDelegate<Guid>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }

--- a/tests/Chr.Avro.Binary.Tests/FloatSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/FloatSerializationTests.cs
@@ -1,7 +1,6 @@
 namespace Chr.Avro.Serialization.Tests
 {
     using System.Collections.Generic;
-    using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
 
@@ -14,13 +13,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public FloatSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         public static IEnumerable<object[]> Integers => new List<object[]>
@@ -50,12 +49,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal((float)value, deserialize(ref reader));
         }
@@ -69,12 +65,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<float>(schema);
             var serialize = serializerBuilder.BuildDelegate<int>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -88,12 +81,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<float>(schema);
             var serialize = serializerBuilder.BuildDelegate<float>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }

--- a/tests/Chr.Avro.Binary.Tests/GuidSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/GuidSerializationTests.cs
@@ -2,7 +2,6 @@ namespace Chr.Avro.Serialization.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
 
@@ -15,13 +14,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public GuidSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         public static IEnumerable<object[]> Guids => new List<object[]>
@@ -42,12 +41,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value.ToString(), deserialize(ref reader));
         }
@@ -64,12 +60,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<Guid>(schema);
             var serialize = serializerBuilder.BuildDelegate<Guid>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -86,12 +79,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<Guid?>(schema);
             var serialize = serializerBuilder.BuildDelegate<Guid>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }

--- a/tests/Chr.Avro.Binary.Tests/IntegerSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/IntegerSerializationTests.cs
@@ -2,7 +2,6 @@ namespace Chr.Avro.Serialization.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
     using Xunit.Sdk;
@@ -16,13 +15,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public IntegerSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         public static IEnumerable<object[]> Bytes => new List<object[]>
@@ -106,12 +105,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<byte>(schema);
             var serialize = serializerBuilder.BuildDelegate<byte>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -133,12 +129,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal((long)value, deserialize(ref reader));
         }
@@ -152,12 +145,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateTimeKind>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateTimeKind>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -171,12 +161,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<short>(schema);
             var serialize = serializerBuilder.BuildDelegate<short>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -190,12 +177,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<int>(schema);
             var serialize = serializerBuilder.BuildDelegate<int>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -209,12 +193,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<long>(schema);
             var serialize = serializerBuilder.BuildDelegate<long>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -228,12 +209,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<IntPtr>(schema);
             var serialize = serializerBuilder.BuildDelegate<IntPtr>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -246,14 +224,11 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<int>(schema);
             var serialize = serializerBuilder.BuildDelegate<ulong>(schema);
 
-            using (stream)
-            {
-                Assert.Throws<OverflowException>(() => serialize(ulong.MaxValue, new BinaryWriter(stream)));
+            Assert.Throws<OverflowException>(() => serialize(ulong.MaxValue, new BinaryWriter(bufferWriter)));
 
-                serialize((ulong)int.MaxValue + 1, new BinaryWriter(stream));
-            }
+            serialize((ulong)int.MaxValue + 1, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             try
             {
@@ -276,12 +251,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<sbyte>(schema);
             var serialize = serializerBuilder.BuildDelegate<sbyte>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -295,12 +267,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ushort>(schema);
             var serialize = serializerBuilder.BuildDelegate<ushort>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -314,12 +283,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<uint>(schema);
             var serialize = serializerBuilder.BuildDelegate<uint>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -333,12 +299,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ulong>(schema);
             var serialize = serializerBuilder.BuildDelegate<ulong>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -352,12 +315,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<UIntPtr>(schema);
             var serialize = serializerBuilder.BuildDelegate<UIntPtr>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }

--- a/tests/Chr.Avro.Binary.Tests/MapSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/MapSerializationTests.cs
@@ -4,7 +4,6 @@ namespace Chr.Avro.Serialization.Tests
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Collections.ObjectModel;
-    using System.IO;
     using System.Linq;
     using Chr.Avro.Abstract;
     using Xunit;
@@ -18,13 +17,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public MapSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         public static IEnumerable<object[]> DateTimeKeyData => new List<object[]>
@@ -63,12 +62,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<Dictionary<DateTime, string>>(schema);
             var serialize = serializerBuilder.BuildDelegate<Dictionary<DateTime, string>>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -82,12 +78,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value.ToDictionary(p => p.Key, p => (object)p.Value), deserialize(ref reader));
         }
@@ -101,12 +94,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<IDictionary<DateTime, string>>(schema);
             var serialize = serializerBuilder.BuildDelegate<IDictionary<DateTime, string>>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -120,12 +110,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<IEnumerable<KeyValuePair<string, double>>>(schema);
             var serialize = serializerBuilder.BuildDelegate<IEnumerable<KeyValuePair<string, double>>>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -139,12 +126,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<IImmutableDictionary<string, double>>(schema);
             var serialize = serializerBuilder.BuildDelegate<IImmutableDictionary<string, double>>(schema);
 
-            using (stream)
-            {
-                serialize(value.ToImmutableDictionary(), new BinaryWriter(stream));
-            }
+            serialize(value.ToImmutableDictionary(), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -158,12 +142,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<IReadOnlyDictionary<string, double>>(schema);
             var serialize = serializerBuilder.BuildDelegate<IReadOnlyDictionary<string, double>>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -177,12 +158,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ImmutableDictionary<string, double>>(schema);
             var serialize = serializerBuilder.BuildDelegate<ImmutableDictionary<string, double>>(schema);
 
-            using (stream)
-            {
-                serialize(value.ToImmutableDictionary(), new BinaryWriter(stream));
-            }
+            serialize(value.ToImmutableDictionary(), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -196,12 +174,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ImmutableSortedDictionary<string, double>>(schema);
             var serialize = serializerBuilder.BuildDelegate<ImmutableSortedDictionary<string, double>>(schema);
 
-            using (stream)
-            {
-                serialize(value.ToImmutableSortedDictionary(), new BinaryWriter(stream));
-            }
+            serialize(value.ToImmutableSortedDictionary(), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -215,12 +190,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<ReadOnlyDictionary<string, double>>(schema);
             var serialize = serializerBuilder.BuildDelegate<ReadOnlyDictionary<string, double>>(schema);
 
-            using (stream)
-            {
-                serialize(new ReadOnlyDictionary<string, double>(value), new BinaryWriter(stream));
-            }
+            serialize(new ReadOnlyDictionary<string, double>(value), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -234,12 +206,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<SortedDictionary<string, double>>(schema);
             var serialize = serializerBuilder.BuildDelegate<SortedDictionary<string, double>>(schema);
 
-            using (stream)
-            {
-                serialize(new SortedDictionary<string, double>(value), new BinaryWriter(stream));
-            }
+            serialize(new SortedDictionary<string, double>(value), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -253,12 +222,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<SortedList<string, double>>(schema);
             var serialize = serializerBuilder.BuildDelegate<SortedList<string, double>>(schema);
 
-            using (stream)
-            {
-                serialize(new SortedList<string, double>(value), new BinaryWriter(stream));
-            }
+            serialize(new SortedList<string, double>(value), new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }

--- a/tests/Chr.Avro.Binary.Tests/NullSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/NullSerializationTests.cs
@@ -1,6 +1,5 @@
 namespace Chr.Avro.Serialization.Tests
 {
-    using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
 
@@ -13,13 +12,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public NullSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         [Theory]
@@ -32,12 +31,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(null, deserialize(ref reader));
         }
@@ -52,12 +48,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<int>(schema);
             var serialize = serializerBuilder.BuildDelegate<int>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(default, deserialize(ref reader));
         }
@@ -72,12 +65,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<string>(schema);
             var serialize = serializerBuilder.BuildDelegate<string>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(default, deserialize(ref reader));
         }

--- a/tests/Chr.Avro.Binary.Tests/RecordSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/RecordSerializationTests.cs
@@ -2,7 +2,6 @@ namespace Chr.Avro.Serialization.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using Chr.Avro.Abstract;
     using Chr.Avro.Fixtures;
     using Xunit;
@@ -16,13 +15,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public RecordSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         [Fact]
@@ -60,24 +59,21 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new
-                    {
-                        First = new List<bool>() { false },
-                        Second = new List<bool>() { false, false },
-                        Third = new List<bool>() { false, false, false },
-                        Fourth = new List<bool>() { false },
-                        Fifth = new Dictionary<string, int>() { { "first", 1 } },
-                        Sixth = new Dictionary<string, int>() { { "first", 1 }, { "second", 2 } },
-                        Seventh = ImplicitEnum.First,
-                        Eighth = ImplicitEnum.None,
-                    },
-                    new BinaryWriter(stream));
-            }
+            serialize(
+                new
+                {
+                    First = new List<bool>() { false },
+                    Second = new List<bool>() { false, false },
+                    Third = new List<bool>() { false, false, false },
+                    Fourth = new List<bool>() { false },
+                    Fifth = new Dictionary<string, int>() { { "first", 1 } },
+                    Sixth = new Dictionary<string, int>() { { "first", 1 }, { "second", 2 } },
+                    Seventh = ImplicitEnum.First,
+                    Eighth = ImplicitEnum.None,
+                },
+                new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var value = deserialize(ref reader);
 
             Assert.Equal(nameof(ImplicitEnum.First), value.Seventh);
@@ -94,42 +90,39 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<Node>(schema);
             var serialize = serializerBuilder.BuildDelegate<Node>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new Node()
+            serialize(
+                new Node()
+                {
+                    Value = 5,
+                    Children = new[]
                     {
-                        Value = 5,
-                        Children = new[]
+                        new Node()
                         {
-                            new Node()
+                            Value = 4,
+                            Children = Array.Empty<Node>(),
+                        },
+                        new Node()
+                        {
+                            Value = 7,
+                            Children = new[]
                             {
-                                Value = 4,
-                                Children = Array.Empty<Node>(),
-                            },
-                            new Node()
-                            {
-                                Value = 7,
-                                Children = new[]
+                                new Node()
                                 {
-                                    new Node()
-                                    {
-                                        Value = 6,
-                                        Children = Array.Empty<Node>(),
-                                    },
-                                    new Node
-                                    {
-                                        Value = 8,
-                                        Children = Array.Empty<Node>(),
-                                    },
+                                    Value = 6,
+                                    Children = Array.Empty<Node>(),
+                                },
+                                new Node
+                                {
+                                    Value = 8,
+                                    Children = Array.Empty<Node>(),
                                 },
                             },
                         },
                     },
-                    new BinaryWriter(stream));
-            }
+                },
+                new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             var n5 = deserialize(ref reader);
 
@@ -169,42 +162,39 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<MappedNode>(schema);
             var serialize = serializerBuilder.BuildDelegate<Node>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new Node()
+            serialize(
+                new Node()
+                {
+                    Value = 5,
+                    Children = new[]
                     {
-                        Value = 5,
-                        Children = new[]
+                        new Node()
                         {
-                            new Node()
+                            Value = 9,
+                            Children = Array.Empty<Node>(),
+                        },
+                        new Node()
+                        {
+                            Value = 3,
+                            Children = new[]
                             {
-                                Value = 9,
-                                Children = Array.Empty<Node>(),
-                            },
-                            new Node()
-                            {
-                                Value = 3,
-                                Children = new[]
+                                new Node()
                                 {
-                                    new Node()
-                                    {
-                                        Value = 2,
-                                        Children = Array.Empty<Node>(),
-                                    },
-                                    new Node()
-                                    {
-                                        Value = 10,
-                                        Children = Array.Empty<Node>(),
-                                    },
+                                    Value = 2,
+                                    Children = Array.Empty<Node>(),
+                                },
+                                new Node()
+                                {
+                                    Value = 10,
+                                    Children = Array.Empty<Node>(),
                                 },
                             },
                         },
                     },
-                    new BinaryWriter(stream));
-            }
+                },
+                new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             var n5 = deserialize(ref reader);
 
@@ -291,12 +281,9 @@ namespace Chr.Avro.Serialization.Tests
                 Seventh = ImplicitEnum.First,
             };
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             var with = deserialize(ref reader);
 
@@ -349,12 +336,9 @@ namespace Chr.Avro.Serialization.Tests
                 Eighth = ImplicitEnum.None,
             };
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value.Seventh.ToString(), deserialize(ref reader).Seventh);
         }
@@ -402,12 +386,9 @@ namespace Chr.Avro.Serialization.Tests
                 Eighth = ImplicitEnum.None,
             };
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value.Seventh, deserialize(ref reader).Seventh);
         }
@@ -442,12 +423,9 @@ namespace Chr.Avro.Serialization.Tests
                 Name = "Bob",
             };
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var deserialized = deserialize(ref reader);
             Assert.Equal(value.Name, deserialized.Name);
             Assert.Empty(deserialized.SubRecordArray);
@@ -495,12 +473,9 @@ namespace Chr.Avro.Serialization.Tests
                 },
             };
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var deserialized = deserialize(ref reader);
             Assert.Equal(value.Name, deserialized.Name);
             Assert.Equal(value.Age, deserialized.Age);
@@ -525,21 +500,18 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<Reference>(schema);
             var serialize = serializerBuilder.BuildDelegate<Reference>(schema);
 
-            using (stream)
-            {
-                serialize(
-                    new Reference()
+            serialize(
+                new Reference()
+                {
+                    Node = new Node()
                     {
-                        Node = new Node()
-                        {
-                            Children = Array.Empty<Node>(),
-                        },
-                        RelatedNodes = Array.Empty<Node>(),
+                        Children = Array.Empty<Node>(),
                     },
-                    new BinaryWriter(stream));
-            }
+                    RelatedNodes = Array.Empty<Node>(),
+                },
+                new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             var root = deserialize(ref reader);
 

--- a/tests/Chr.Avro.Binary.Tests/StringSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/StringSerializationTests.cs
@@ -2,7 +2,6 @@ namespace Chr.Avro.Serialization.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Xml;
     using Chr.Avro.Abstract;
     using Xunit;
@@ -16,13 +15,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public StringSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 #if NET6_0_OR_GREATER
 
@@ -102,12 +101,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value.ToString("O"), deserialize(ref reader));
         }
@@ -123,12 +119,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value.ToString("O"), deserialize(ref reader));
         }
@@ -143,12 +136,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value.ToString(), deserialize(ref reader));
         }
@@ -163,12 +153,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value.ToString("O"), deserialize(ref reader));
         }
@@ -183,12 +170,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<dynamic>(schema);
             var serialize = serializerBuilder.BuildDelegate<dynamic>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(XmlConvert.ToString(value), deserialize(ref reader));
         }
@@ -203,12 +187,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateOnly>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateOnly>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -222,12 +203,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateOnly?>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateOnly>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -242,12 +220,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateTime>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateTime>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -261,12 +236,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateTime?>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateTime>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -280,12 +252,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateTimeOffset>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateTimeOffset>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var decoded = deserialize(ref reader);
 
             // comparing two DateTimeOffsets doesn’t necessarily ensure that they’re identical:
@@ -302,12 +271,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateTimeOffset?>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateTimeOffset>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
             var decoded = deserialize(ref reader);
 
             // comparing two DateTimeOffsets doesn’t necessarily ensure that they’re identical:
@@ -324,12 +290,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateTimeKind>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateTimeKind>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -343,12 +306,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<Guid>(schema);
             var serialize = serializerBuilder.BuildDelegate<Guid>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -362,12 +322,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateTimeKind?>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateTimeKind>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -381,12 +338,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<Guid?>(schema);
             var serialize = serializerBuilder.BuildDelegate<Guid>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -400,12 +354,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<string>(schema);
             var serialize = serializerBuilder.BuildDelegate<string>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -420,12 +371,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<TimeOnly>(schema);
             var serialize = serializerBuilder.BuildDelegate<TimeOnly>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -439,12 +387,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<TimeOnly?>(schema);
             var serialize = serializerBuilder.BuildDelegate<TimeOnly>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -459,12 +404,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<TimeSpan>(schema);
             var serialize = serializerBuilder.BuildDelegate<TimeSpan>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -478,12 +420,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<TimeSpan?>(schema);
             var serialize = serializerBuilder.BuildDelegate<TimeSpan>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }
@@ -497,12 +436,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<Uri>(schema);
             var serialize = serializerBuilder.BuildDelegate<Uri>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             Assert.Equal(value, deserialize(ref reader));
         }

--- a/tests/Chr.Avro.Binary.Tests/TestBufferWriter.cs
+++ b/tests/Chr.Avro.Binary.Tests/TestBufferWriter.cs
@@ -1,0 +1,49 @@
+namespace Chr.Avro.Serialization.Tests
+{
+    using System;
+    using System.Buffers;
+
+    /// <summary>
+    /// A simple <see cref="IBufferWriter{T}" /> implementation backed by a resizable array,
+    /// used in tests to capture written bytes.
+    /// </summary>
+    internal sealed class TestBufferWriter : IBufferWriter<byte>
+    {
+        private byte[] buffer;
+        private int written;
+
+        public TestBufferWriter(int initialCapacity = 256)
+        {
+            buffer = new byte[initialCapacity];
+            written = 0;
+        }
+
+        public ReadOnlySpan<byte> WrittenSpan => new ReadOnlySpan<byte>(buffer, 0, written);
+
+        public void Advance(int count)
+        {
+            written += count;
+        }
+
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint > 0 ? sizeHint : 1);
+            return new Memory<byte>(buffer, written, buffer.Length - written);
+        }
+
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint > 0 ? sizeHint : 1);
+            return new Span<byte>(buffer, written, buffer.Length - written);
+        }
+
+        private void EnsureCapacity(int needed)
+        {
+            if (buffer.Length - written < needed)
+            {
+                var newSize = Math.Max(buffer.Length * 2, written + needed);
+                Array.Resize(ref buffer, newSize);
+            }
+        }
+    }
+}

--- a/tests/Chr.Avro.Binary.Tests/TimeSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/TimeSerializationTests.cs
@@ -3,7 +3,6 @@ namespace Chr.Avro.Serialization.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
 
@@ -16,13 +15,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public TimeSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         public static IEnumerable<object[]> MicrosecondTimeEncodings => new List<object[]>
@@ -65,12 +64,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<TimeOnly>(schema);
             var serialize = serializerBuilder.BuildDelegate<TimeOnly>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);
@@ -89,12 +85,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<TimeOnly>(schema);
             var serialize = serializerBuilder.BuildDelegate<TimeOnly>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);

--- a/tests/Chr.Avro.Binary.Tests/TimestampSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/TimestampSerializationTests.cs
@@ -2,7 +2,6 @@ namespace Chr.Avro.Serialization.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using Chr.Avro.Abstract;
     using Xunit;
 
@@ -15,13 +14,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public TimestampSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         public static IEnumerable<object[]> MicrosecondDateTimeEncodings => new List<object[]>
@@ -93,12 +92,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateTime>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateTime>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);
@@ -117,12 +113,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateTimeOffset>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateTimeOffset>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);
@@ -141,12 +134,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateTime>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateTime>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);
@@ -165,12 +155,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateTimeOffset>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateTimeOffset>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);
@@ -189,12 +176,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateTime>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateTime>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);
@@ -213,12 +197,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<DateTimeOffset>(schema);
             var serialize = serializerBuilder.BuildDelegate<DateTimeOffset>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);

--- a/tests/Chr.Avro.Binary.Tests/UnionSerializationTests.cs
+++ b/tests/Chr.Avro.Binary.Tests/UnionSerializationTests.cs
@@ -2,7 +2,6 @@ namespace Chr.Avro.Serialization.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using Chr.Avro.Abstract;
     using Xunit;
@@ -16,13 +15,13 @@ namespace Chr.Avro.Serialization.Tests
 
         private readonly IBinarySerializerBuilder serializerBuilder;
 
-        private readonly MemoryStream stream;
+        private readonly TestBufferWriter bufferWriter;
 
         public UnionSerializationTests()
         {
             deserializerBuilder = new BinaryDeserializerBuilder();
             serializerBuilder = new BinarySerializerBuilder();
-            stream = new MemoryStream();
+            bufferWriter = new TestBufferWriter();
         }
 
         public interface IEvent
@@ -75,12 +74,9 @@ namespace Chr.Avro.Serialization.Tests
 
             if (value.HasValue)
             {
-                using (stream)
-                {
-                    serialize(value.Value, new BinaryWriter(stream));
-                }
+                serialize(value.Value, new BinaryWriter(bufferWriter));
 
-                Assert.Equal(encoding, stream.ToArray());
+                Assert.Equal(encoding, bufferWriter.WrittenSpan.ToArray());
             }
 
             Assert.Throws<UnsupportedTypeException>(() => deserializerBuilder.BuildDelegate<int>(schema));
@@ -99,12 +95,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<int?>(schema);
             var serialize = serializerBuilder.BuildDelegate<int?>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);
@@ -137,12 +130,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<string>(schema);
             var serialize = serializerBuilder.BuildDelegate<string>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);
@@ -161,12 +151,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<string>(schema);
             var serialize = serializerBuilder.BuildDelegate<string>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);
@@ -212,12 +199,9 @@ namespace Chr.Avro.Serialization.Tests
                 Total = 40M,
             };
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
             var result = deserialize(ref reader);
             Assert.Equal(value.Timestamp, result.Timestamp);
@@ -285,23 +269,20 @@ namespace Chr.Avro.Serialization.Tests
                 },
             };
 
-            using (stream)
-            {
-                serialize(creation, new BinaryWriter(stream));
+            serialize(creation, new BinaryWriter(bufferWriter));
 
-                var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
-                var result = deserialize(ref reader);
-                Assert.IsType<OrderCreatedEvent>(result.Event);
+            var result = deserialize(ref reader);
+            Assert.IsType<OrderCreatedEvent>(result.Event);
 
-                stream.Position = 0;
-                serialize(cancellation, new BinaryWriter(stream));
+            var bufferWriter2 = new TestBufferWriter();
+            serialize(cancellation, new BinaryWriter(bufferWriter2));
 
-                reader = new BinaryReader(stream.ToArray());
+            reader = new BinaryReader(bufferWriter2.WrittenSpan);
 
-                result = deserialize(ref reader);
-                Assert.IsType<OrderCancelledEvent>(result.Event);
-            }
+            result = deserialize(ref reader);
+            Assert.IsType<OrderCancelledEvent>(result.Event);
         }
 
         [Fact]
@@ -366,23 +347,20 @@ namespace Chr.Avro.Serialization.Tests
                 },
             };
 
-            using (stream)
-            {
-                serialize(creation, new BinaryWriter(stream));
+            serialize(creation, new BinaryWriter(bufferWriter));
 
-                var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
-                var result = deserialize(ref reader);
-                Assert.IsType<OrderCreatedEvent>(result.Event);
+            var result = deserialize(ref reader);
+            Assert.IsType<OrderCreatedEvent>(result.Event);
 
-                stream.Position = 0;
-                serialize(cancellation, new BinaryWriter(stream));
+            var bufferWriter2 = new TestBufferWriter();
+            serialize(cancellation, new BinaryWriter(bufferWriter2));
 
-                reader = new BinaryReader(stream.ToArray());
+            reader = new BinaryReader(bufferWriter2.WrittenSpan);
 
-                result = deserialize(ref reader);
-                Assert.IsType<OrderCancelledEvent>(result.Event);
-            }
+            result = deserialize(ref reader);
+            Assert.IsType<OrderCancelledEvent>(result.Event);
         }
 
         [Fact]
@@ -435,15 +413,12 @@ namespace Chr.Avro.Serialization.Tests
                 Event = null,
             };
 
-            using (stream)
-            {
-                serialize(empty, new BinaryWriter(stream));
+            serialize(empty, new BinaryWriter(bufferWriter));
 
-                var reader = new BinaryReader(stream.ToArray());
+            var reader = new BinaryReader(bufferWriter.WrittenSpan);
 
-                var result = deserialize(ref reader);
-                Assert.Null(result.Event);
-            }
+            var result = deserialize(ref reader);
+            Assert.Null(result.Event);
         }
 
         [Theory]
@@ -458,12 +433,9 @@ namespace Chr.Avro.Serialization.Tests
             var deserialize = deserializerBuilder.BuildDelegate<string>(schema);
             var serialize = serializerBuilder.BuildDelegate<string>(schema);
 
-            using (stream)
-            {
-                serialize(value, new BinaryWriter(stream));
-            }
+            serialize(value, new BinaryWriter(bufferWriter));
 
-            var encoded = stream.ToArray();
+            var encoded = bufferWriter.WrittenSpan.ToArray();
             var reader = new BinaryReader(encoded);
 
             Assert.Equal(encoding, encoded);


### PR DESCRIPTION
Since we [talked about making a new major version](https://github.com/ch-robinson/dotnet-avro/pull/366#issuecomment-4336093238), I think it might be a good time to replace the usage of `Stream` in the serialization code for `IBufferWriter<byte>`.

I purposefully didn't try to optimize `BinaryWriter` do keep the diffs in this PR small, but once it's merged we can make proper use of IBufferWriter and optimize it


AI USE DISCLAIMER: I just reimplemented BinaryWriter. All other changes where made by copilot